### PR TITLE
#57178: Allow CORS requests with Origin header value "null"

### DIFF
--- a/java/org/apache/catalina/filters/CorsFilter.java
+++ b/java/org/apache/catalina/filters/CorsFilter.java
@@ -800,6 +800,7 @@ public final class CorsFilter implements Filter {
      * Checks if a given origin is valid or not. Criteria:
      * <ul>
      * <li>If an encoded character is present in origin, it's not valid.</li>
+     * <li>If origin is "null", it's valid.</li>
      * <li>Origin should be a valid {@link URI}</li>
      * </ul>
      *
@@ -810,6 +811,11 @@ public final class CorsFilter implements Filter {
         // Checks for encoded characters. Helps prevent CRLF injection.
         if (origin.contains("%")) {
             return false;
+        }
+
+        // "null" is a valid origin
+        if ("null".equals(origin)) {
+            return true;
         }
 
         URI originURI;

--- a/test/org/apache/catalina/filters/TestCorsFilter.java
+++ b/test/org/apache/catalina/filters/TestCorsFilter.java
@@ -497,10 +497,10 @@ public class TestCorsFilter {
     }
 
     /*
-     * Negative test, when a CORS request arrives, with a null origin.
+     * Negative test, when a CORS request arrives, with no origin header.
      */
     @Test
-    public void testDoFilterNullOrigin() throws IOException, ServletException {
+    public void testDoFilterNoOrigin() throws IOException, ServletException {
         TesterHttpServletRequest request = new TesterHttpServletRequest();
 
         request.setMethod("POST");
@@ -534,6 +534,58 @@ public class TestCorsFilter {
 
         Assert.assertEquals(HttpServletResponse.SC_FORBIDDEN,
                 response.getStatus());
+    }
+
+    /*
+     * A CORS request arrives with a "null" origin which is allowed by default.
+     */
+    @Test
+    public void testDoFilterNullOriginAllowedByDefault() throws IOException, 
+            ServletException {
+        TesterHttpServletRequest request = new TesterHttpServletRequest();
+
+        request.setMethod("POST");
+        request.setContentType("text/plain");
+        request.setHeader(CorsFilter.REQUEST_HEADER_ORIGIN, "null");
+        TesterHttpServletResponse response = new TesterHttpServletResponse();
+
+        CorsFilter corsFilter = new CorsFilter();
+        corsFilter.init(TesterFilterConfigs.getDefaultFilterConfig());
+        CorsFilter.CORSRequestType requestType =
+                corsFilter.checkRequestType(request);
+        Assert.assertEquals(CorsFilter.CORSRequestType.SIMPLE, requestType);
+
+        corsFilter.doFilter(request, response, filterChain);
+
+        Assert.assertTrue(((Boolean) request.getAttribute(
+                CorsFilter.HTTP_REQUEST_ATTRIBUTE_IS_CORS_REQUEST)).booleanValue());
+    }
+
+    /*
+     * A CORS request arrives with a "null" origin which is explicitly allowed 
+     * by configuration.
+     */
+    @Test
+    public void testDoFilterNullOriginAllowedByConfiguration() throws 
+            IOException, ServletException {
+        TesterHttpServletRequest request = new TesterHttpServletRequest();
+
+        request.setMethod("POST");
+        request.setContentType("text/plain");
+        request.setHeader(CorsFilter.REQUEST_HEADER_ORIGIN, "null");
+        TesterHttpServletResponse response = new TesterHttpServletResponse();
+
+        CorsFilter corsFilter = new CorsFilter();
+        corsFilter.init(
+                TesterFilterConfigs.getFilterConfigSpecificOriginNullAllowed());
+        CorsFilter.CORSRequestType requestType =
+                corsFilter.checkRequestType(request);
+        Assert.assertEquals(CorsFilter.CORSRequestType.SIMPLE, requestType);
+
+        corsFilter.doFilter(request, response, filterChain);
+
+        Assert.assertTrue(((Boolean) request.getAttribute(
+                CorsFilter.HTTP_REQUEST_ATTRIBUTE_IS_CORS_REQUEST)).booleanValue());
     }
 
     @Test(expected = ServletException.class)
@@ -1031,6 +1083,24 @@ public class TestCorsFilter {
         CorsFilter corsFilter = new CorsFilter();
         corsFilter.init(TesterFilterConfigs
                 .getSpecificOriginFilterConfig());
+        corsFilter.doFilter(request, response, filterChain);
+        Assert.assertEquals(HttpServletResponse.SC_FORBIDDEN,
+                response.getStatus());
+    }
+    
+    /*
+     * Tests for failure, when the 'null' origin is used, and it's not in the
+     * list of allowed origins.
+     */
+    @Test
+    public void testCheckNullOriginNotAllowed() throws ServletException, 
+            IOException {
+        TesterHttpServletRequest request = new TesterHttpServletRequest();
+        TesterHttpServletResponse response = new TesterHttpServletResponse();
+        request.setHeader(CorsFilter.REQUEST_HEADER_ORIGIN, "null");
+        request.setMethod("GET");
+        CorsFilter corsFilter = new CorsFilter();
+        corsFilter.init(TesterFilterConfigs.getSpecificOriginFilterConfig());
         corsFilter.doFilter(request, response, filterChain);
         Assert.assertEquals(HttpServletResponse.SC_FORBIDDEN,
                 response.getStatus());

--- a/test/org/apache/catalina/filters/TesterFilterConfigs.java
+++ b/test/org/apache/catalina/filters/TesterFilterConfigs.java
@@ -106,6 +106,24 @@ public class TesterFilterConfigs {
                 preflightMaxAge, decorateRequest);
     }
 
+    public static FilterConfig getFilterConfigSpecificOriginNullAllowed() {
+        final String allowedHttpHeaders =
+                CorsFilter.DEFAULT_ALLOWED_HTTP_HEADERS;
+        final String allowedHttpMethods =
+                CorsFilter.DEFAULT_ALLOWED_HTTP_METHODS;
+        final String allowedOrigins = HTTP_TOMCAT_APACHE_ORG + ",null";
+        final String exposedHeaders = CorsFilter.DEFAULT_EXPOSED_HEADERS;
+        final String supportCredentials = 
+                CorsFilter.DEFAULT_SUPPORTS_CREDENTIALS;
+        final String preflightMaxAge =
+                CorsFilter.DEFAULT_PREFLIGHT_MAXAGE;
+        final String decorateRequest = CorsFilter.DEFAULT_DECORATE_REQUEST;
+
+        return generateFilterConfig(allowedHttpHeaders, allowedHttpMethods,
+                allowedOrigins, exposedHeaders, supportCredentials,
+                preflightMaxAge, decorateRequest);
+    }
+
     public static FilterConfig getFilterConfigWithExposedHeaders() {
         final String allowedHttpHeaders =
                 CorsFilter.DEFAULT_ALLOWED_HTTP_HEADERS;


### PR DESCRIPTION
See also: https://issues.apache.org/bugzilla/show_bug.cgi?id=57178

Signed-off-by: Gregor Zurowski gregor@zurowski.org