### PR TITLE
fix: MethodParameters_attribute's parameters_count  is only 1 byte long

### DIFF
--- a/java/org/apache/tomcat/util/bcel/classfile/Utility.java
+++ b/java/org/apache/tomcat/util/bcel/classfile/Utility.java
@@ -182,7 +182,7 @@ final class Utility {
     }
 
     static void swallowMethodParameters(DataInput file) throws IOException {
-        int parameters_count = file.readUnsignedShort();
+        int parameters_count = file.readUnsignedByte();
         for (int i = 0; i < parameters_count; i++) {
             file.readUnsignedShort();   // Unused name_index
             file.readUnsignedShort();   // Unused access_flags


### PR DESCRIPTION
JDK 8 specification, 4.7.24 "The MethodParameters Attribute"
http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.24
