### PR TITLE
Update JasperELResolver.java

### DIFF
--- a/java/org/apache/jasper/el/JasperELResolver.java
+++ b/java/org/apache/jasper/el/JasperELResolver.java
@@ -69,7 +69,8 @@ public class JasperELResolver extends CompositeELResolver {
     public synchronized void add(ELResolver elResolver) {
         super.add(elResolver);
 
-        if (resolvers.length < size) {
+        //this looked wrong...
+        if (resolvers.length > size) {
             resolvers[size] = elResolver;
         } else {
             ELResolver[] nr = new ELResolver[size + 1];


### PR DESCRIPTION
Just trying some static analysis tool and it claims that 
        if (resolvers.length < size) {
            resolvers[size] = elResolver;
is a bad idea ... shouldn't it be rather ">"?
