### PR TITLE
Fix how a link to $0 is determined

### DIFF
--- a/bin/catalina.sh
+++ b/bin/catalina.sh
@@ -108,15 +108,9 @@ esac
 # resolve links - $0 may be a softlink
 PRG="$0"
 
-while [ -h "$PRG" ]; do
-  ls=`ls -ld "$PRG"`
-  link=`expr "$ls" : '.*-> \(.*\)$'`
-  if expr "$link" : '/.*' > /dev/null; then
-    PRG="$link"
-  else
-    PRG=`dirname "$PRG"`/"$link"
-  fi
-done
+if [ -L "$PRG" ]; then
+  PRG=`readlink -fn "$PRG"`
+fi
 
 # Get standard environment variables
 PRGDIR=`dirname "$PRG"`

--- a/bin/configtest.sh
+++ b/bin/configtest.sh
@@ -28,15 +28,9 @@ esac
 # resolve links - $0 may be a softlink
 PRG="$0"
 
-while [ -h "$PRG" ] ; do
-  ls=`ls -ld "$PRG"`
-  link=`expr "$ls" : '.*-> \(.*\)$'`
-  if expr "$link" : '/.*' > /dev/null; then
-    PRG="$link"
-  else
-    PRG=`dirname "$PRG"`/"$link"
-  fi
-done
+if [ -L "$PRG" ]; then
+  PRG=`readlink -fn "$PRG"`
+fi
 
 PRGDIR=`dirname "$PRG"`
 EXECUTABLE=catalina.sh

--- a/bin/daemon.sh
+++ b/bin/daemon.sh
@@ -20,18 +20,13 @@
 # -----------------------------------------------------------------------------
 #
 # resolve links - $0 may be a softlink
-ARG0="$0"
-while [ -h "$ARG0" ]; do
-  ls=`ls -ld "$ARG0"`
-  link=`expr "$ls" : '.*-> \(.*\)$'`
-  if expr "$link" : '/.*' > /dev/null; then
-    ARG0="$link"
-  else
-    ARG0="`dirname $ARG0`/$link"
-  fi
-done
-DIRNAME="`dirname $ARG0`"
-PROGRAM="`basename $ARG0`"
+command="$0"
+if [ -L "$command" ]; then
+  command=`readlink -fn "$command"`
+fi
+DIRNAME=`dirname "$command"`
+PROGRAM=`basename "$command"`
+
 while [ ".$1" != . ]
 do
   case "$1" in

--- a/bin/digest.sh
+++ b/bin/digest.sh
@@ -28,15 +28,9 @@ esac
 # resolve links - $0 may be a softlink
 PRG="$0"
 
-while [ -h "$PRG" ] ; do
-  ls=`ls -ld "$PRG"`
-  link=`expr "$ls" : '.*-> \(.*\)$'`
-  if expr "$link" : '/.*' > /dev/null; then
-    PRG="$link"
-  else
-    PRG=`dirname "$PRG"`/"$link"
-  fi
-done
+if [ -L "$PRG" ]; then
+  PRG=`readlink -fn "$PRG"`
+fi
 
 PRGDIR=`dirname "$PRG"`
 EXECUTABLE=tool-wrapper.sh

--- a/bin/shutdown.sh
+++ b/bin/shutdown.sh
@@ -28,15 +28,9 @@ esac
 # resolve links - $0 may be a softlink
 PRG="$0"
 
-while [ -h "$PRG" ] ; do
-  ls=`ls -ld "$PRG"`
-  link=`expr "$ls" : '.*-> \(.*\)$'`
-  if expr "$link" : '/.*' > /dev/null; then
-    PRG="$link"
-  else
-    PRG=`dirname "$PRG"`/"$link"
-  fi
-done
+if [ -L "$PRG" ]; then
+  PRG=`readlink -fn "$PRG"`
+fi
 
 PRGDIR=`dirname "$PRG"`
 EXECUTABLE=catalina.sh

--- a/bin/startup.sh
+++ b/bin/startup.sh
@@ -28,15 +28,9 @@ esac
 # resolve links - $0 may be a softlink
 PRG="$0"
 
-while [ -h "$PRG" ] ; do
-  ls=`ls -ld "$PRG"`
-  link=`expr "$ls" : '.*-> \(.*\)$'`
-  if expr "$link" : '/.*' > /dev/null; then
-    PRG="$link"
-  else
-    PRG=`dirname "$PRG"`/"$link"
-  fi
-done
+if [ -L "$PRG" ]; then
+  PRG=`readlink -fn "$PRG"`
+fi
 
 PRGDIR=`dirname "$PRG"`
 EXECUTABLE=catalina.sh

--- a/bin/tool-wrapper.sh
+++ b/bin/tool-wrapper.sh
@@ -53,15 +53,9 @@ esac
 # resolve links - $0 may be a softlink
 PRG="$0"
 
-while [ -h "$PRG" ]; do
-  ls=`ls -ld "$PRG"`
-  link=`expr "$ls" : '.*-> \(.*\)$'`
-  if expr "$link" : '/.*' > /dev/null; then
-    PRG="$link"
-  else
-    PRG=`dirname "$PRG"`/"$link"
-  fi
-done
+if [ -L "$PRG" ]; then
+  PRG=`readlink -fn "$PRG"`
+fi
 
 # Get standard environment variables
 PRGDIR=`dirname "$PRG"`

--- a/bin/version.sh
+++ b/bin/version.sh
@@ -28,15 +28,9 @@ esac
 # resolve links - $0 may be a softlink
 PRG="$0"
 
-while [ -h "$PRG" ] ; do
-  ls=`ls -ld "$PRG"`
-  link=`expr "$ls" : '.*-> \(.*\)$'`
-  if expr "$link" : '/.*' > /dev/null; then
-    PRG="$link"
-  else
-    PRG=`dirname "$PRG"`/"$link"
-  fi
-done
+if [ -L "$PRG" ]; then
+  PRG=`readlink -fn "$PRG"`
+fi
 
 PRGDIR=`dirname "$PRG"`
 EXECUTABLE=catalina.sh


### PR DESCRIPTION
- The test '-L' is true of the file provided is a symbolic link
- 'readlink -f' will print the absolute path to a symbolic link's target
- 'readlink -n' will skip a trailing newline
