### PR TITLE
Fix how a link to $0 is determined

### DIFF
--- a/bin/daemon.sh
+++ b/bin/daemon.sh
@@ -20,18 +20,13 @@
 # -----------------------------------------------------------------------------
 #
 # resolve links - $0 may be a softlink
-ARG0="$0"
-while [ -h "$ARG0" ]; do
-  ls=`ls -ld "$ARG0"`
-  link=`expr "$ls" : '.*-> \(.*\)$'`
-  if expr "$link" : '/.*' > /dev/null; then
-    ARG0="$link"
-  else
-    ARG0="`dirname $ARG0`/$link"
-  fi
-done
-DIRNAME="`dirname $ARG0`"
-PROGRAM="`basename $ARG0`"
+command="$0"
+if [ -L "$command" ]; then
+  command=`readlink -fn "$command"`
+fi
+DIRNAME=`dirname "$command"`
+PROGRAM=`basename "$command"`
+
 while [ ".$1" != . ]
 do
   case "$1" in


### PR DESCRIPTION
- The test '-L' is true of the file provided is a symbolic link
- 'readlink -f' will print the absolute path to a symbolic link's target
- 'readlink -n' will skip a trailing newline
