### PR TITLE
#57178: Allow CORS requests with Origin value "null".

### DIFF
--- a/java/org/apache/catalina/filters/CorsFilter.java
+++ b/java/org/apache/catalina/filters/CorsFilter.java
@@ -95,6 +95,12 @@ public final class CorsFilter implements Filter {
     private boolean anyOriginAllowed;
 
     /**
+     * The null origin allowed flag indicates whether requests with the
+     * Origin header value 'null' should be allowed.
+     */
+    private boolean nullOriginAllowed;
+
+    /**
      * A {@link Collection} of methods consisting of zero or more methods that
      * are supported by the resource.
      */
@@ -188,14 +194,16 @@ public final class CorsFilter implements Filter {
     @Override
     public void init(final FilterConfig filterConfig) throws ServletException {
         // Initialize defaults
-        parseAndStore(DEFAULT_ALLOWED_ORIGINS, DEFAULT_ALLOWED_HTTP_METHODS,
-                DEFAULT_ALLOWED_HTTP_HEADERS, DEFAULT_EXPOSED_HEADERS,
-                DEFAULT_SUPPORTS_CREDENTIALS, DEFAULT_PREFLIGHT_MAXAGE,
-                DEFAULT_DECORATE_REQUEST);
+        parseAndStore(DEFAULT_ALLOWED_ORIGINS, DEFAULT_ALLOW_NULL_ORIGIN,
+                DEFAULT_ALLOWED_HTTP_METHODS, DEFAULT_ALLOWED_HTTP_HEADERS,
+                DEFAULT_EXPOSED_HEADERS, DEFAULT_SUPPORTS_CREDENTIALS,
+                DEFAULT_PREFLIGHT_MAXAGE, DEFAULT_DECORATE_REQUEST);
 
         if (filterConfig != null) {
             String configAllowedOrigins = filterConfig
                     .getInitParameter(PARAM_CORS_ALLOWED_ORIGINS);
+            String configAllowNullOrigin = filterConfig
+                    .getInitParameter(PARAM_CORS_ALLOW_NULL_ORIGIN);
             String configAllowedHttpMethods = filterConfig
                     .getInitParameter(PARAM_CORS_ALLOWED_METHODS);
             String configAllowedHttpHeaders = filterConfig
@@ -209,10 +217,10 @@ public final class CorsFilter implements Filter {
             String configDecorateRequest = filterConfig
                     .getInitParameter(PARAM_CORS_REQUEST_DECORATE);
 
-            parseAndStore(configAllowedOrigins, configAllowedHttpMethods,
-                    configAllowedHttpHeaders, configExposedHeaders,
-                    configSupportsCredentials, configPreflightMaxAge,
-                    configDecorateRequest);
+            parseAndStore(configAllowedOrigins, configAllowNullOrigin,
+                    configAllowedHttpMethods, configAllowedHttpHeaders,
+                    configExposedHeaders, configSupportsCredentials,
+                    configPreflightMaxAge, configDecorateRequest);
         }
     }
 
@@ -703,9 +711,10 @@ public final class CorsFilter implements Filter {
      * @throws ServletException
      */
     private void parseAndStore(final String allowedOrigins,
-            final String allowedHttpMethods, final String allowedHttpHeaders,
-            final String exposedHeaders, final String supportsCredentials,
-            final String preflightMaxAge, final String decorateRequest)
+            final String allowNullOrigin, final String allowedHttpMethods,
+            final String allowedHttpHeaders, final String exposedHeaders,
+            final String supportsCredentials, final String preflightMaxAge,
+            final String decorateRequest)
                     throws ServletException {
         if (allowedOrigins != null) {
             if (allowedOrigins.trim().equals("*")) {
@@ -717,6 +726,10 @@ public final class CorsFilter implements Filter {
                 this.allowedOrigins.clear();
                 this.allowedOrigins.addAll(setAllowedOrigins);
             }
+        }
+
+        if (allowNullOrigin != null) {
+            this.nullOriginAllowed = Boolean.parseBoolean(allowNullOrigin);
         }
 
         if (allowedHttpMethods != null) {
@@ -806,10 +819,16 @@ public final class CorsFilter implements Filter {
      * @param origin
      * @see <a href="http://tools.ietf.org/html/rfc952">RFC952</a>
      */
-    protected static boolean isValidOrigin(String origin) {
+    protected boolean isValidOrigin(String origin) {
         // Checks for encoded characters. Helps prevent CRLF injection.
         if (origin.contains("%")) {
             return false;
+        }
+
+        // If allowed by configuration, requests with Origin header value 
+        // 'null' are valid
+        if (this.nullOriginAllowed && origin.equals("null")) {
+            return true;
         }
 
         URI originURI;
@@ -1083,6 +1102,12 @@ public final class CorsFilter implements Filter {
     public static final String DEFAULT_ALLOWED_ORIGINS = "*";
 
     /**
+     * By default, don't allow processing of requests with the Origin header 
+     * set to 'null'.
+     */
+    public static final String DEFAULT_ALLOW_NULL_ORIGIN = "false";
+
+    /**
      * By default, following methods are supported: GET, POST, HEAD and OPTIONS.
      */
     public static final String DEFAULT_ALLOWED_HTTP_METHODS =
@@ -1123,6 +1148,13 @@ public final class CorsFilter implements Filter {
      */
     public static final String PARAM_CORS_ALLOWED_ORIGINS =
             "cors.allowed.origins";
+
+    /**
+     * Key to determine if request with Origin header value 'null' should be
+     * allowed.
+     */
+    public static final String PARAM_CORS_ALLOW_NULL_ORIGIN =
+            "cors.allow.nullorigin";
 
     /**
      * Key to retrieve support credentials from {@link FilterConfig}.

--- a/test/org/apache/catalina/filters/TestCorsFilter.java
+++ b/test/org/apache/catalina/filters/TestCorsFilter.java
@@ -519,6 +519,59 @@ public class TestCorsFilter {
                 CorsFilter.HTTP_REQUEST_ATTRIBUTE_IS_CORS_REQUEST)).booleanValue());
     }
 
+    /*
+     * Tests whether requests with Origin 'null' (String) are accepted when
+     * enabled explicitly by configuration.
+     */
+    @Test
+    public void testDoFilterNullOriginAllowed() throws IOException,
+            ServletException {
+        TesterHttpServletRequest request = new TesterHttpServletRequest();
+
+        request.setMethod("POST");
+        request.setContentType("text/plain");
+        request.setHeader(CorsFilter.REQUEST_HEADER_ORIGIN, "null");
+        TesterHttpServletResponse response = new TesterHttpServletResponse();
+
+        CorsFilter corsFilter = new CorsFilter();
+        corsFilter.init(TesterFilterConfigs.getFilterConfigNullOriginAllowed());
+        CorsFilter.CORSRequestType requestType =
+                corsFilter.checkRequestType(request);
+        Assert.assertEquals(CorsFilter.CORSRequestType.SIMPLE, requestType);
+
+        corsFilter.doFilter(request, response, filterChain);
+
+        Assert.assertTrue(((Boolean) request.getAttribute(
+                CorsFilter.HTTP_REQUEST_ATTRIBUTE_IS_CORS_REQUEST)).booleanValue());
+    }
+
+    /*
+     * Tests whether requests with Origin 'null' (String) are not accepted when
+     * disabled by configuration (which is the default).
+     */
+    @Test
+    public void testDoFilterNullOriginNotAllowed() throws IOException,
+            ServletException {
+        TesterHttpServletRequest request = new TesterHttpServletRequest();
+
+        request.setMethod("POST");
+        request.setContentType("text/plain");
+        request.setHeader(CorsFilter.REQUEST_HEADER_ORIGIN, "null");
+        TesterHttpServletResponse response = new TesterHttpServletResponse();
+
+        CorsFilter corsFilter = new CorsFilter();
+        corsFilter.init(TesterFilterConfigs.getDefaultFilterConfig());
+        CorsFilter.CORSRequestType requestType = corsFilter
+                .checkRequestType(request);
+        Assert.assertEquals(CorsFilter.CORSRequestType.INVALID_CORS,
+                requestType);
+
+        corsFilter.doFilter(request, response, filterChain);
+
+        Assert.assertNull(request
+                .getAttribute(CorsFilter.HTTP_REQUEST_ATTRIBUTE_IS_CORS_REQUEST));
+    }
+
     @Test
     public void testDoFilterInvalidCORSOriginNotAllowed() throws IOException,
             ServletException {
@@ -1285,28 +1338,38 @@ public class TestCorsFilter {
     }
 
     @Test
-    public void testValidOrigin() {
-        Assert.assertTrue(CorsFilter.isValidOrigin("http://www.w3.org"));
+    public void testValidOrigin() throws ServletException {
+        CorsFilter corsFilter = new CorsFilter();
+        corsFilter.init(TesterFilterConfigs.getNullFilterConfig());
+        Assert.assertTrue(corsFilter.isValidOrigin("http://www.w3.org"));
     }
 
     @Test
-    public void testInValidOriginCRLF() {
-        Assert.assertFalse(CorsFilter.isValidOrigin("http://www.w3.org\r\n"));
+    public void testInValidOriginCRLF() throws ServletException {
+        CorsFilter corsFilter = new CorsFilter();
+        corsFilter.init(TesterFilterConfigs.getNullFilterConfig());
+        Assert.assertFalse(corsFilter.isValidOrigin("http://www.w3.org\r\n"));
     }
 
     @Test
-    public void testInValidOriginEncodedCRLF1() {
-        Assert.assertFalse(CorsFilter.isValidOrigin("http://www.w3.org%0d%0a"));
+    public void testInValidOriginEncodedCRLF1() throws ServletException {
+        CorsFilter corsFilter = new CorsFilter();
+        corsFilter.init(TesterFilterConfigs.getNullFilterConfig());
+        Assert.assertFalse(corsFilter.isValidOrigin("http://www.w3.org%0d%0a"));
     }
 
     @Test
-    public void testInValidOriginEncodedCRLF2() {
-        Assert.assertFalse(CorsFilter.isValidOrigin("http://www.w3.org%0D%0A"));
+    public void testInValidOriginEncodedCRLF2() throws ServletException {
+        CorsFilter corsFilter = new CorsFilter();
+        corsFilter.init(TesterFilterConfigs.getNullFilterConfig());
+        Assert.assertFalse(corsFilter.isValidOrigin("http://www.w3.org%0D%0A"));
     }
 
     @Test
-    public void testInValidOriginEncodedCRLF3() {
-        Assert.assertFalse(CorsFilter
+    public void testInValidOriginEncodedCRLF3() throws ServletException {
+        CorsFilter corsFilter = new CorsFilter();
+        corsFilter.init(TesterFilterConfigs.getNullFilterConfig());
+        Assert.assertFalse(corsFilter
                 .isValidOrigin("http://www.w3.org%0%0d%0ad%0%0d%0aa"));
     }
 

--- a/test/org/apache/catalina/filters/TesterFilterConfigs.java
+++ b/test/org/apache/catalina/filters/TesterFilterConfigs.java
@@ -40,6 +40,7 @@ public class TesterFilterConfigs {
         final String allowedHttpMethods =
                 CorsFilter.DEFAULT_ALLOWED_HTTP_METHODS;
         final String allowedOrigins = CorsFilter.DEFAULT_ALLOWED_ORIGINS;
+        final String allowNullOrigin = CorsFilter.DEFAULT_ALLOW_NULL_ORIGIN;
         final String exposedHeaders = CorsFilter.DEFAULT_EXPOSED_HEADERS;
         final String supportCredentials =
                 CorsFilter.DEFAULT_SUPPORTS_CREDENTIALS;
@@ -48,8 +49,8 @@ public class TesterFilterConfigs {
         final String decorateRequest = CorsFilter.DEFAULT_DECORATE_REQUEST;
 
         return generateFilterConfig(allowedHttpHeaders, allowedHttpMethods,
-                allowedOrigins, exposedHeaders, supportCredentials,
-                preflightMaxAge, decorateRequest);
+                allowedOrigins, allowNullOrigin, exposedHeaders,
+                supportCredentials, preflightMaxAge, decorateRequest);
     }
 
     public static FilterConfig getFilterConfigAnyOriginAndSupportsCredentials() {
@@ -58,6 +59,7 @@ public class TesterFilterConfigs {
         final String allowedHttpMethods =
                 CorsFilter.DEFAULT_ALLOWED_HTTP_METHODS + ",PUT";
         final String allowedOrigins = CorsFilter.DEFAULT_ALLOWED_ORIGINS;
+        final String allowNullOrigin = CorsFilter.DEFAULT_ALLOW_NULL_ORIGIN;
         final String exposedHeaders = CorsFilter.DEFAULT_EXPOSED_HEADERS;
         final String supportCredentials = "true";
         final String preflightMaxAge =
@@ -65,8 +67,8 @@ public class TesterFilterConfigs {
         final String decorateRequest = CorsFilter.DEFAULT_DECORATE_REQUEST;
 
         return generateFilterConfig(allowedHttpHeaders, allowedHttpMethods,
-                allowedOrigins, exposedHeaders, supportCredentials,
-                preflightMaxAge, decorateRequest);
+                allowedOrigins, allowNullOrigin, exposedHeaders, 
+                supportCredentials, preflightMaxAge, decorateRequest);
     }
 
     public static FilterConfig
@@ -76,6 +78,7 @@ public class TesterFilterConfigs {
         final String allowedHttpMethods =
                 CorsFilter.DEFAULT_ALLOWED_HTTP_METHODS + ",PUT";
         final String allowedOrigins = CorsFilter.DEFAULT_ALLOWED_ORIGINS;
+        final String allowNullOrigin = CorsFilter.DEFAULT_ALLOW_NULL_ORIGIN;
         final String exposedHeaders = CorsFilter.DEFAULT_EXPOSED_HEADERS;
         final String supportCredentials = "false";
         final String preflightMaxAge =
@@ -83,8 +86,8 @@ public class TesterFilterConfigs {
         final String decorateRequest = CorsFilter.DEFAULT_DECORATE_REQUEST;
 
         return generateFilterConfig(allowedHttpHeaders, allowedHttpMethods,
-                allowedOrigins, exposedHeaders, supportCredentials,
-                preflightMaxAge, decorateRequest);
+                allowedOrigins, allowNullOrigin, exposedHeaders,
+                supportCredentials, preflightMaxAge, decorateRequest);
     }
 
     public static FilterConfig
@@ -95,6 +98,7 @@ public class TesterFilterConfigs {
                 CorsFilter.DEFAULT_ALLOWED_HTTP_METHODS + ",PUT";
         final String allowedOrigins =
                 HTTP_TOMCAT_APACHE_ORG + "," + HTTPS_WWW_APACHE_ORG;
+        final String allowNullOrigin = CorsFilter.DEFAULT_ALLOW_NULL_ORIGIN;
         final String exposedHeaders = CorsFilter.DEFAULT_EXPOSED_HEADERS;
         final String supportCredentials = "false";
         final String preflightMaxAge =
@@ -102,8 +106,8 @@ public class TesterFilterConfigs {
         final String decorateRequest = CorsFilter.DEFAULT_DECORATE_REQUEST;
 
         return generateFilterConfig(allowedHttpHeaders, allowedHttpMethods,
-                allowedOrigins, exposedHeaders, supportCredentials,
-                preflightMaxAge, decorateRequest);
+                allowedOrigins, allowNullOrigin, exposedHeaders,
+                supportCredentials, preflightMaxAge, decorateRequest);
     }
 
     public static FilterConfig getFilterConfigWithExposedHeaders() {
@@ -112,6 +116,7 @@ public class TesterFilterConfigs {
         final String allowedHttpMethods =
                 CorsFilter.DEFAULT_ALLOWED_HTTP_METHODS;
         final String allowedOrigins = CorsFilter.DEFAULT_ALLOWED_ORIGINS;
+        final String allowNullOrigin = CorsFilter.DEFAULT_ALLOW_NULL_ORIGIN;
         final String exposedHeaders = EXPOSED_HEADERS;
         final String supportCredentials =
                 CorsFilter.DEFAULT_SUPPORTS_CREDENTIALS;
@@ -120,8 +125,27 @@ public class TesterFilterConfigs {
         final String decorateRequest = CorsFilter.DEFAULT_DECORATE_REQUEST;
 
         return generateFilterConfig(allowedHttpHeaders, allowedHttpMethods,
-                allowedOrigins, exposedHeaders, supportCredentials,
-                preflightMaxAge, decorateRequest);
+                allowedOrigins, allowNullOrigin, exposedHeaders,
+                supportCredentials, preflightMaxAge, decorateRequest);
+    }
+
+    public static FilterConfig getFilterConfigNullOriginAllowed() {
+        final String allowedHttpHeaders =
+                CorsFilter.DEFAULT_ALLOWED_HTTP_HEADERS;
+        final String allowedHttpMethods =
+                CorsFilter.DEFAULT_ALLOWED_HTTP_METHODS;
+        final String allowedOrigins = CorsFilter.DEFAULT_ALLOWED_ORIGINS;
+        final String allowNullOrigin = "true";
+        final String exposedHeaders = EXPOSED_HEADERS;
+        final String supportCredentials =
+                CorsFilter.DEFAULT_SUPPORTS_CREDENTIALS;
+        final String preflightMaxAge =
+                CorsFilter.DEFAULT_PREFLIGHT_MAXAGE;
+        final String decorateRequest = CorsFilter.DEFAULT_DECORATE_REQUEST;
+
+        return generateFilterConfig(allowedHttpHeaders, allowedHttpMethods,
+                allowedOrigins, allowNullOrigin, exposedHeaders,
+                supportCredentials, preflightMaxAge, decorateRequest);
     }
 
     public static FilterConfig getSecureFilterConfig() {
@@ -130,6 +154,7 @@ public class TesterFilterConfigs {
         final String allowedHttpMethods =
                 CorsFilter.DEFAULT_ALLOWED_HTTP_METHODS + ",PUT";
         final String allowedOrigins = HTTPS_WWW_APACHE_ORG;
+        final String allowNullOrigin = CorsFilter.DEFAULT_ALLOW_NULL_ORIGIN;
         final String exposedHeaders = CorsFilter.DEFAULT_EXPOSED_HEADERS;
         final String supportCredentials = "true";
         final String preflightMaxAge =
@@ -137,18 +162,20 @@ public class TesterFilterConfigs {
         final String decorateRequest = CorsFilter.DEFAULT_DECORATE_REQUEST;
 
         return generateFilterConfig(allowedHttpHeaders, allowedHttpMethods,
-                allowedOrigins, exposedHeaders, supportCredentials,
-                preflightMaxAge, decorateRequest);
+                allowedOrigins, allowNullOrigin, exposedHeaders, 
+                supportCredentials, preflightMaxAge, decorateRequest);
     }
 
     public static FilterConfig getNullFilterConfig() {
-        return generateFilterConfig(null, null, null, null, null, null, null);
+        return generateFilterConfig(null, null, null, null, null, null, null,
+                null);
     }
 
     public static FilterConfig getSpecificOriginFilterConfig() {
         final String allowedOrigins =
                 HTTPS_WWW_APACHE_ORG + "," + HTTP_TOMCAT_APACHE_ORG;
 
+        final String allowNullOrigin = CorsFilter.DEFAULT_ALLOW_NULL_ORIGIN;
         final String allowedHttpHeaders =
                 CorsFilter.DEFAULT_ALLOWED_HTTP_HEADERS;
         final String allowedHttpMethods =
@@ -161,14 +188,15 @@ public class TesterFilterConfigs {
         final String decorateRequest = CorsFilter.DEFAULT_DECORATE_REQUEST;
 
         return generateFilterConfig(allowedHttpHeaders, allowedHttpMethods,
-                allowedOrigins, exposedHeaders, supportCredentials,
-                preflightMaxAge, decorateRequest);
+                allowedOrigins, allowNullOrigin, exposedHeaders,
+                supportCredentials, preflightMaxAge, decorateRequest);
     }
 
     public static FilterConfig getSpecificOriginFilterConfigNegativeMaxAge() {
         final String allowedOrigins =
                 HTTPS_WWW_APACHE_ORG + "," + HTTP_TOMCAT_APACHE_ORG;
 
+        final String allowNullOrigin = CorsFilter.DEFAULT_ALLOW_NULL_ORIGIN;
         final String allowedHttpHeaders =
                 CorsFilter.DEFAULT_ALLOWED_HTTP_HEADERS;
         final String allowedHttpMethods =
@@ -180,8 +208,8 @@ public class TesterFilterConfigs {
         final String decorateRequest = CorsFilter.DEFAULT_DECORATE_REQUEST;
 
         return generateFilterConfig(allowedHttpHeaders, allowedHttpMethods,
-                allowedOrigins, exposedHeaders, supportCredentials,
-                preflightMaxAge, decorateRequest);
+                allowedOrigins, allowNullOrigin, exposedHeaders,
+                supportCredentials, preflightMaxAge, decorateRequest);
     }
 
     public static FilterConfig getFilterConfigInvalidMaxPreflightAge() {
@@ -190,6 +218,7 @@ public class TesterFilterConfigs {
         final String allowedHttpMethods =
                 CorsFilter.DEFAULT_ALLOWED_HTTP_METHODS;
         final String allowedOrigins = CorsFilter.DEFAULT_ALLOWED_ORIGINS;
+        final String allowNullOrigin = CorsFilter.DEFAULT_ALLOW_NULL_ORIGIN;
         final String exposedHeaders = CorsFilter.DEFAULT_EXPOSED_HEADERS;
         final String supportCredentials =
                 CorsFilter.DEFAULT_SUPPORTS_CREDENTIALS;
@@ -197,22 +226,23 @@ public class TesterFilterConfigs {
         final String decorateRequest = CorsFilter.DEFAULT_DECORATE_REQUEST;
 
         return generateFilterConfig(allowedHttpHeaders, allowedHttpMethods,
-                allowedOrigins, exposedHeaders, supportCredentials,
-                preflightMaxAge, decorateRequest);
+                allowedOrigins, allowNullOrigin, exposedHeaders,
+                supportCredentials, preflightMaxAge, decorateRequest);
     }
 
     public static FilterConfig getEmptyFilterConfig() {
         final String allowedHttpHeaders = "";
         final String allowedHttpMethods = "";
         final String allowedOrigins = "";
+        final String allowNullOrigin = "";
         final String exposedHeaders = "";
         final String supportCredentials = "";
         final String preflightMaxAge = "";
         final String decorateRequest = "";
 
         return generateFilterConfig(allowedHttpHeaders, allowedHttpMethods,
-                allowedOrigins, exposedHeaders, supportCredentials,
-                preflightMaxAge, decorateRequest);
+                allowedOrigins, allowNullOrigin, exposedHeaders, 
+                supportCredentials, preflightMaxAge, decorateRequest);
     }
 
     public static FilterConfig getFilterConfigDecorateRequestDisabled() {
@@ -221,6 +251,7 @@ public class TesterFilterConfigs {
         final String allowedHttpMethods =
                 CorsFilter.DEFAULT_ALLOWED_HTTP_METHODS;
         final String allowedOrigins = CorsFilter.DEFAULT_ALLOWED_ORIGINS;
+        final String allowNullOrigin = CorsFilter.DEFAULT_ALLOW_NULL_ORIGIN;
         final String exposedHeaders = CorsFilter.DEFAULT_EXPOSED_HEADERS;
         final String supportCredentials =
                 CorsFilter.DEFAULT_SUPPORTS_CREDENTIALS;
@@ -229,15 +260,15 @@ public class TesterFilterConfigs {
         final String decorateRequest = "false";
 
         return generateFilterConfig(allowedHttpHeaders, allowedHttpMethods,
-                allowedOrigins, exposedHeaders, supportCredentials,
-                preflightMaxAge, decorateRequest);
+                allowedOrigins, allowNullOrigin, exposedHeaders,
+                supportCredentials, preflightMaxAge, decorateRequest);
     }
 
     private static FilterConfig generateFilterConfig(
             final String allowedHttpHeaders, final String allowedHttpMethods,
-            final String allowedOrigins, final String exposedHeaders,
-            final String supportCredentials, final String preflightMaxAge,
-            final String decorateRequest) {
+            final String allowedOrigins, final String allowNullOrigin,
+            final String exposedHeaders, final String supportCredentials,
+            final String preflightMaxAge, final String decorateRequest) {
         FilterConfig filterConfig = new FilterConfig() {
 
             @Override
@@ -261,6 +292,9 @@ public class TesterFilterConfigs {
                 } else if (CorsFilter.PARAM_CORS_ALLOWED_ORIGINS
                         .equalsIgnoreCase(name)) {
                     return allowedOrigins;
+                } else if (CorsFilter.PARAM_CORS_ALLOW_NULL_ORIGIN
+                        .equalsIgnoreCase(name)) {
+                    return allowNullOrigin;
                 } else if (CorsFilter.PARAM_CORS_EXPOSED_HEADERS
                         .equalsIgnoreCase(name)) {
                     return exposedHeaders;


### PR DESCRIPTION
Add a new configuration option "cors.allow.nullorigin" for CorsFilter to
explicitly allow requests with Origin value "null" (disabled by
default). When enabled, requests with Origin "null" will be handled as
valid CORS requests and processed by the filter.

See: https://issues.apache.org/bugzilla/show_bug.cgi?id=57178

Signed-off-by: Gregor Zurowski <gregor@zurowski.org>