### PR TITLE
Recursively create document base directory

### DIFF
--- a/java/org/apache/catalina/startup/ExpandWar.java
+++ b/java/org/apache/catalina/startup/ExpandWar.java
@@ -111,7 +111,7 @@ public class ExpandWar {
         }
 
         // Create the new document base directory
-        if(!docBase.mkdir() && !docBase.isDirectory()) {
+        if(!docBase.mkdirs() && !docBase.isDirectory()) {
             throw new IOException(sm.getString("expandWar.createFailed", docBase));
         }
 


### PR DESCRIPTION
The "expand" method will create the docBase directory, however sometimes this fails because the intermediate "webapps" directory has not been created already.  This will create the intermediate directory if it hasn't already been created externally.