### PR TITLE
[Bug 58242] Scanning jars in classpath to get annotations in parallel instead of synchronously

### DIFF
--- a/java/org/apache/catalina/startup/AnnotationScanner.java
+++ b/java/org/apache/catalina/startup/AnnotationScanner.java
@@ -1,0 +1,762 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.catalina.startup;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.servlet.ServletContainerInitializer;
+import javax.servlet.annotation.HandlesTypes;
+
+import org.apache.catalina.Context;
+import org.apache.catalina.startup.ContextConfig.JavaClassCacheEntry;
+import org.apache.catalina.util.Introspection;
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
+import org.apache.tomcat.util.bcel.classfile.AnnotationElementValue;
+import org.apache.tomcat.util.bcel.classfile.AnnotationEntry;
+import org.apache.tomcat.util.bcel.classfile.ArrayElementValue;
+import org.apache.tomcat.util.bcel.classfile.ClassFormatException;
+import org.apache.tomcat.util.bcel.classfile.ClassParser;
+import org.apache.tomcat.util.bcel.classfile.ElementValue;
+import org.apache.tomcat.util.bcel.classfile.ElementValuePair;
+import org.apache.tomcat.util.bcel.classfile.JavaClass;
+import org.apache.tomcat.util.descriptor.web.FilterDef;
+import org.apache.tomcat.util.descriptor.web.FilterMap;
+import org.apache.tomcat.util.descriptor.web.ServletDef;
+import org.apache.tomcat.util.descriptor.web.WebXml;
+import org.apache.tomcat.util.res.StringManager;
+import org.apache.tomcat.util.scan.Jar;
+import org.apache.tomcat.util.scan.JarFactory;
+
+/**
+ * 
+ * Scanner for one web fragment (one jar) to get interested annotations.
+ * 
+ * @author Simon Wang
+ *
+ */
+public class AnnotationScanner {
+
+    private static final Log log = LogFactory.getLog(AnnotationScanner.class);
+    protected static final StringManager sm = StringManager
+            .getManager(Constants.Package);
+
+    /**
+     * Set used as the value for {@code JavaClassCacheEntry.sciSet} when there
+     * are no SCIs associated with a class.
+     */
+    private static final Set<ServletContainerInitializer> EMPTY_SCI_SET = Collections
+            .emptySet();
+
+    /**
+     * Map of ServletContainerInitializer to classes they expressed interest in.
+     */
+    protected Map<ServletContainerInitializer, Set<Class<?>>> initializerClassMap;
+
+    /**
+     * Map of Types to ServletContainerInitializer that are interested in those
+     * types.
+     */
+    protected Map<Class<?>, Set<ServletContainerInitializer>> typeInitializerMap;
+
+    /**
+     * Cache of JavaClass objects (byte code) by fully qualified class name.
+     * Only populated if it is necessary to scan the super types and interfaces
+     * as part of the processing for {@link HandlesTypes}.
+     */
+    protected Map<String, JavaClassCacheEntry> javaClassCache;
+
+    /**
+     * Flag that indicates whether check handlesTypes or not.
+     */
+    protected boolean handlesTypesOnly;
+
+    /**
+     * Flag that indicates if at least one {@link HandlesTypes} entry is present
+     * that represents a non-annotation.
+     */
+    protected boolean handlesTypesNonAnnotations;
+
+    /**
+     * Flag that indicates if at least one {@link HandlesTypes} entry is present
+     * that represents an annotation.
+     */
+    protected boolean handlesTypesAnnotations;
+
+    /**
+     * The Context we are associated with.
+     */
+    protected Context context;
+
+    public AnnotationScanner(
+            Map<ServletContainerInitializer, Set<Class<?>>> initializerClassMap,
+            Map<String, JavaClassCacheEntry> javaClassCache,
+            final Map<Class<?>, Set<ServletContainerInitializer>> typeInitializerMap,
+            boolean handlesTypesNonAnnotations,
+            boolean handlesTypesAnnotations, Context context) {
+        this.initializerClassMap = initializerClassMap;
+        this.typeInitializerMap = typeInitializerMap;
+        this.javaClassCache = javaClassCache;
+        this.handlesTypesAnnotations = handlesTypesAnnotations;
+        this.handlesTypesNonAnnotations = handlesTypesNonAnnotations;
+        this.context = context;
+    }
+
+    public void scan(WebXml fragment, boolean handlesTypesOnly) {
+        // Only need to scan for @HandlesTypes matches if any of the
+        // following are true:
+        // - it has already been determined only @HandlesTypes is required
+        // (e.g. main web.xml has metadata-complete="true"
+        // - this fragment is for a container JAR (Servlet 3.1 section 8.1)
+        // - this fragment has metadata-complete="true"
+        boolean htOnly = handlesTypesOnly || !fragment.getWebappJar()
+                || fragment.isMetadataComplete();
+
+        WebXml annotations = new WebXml();
+        // no impact on distributable
+        annotations.setDistributable(true);
+        URL url = fragment.getURL();
+        processAnnotationsUrl(url, annotations, htOnly);
+        Set<WebXml> set = new HashSet<>();
+        set.add(annotations);
+        // Merge annotations into fragment - fragment takes priority
+        fragment.merge(set);
+    }
+
+    protected void processAnnotationsUrl(URL url, WebXml fragment,
+            boolean handlesTypesOnly) {
+        if (url == null) {
+            // Nothing to do.
+            return;
+        } else if ("jar".equals(url.getProtocol())) {
+            processAnnotationsJar(url, fragment, handlesTypesOnly);
+        } else if ("file".equals(url.getProtocol())) {
+            try {
+                processAnnotationsFile(new File(url.toURI()), fragment,
+                        handlesTypesOnly);
+            } catch (URISyntaxException e) {
+                log.error(sm.getString("contextConfig.fileUrl", url), e);
+            }
+        } else {
+            log.error(sm.getString("contextConfig.unknownUrlProtocol",
+                    url.getProtocol(), url));
+        }
+
+    }
+
+    protected void processAnnotationsJar(URL url, WebXml fragment,
+            boolean handlesTypesOnly) {
+
+        try (Jar jar = JarFactory.newInstance(url)) {
+            jar.nextEntry();
+            String entryName = jar.getEntryName();
+            while (entryName != null) {
+                if (entryName.endsWith(".class")) {
+                    try (InputStream is = jar.getEntryInputStream()) {
+                        processAnnotationsStream(is, fragment, handlesTypesOnly);
+                    } catch (IOException e) {
+                        log.error(sm.getString("contextConfig.inputStreamJar",
+                                entryName, url), e);
+                    } catch (ClassFormatException e) {
+                        log.error(sm.getString("contextConfig.inputStreamJar",
+                                entryName, url), e);
+                    }
+                }
+                jar.nextEntry();
+                entryName = jar.getEntryName();
+            }
+        } catch (IOException e) {
+            log.error(sm.getString("contextConfig.jarFile", url), e);
+        }
+    }
+
+    protected void processAnnotationsFile(File file, WebXml fragment,
+            boolean handlesTypesOnly) {
+
+        if (file.isDirectory()) {
+            // Returns null if directory is not readable
+            String[] dirs = file.list();
+            if (dirs != null) {
+                for (String dir : dirs) {
+                    processAnnotationsFile(new File(file, dir), fragment,
+                            handlesTypesOnly);
+                }
+            }
+        } else if (file.canRead() && file.getName().endsWith(".class")) {
+            try (FileInputStream fis = new FileInputStream(file)) {
+                processAnnotationsStream(fis, fragment, handlesTypesOnly);
+            } catch (IOException e) {
+                log.error(
+                        sm.getString("contextConfig.inputStreamFile",
+                                file.getAbsolutePath()), e);
+            } catch (ClassFormatException e) {
+                log.error(
+                        sm.getString("contextConfig.inputStreamFile",
+                                file.getAbsolutePath()), e);
+            }
+        }
+    }
+
+    protected void processAnnotationsStream(InputStream is, WebXml fragment,
+            boolean handlesTypesOnly) throws ClassFormatException, IOException {
+
+        ClassParser parser = new ClassParser(is);
+        JavaClass clazz = parser.parse();
+        checkHandlesTypes(clazz);
+
+        if (handlesTypesOnly) {
+            return;
+        }
+
+        AnnotationEntry[] annotationsEntries = clazz.getAnnotationEntries();
+        if (annotationsEntries != null) {
+            String className = clazz.getClassName();
+            for (AnnotationEntry ae : annotationsEntries) {
+                String type = ae.getAnnotationType();
+                if ("Ljavax/servlet/annotation/WebServlet;".equals(type)) {
+                    processAnnotationWebServlet(className, ae, fragment);
+                } else if ("Ljavax/servlet/annotation/WebFilter;".equals(type)) {
+                    processAnnotationWebFilter(className, ae, fragment);
+                } else if ("Ljavax/servlet/annotation/WebListener;"
+                        .equals(type)) {
+                    fragment.addListener(className);
+                } else {
+                    // Unknown annotation - ignore
+                }
+            }
+        }
+    }
+
+    /**
+     * For classes packaged with the web application, the class and each super
+     * class needs to be checked for a match with {@link HandlesTypes} or for an
+     * annotation that matches {@link HandlesTypes}.
+     *
+     * @param javaClass
+     */
+    protected void checkHandlesTypes(JavaClass javaClass) {
+
+        // Skip this if we can
+        if (typeInitializerMap.size() == 0) {
+            return;
+        }
+
+        if ((javaClass.getAccessFlags() & org.apache.tomcat.util.bcel.Constants.ACC_ANNOTATION) > 0) {
+            // Skip annotations.
+            return;
+        }
+
+        String className = javaClass.getClassName();
+
+        Class<?> clazz = null;
+        if (handlesTypesNonAnnotations) {
+            // This *might* be match for a HandlesType.
+            populateJavaClassCache(className, javaClass);
+            JavaClassCacheEntry entry = javaClassCache.get(className);
+            if (entry.getSciSet() == null) {
+                try {
+                    populateSCIsForCacheEntry(entry);
+                } catch (StackOverflowError soe) {
+                    throw new IllegalStateException(sm.getString(
+                            "contextConfig.annotationsStackOverflow",
+                            context.getName(),
+                            classHierarchyToString(className, entry)));
+                }
+            }
+            if (!entry.getSciSet().isEmpty()) {
+                // Need to try and load the class
+                clazz = Introspection.loadClass(context, className);
+                if (clazz == null) {
+                    // Can't load the class so no point continuing
+                    return;
+                }
+
+                for (ServletContainerInitializer sci : entry.getSciSet()) {
+                    Set<Class<?>> classes = initializerClassMap.get(sci);
+                    if (classes == null) {
+                        classes = new HashSet<>();
+                        initializerClassMap.put(sci, classes);
+                    }
+                    classes.add(clazz);
+                }
+            }
+        }
+
+        if (handlesTypesAnnotations) {
+            AnnotationEntry[] annotationEntries = javaClass
+                    .getAnnotationEntries();
+            if (annotationEntries != null) {
+                for (Map.Entry<Class<?>, Set<ServletContainerInitializer>> entry : typeInitializerMap
+                        .entrySet()) {
+                    if (entry.getKey().isAnnotation()) {
+                        String entryClassName = entry.getKey().getName();
+                        for (AnnotationEntry annotationEntry : annotationEntries) {
+                            if (entryClassName
+                                    .equals(getClassName(annotationEntry
+                                            .getAnnotationType()))) {
+                                if (clazz == null) {
+                                    clazz = Introspection.loadClass(context,
+                                            className);
+                                    if (clazz == null) {
+                                        // Can't load the class so no point
+                                        // continuing
+                                        return;
+                                    }
+                                }
+                                for (ServletContainerInitializer sci : entry
+                                        .getValue()) {
+                                    initializerClassMap.get(sci).add(clazz);
+                                }
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private String classHierarchyToString(String className,
+            JavaClassCacheEntry entry) {
+        JavaClassCacheEntry start = entry;
+        StringBuilder msg = new StringBuilder(className);
+        msg.append("->");
+
+        String parentName = entry.getSuperclassName();
+        JavaClassCacheEntry parent = javaClassCache.get(parentName);
+        int count = 0;
+
+        while (count < 100 && parent != null && parent != start) {
+            msg.append(parentName);
+            msg.append("->");
+
+            count++;
+            parentName = parent.getSuperclassName();
+            parent = javaClassCache.get(parentName);
+        }
+
+        msg.append(parentName);
+
+        return msg.toString();
+    }
+
+    private void populateJavaClassCache(String className, JavaClass javaClass) {
+        if (javaClassCache.containsKey(className)) {
+            return;
+        }
+
+        // Add this class to the cache
+        javaClassCache.put(className, new JavaClassCacheEntry(javaClass));
+
+        populateJavaClassCache(javaClass.getSuperclassName());
+
+        for (String iterface : javaClass.getInterfaceNames()) {
+            populateJavaClassCache(iterface);
+        }
+    }
+
+    private void populateJavaClassCache(String className) {
+        if (!javaClassCache.containsKey(className)) {
+            String name = className.replace('.', '/') + ".class";
+            try (InputStream is = context.getLoader().getClassLoader()
+                    .getResourceAsStream(name)) {
+                if (is == null) {
+                    return;
+                }
+                ClassParser parser = new ClassParser(is);
+                JavaClass clazz = parser.parse();
+                populateJavaClassCache(clazz.getClassName(), clazz);
+            } catch (ClassFormatException e) {
+                log.debug(sm.getString("contextConfig.invalidSciHandlesTypes",
+                        className), e);
+            } catch (IOException e) {
+                log.debug(sm.getString("contextConfig.invalidSciHandlesTypes",
+                        className), e);
+            }
+        }
+    }
+
+    private void populateSCIsForCacheEntry(JavaClassCacheEntry cacheEntry) {
+        Set<ServletContainerInitializer> result = new HashSet<>();
+
+        // Super class
+        String superClassName = cacheEntry.getSuperclassName();
+        JavaClassCacheEntry superClassCacheEntry = javaClassCache
+                .get(superClassName);
+
+        // Avoid an infinite loop with java.lang.Object
+        if (cacheEntry.equals(superClassCacheEntry)) {
+            cacheEntry.setSciSet(EMPTY_SCI_SET);
+            return;
+        }
+
+        // May be null of the class is not present or could not be loaded.
+        if (superClassCacheEntry != null) {
+            if (superClassCacheEntry.getSciSet() == null) {
+                populateSCIsForCacheEntry(superClassCacheEntry);
+            }
+            result.addAll(superClassCacheEntry.getSciSet());
+        }
+        result.addAll(getSCIsForClass(superClassName));
+
+        // Interfaces
+        for (String interfaceName : cacheEntry.getInterfaceNames()) {
+            JavaClassCacheEntry interfaceEntry = javaClassCache
+                    .get(interfaceName);
+            // A null could mean that the class not present in application or
+            // that there is nothing of interest. Either way, nothing to do here
+            // so move along
+            if (interfaceEntry != null) {
+                if (interfaceEntry.getSciSet() == null) {
+                    populateSCIsForCacheEntry(interfaceEntry);
+                }
+                result.addAll(interfaceEntry.getSciSet());
+            }
+            result.addAll(getSCIsForClass(interfaceName));
+        }
+
+        cacheEntry.setSciSet(result.isEmpty() ? EMPTY_SCI_SET : result);
+    }
+
+    private Set<ServletContainerInitializer> getSCIsForClass(String className) {
+        for (Map.Entry<Class<?>, Set<ServletContainerInitializer>> entry : typeInitializerMap
+                .entrySet()) {
+            Class<?> clazz = entry.getKey();
+            if (!clazz.isAnnotation()) {
+                if (clazz.getName().equals(className)) {
+                    return entry.getValue();
+                }
+            }
+        }
+        return EMPTY_SCI_SET;
+    }
+
+    private static final String getClassName(String internalForm) {
+        if (!internalForm.startsWith("L")) {
+            return internalForm;
+        }
+
+        // Assume starts with L, ends with ; and uses / rather than .
+        return internalForm.substring(1, internalForm.length() - 1).replace(
+                '/', '.');
+    }
+
+    protected void processAnnotationWebServlet(String className,
+            AnnotationEntry ae, WebXml fragment) {
+        String servletName = null;
+        // must search for name s. Spec Servlet API 3.0 - 8.2.3.3.n.ii page 81
+        List<ElementValuePair> evps = ae.getElementValuePairs();
+        for (ElementValuePair evp : evps) {
+            String name = evp.getNameString();
+            if ("name".equals(name)) {
+                servletName = evp.getValue().stringifyValue();
+                break;
+            }
+        }
+        if (servletName == null) {
+            // classname is default servletName as annotation has no name!
+            servletName = className;
+        }
+        ServletDef servletDef = fragment.getServlets().get(servletName);
+
+        boolean isWebXMLservletDef;
+        if (servletDef == null) {
+            servletDef = new ServletDef();
+            servletDef.setServletName(servletName);
+            servletDef.setServletClass(className);
+            isWebXMLservletDef = false;
+        } else {
+            isWebXMLservletDef = true;
+        }
+
+        boolean urlPatternsSet = false;
+        String[] urlPatterns = null;
+
+        // List<ElementValuePair> evps = ae.getElementValuePairs();
+        for (ElementValuePair evp : evps) {
+            String name = evp.getNameString();
+            if ("value".equals(name) || "urlPatterns".equals(name)) {
+                if (urlPatternsSet) {
+                    throw new IllegalArgumentException(sm.getString(
+                            "contextConfig.urlPatternValue", className));
+                }
+                urlPatternsSet = true;
+                urlPatterns = processAnnotationsStringArray(evp.getValue());
+            } else if ("description".equals(name)) {
+                if (servletDef.getDescription() == null) {
+                    servletDef.setDescription(evp.getValue().stringifyValue());
+                }
+            } else if ("displayName".equals(name)) {
+                if (servletDef.getDisplayName() == null) {
+                    servletDef.setDisplayName(evp.getValue().stringifyValue());
+                }
+            } else if ("largeIcon".equals(name)) {
+                if (servletDef.getLargeIcon() == null) {
+                    servletDef.setLargeIcon(evp.getValue().stringifyValue());
+                }
+            } else if ("smallIcon".equals(name)) {
+                if (servletDef.getSmallIcon() == null) {
+                    servletDef.setSmallIcon(evp.getValue().stringifyValue());
+                }
+            } else if ("asyncSupported".equals(name)) {
+                if (servletDef.getAsyncSupported() == null) {
+                    servletDef.setAsyncSupported(evp.getValue()
+                            .stringifyValue());
+                }
+            } else if ("loadOnStartup".equals(name)) {
+                if (servletDef.getLoadOnStartup() == null) {
+                    servletDef
+                            .setLoadOnStartup(evp.getValue().stringifyValue());
+                }
+            } else if ("initParams".equals(name)) {
+                Map<String, String> initParams = processAnnotationWebInitParams(evp
+                        .getValue());
+                if (isWebXMLservletDef) {
+                    Map<String, String> webXMLInitParams = servletDef
+                            .getParameterMap();
+                    for (Map.Entry<String, String> entry : initParams
+                            .entrySet()) {
+                        if (webXMLInitParams.get(entry.getKey()) == null) {
+                            servletDef.addInitParameter(entry.getKey(),
+                                    entry.getValue());
+                        }
+                    }
+                } else {
+                    for (Map.Entry<String, String> entry : initParams
+                            .entrySet()) {
+                        servletDef.addInitParameter(entry.getKey(),
+                                entry.getValue());
+                    }
+                }
+            }
+        }
+        if (!isWebXMLservletDef && urlPatterns != null) {
+            fragment.addServlet(servletDef);
+        }
+        if (urlPatterns != null) {
+            if (!fragment.getServletMappings().containsValue(servletName)) {
+                for (String urlPattern : urlPatterns) {
+                    fragment.addServletMapping(urlPattern, servletName);
+                }
+            }
+        }
+
+    }
+
+    /**
+     * process filter annotation and merge with existing one! FIXME: refactoring
+     * method too long and has redundant subroutines with
+     * processAnnotationWebServlet!
+     *
+     * @param className
+     * @param ae
+     * @param fragment
+     */
+    protected void processAnnotationWebFilter(String className,
+            AnnotationEntry ae, WebXml fragment) {
+        String filterName = null;
+        // must search for name s. Spec Servlet API 3.0 - 8.2.3.3.n.ii page 81
+        List<ElementValuePair> evps = ae.getElementValuePairs();
+        for (ElementValuePair evp : evps) {
+            String name = evp.getNameString();
+            if ("filterName".equals(name)) {
+                filterName = evp.getValue().stringifyValue();
+                break;
+            }
+        }
+        if (filterName == null) {
+            // classname is default filterName as annotation has no name!
+            filterName = className;
+        }
+        FilterDef filterDef = fragment.getFilters().get(filterName);
+        FilterMap filterMap = new FilterMap();
+
+        boolean isWebXMLfilterDef;
+        if (filterDef == null) {
+            filterDef = new FilterDef();
+            filterDef.setFilterName(filterName);
+            filterDef.setFilterClass(className);
+            isWebXMLfilterDef = false;
+        } else {
+            isWebXMLfilterDef = true;
+        }
+
+        boolean urlPatternsSet = false;
+        boolean servletNamesSet = false;
+        boolean dispatchTypesSet = false;
+        String[] urlPatterns = null;
+
+        for (ElementValuePair evp : evps) {
+            String name = evp.getNameString();
+            if ("value".equals(name) || "urlPatterns".equals(name)) {
+                if (urlPatternsSet) {
+                    throw new IllegalArgumentException(sm.getString(
+                            "contextConfig.urlPatternValue", className));
+                }
+                urlPatterns = processAnnotationsStringArray(evp.getValue());
+                urlPatternsSet = urlPatterns.length > 0;
+                for (String urlPattern : urlPatterns) {
+                    filterMap.addURLPattern(urlPattern);
+                }
+            } else if ("servletNames".equals(name)) {
+                String[] servletNames = processAnnotationsStringArray(evp
+                        .getValue());
+                servletNamesSet = servletNames.length > 0;
+                for (String servletName : servletNames) {
+                    filterMap.addServletName(servletName);
+                }
+            } else if ("dispatcherTypes".equals(name)) {
+                String[] dispatcherTypes = processAnnotationsStringArray(evp
+                        .getValue());
+                dispatchTypesSet = dispatcherTypes.length > 0;
+                for (String dispatcherType : dispatcherTypes) {
+                    filterMap.setDispatcher(dispatcherType);
+                }
+            } else if ("description".equals(name)) {
+                if (filterDef.getDescription() == null) {
+                    filterDef.setDescription(evp.getValue().stringifyValue());
+                }
+            } else if ("displayName".equals(name)) {
+                if (filterDef.getDisplayName() == null) {
+                    filterDef.setDisplayName(evp.getValue().stringifyValue());
+                }
+            } else if ("largeIcon".equals(name)) {
+                if (filterDef.getLargeIcon() == null) {
+                    filterDef.setLargeIcon(evp.getValue().stringifyValue());
+                }
+            } else if ("smallIcon".equals(name)) {
+                if (filterDef.getSmallIcon() == null) {
+                    filterDef.setSmallIcon(evp.getValue().stringifyValue());
+                }
+            } else if ("asyncSupported".equals(name)) {
+                if (filterDef.getAsyncSupported() == null) {
+                    filterDef
+                            .setAsyncSupported(evp.getValue().stringifyValue());
+                }
+            } else if ("initParams".equals(name)) {
+                Map<String, String> initParams = processAnnotationWebInitParams(evp
+                        .getValue());
+                if (isWebXMLfilterDef) {
+                    Map<String, String> webXMLInitParams = filterDef
+                            .getParameterMap();
+                    for (Map.Entry<String, String> entry : initParams
+                            .entrySet()) {
+                        if (webXMLInitParams.get(entry.getKey()) == null) {
+                            filterDef.addInitParameter(entry.getKey(),
+                                    entry.getValue());
+                        }
+                    }
+                } else {
+                    for (Map.Entry<String, String> entry : initParams
+                            .entrySet()) {
+                        filterDef.addInitParameter(entry.getKey(),
+                                entry.getValue());
+                    }
+                }
+
+            }
+        }
+        if (!isWebXMLfilterDef) {
+            fragment.addFilter(filterDef);
+            if (urlPatternsSet || servletNamesSet) {
+                filterMap.setFilterName(filterName);
+                fragment.addFilterMapping(filterMap);
+            }
+        }
+        if (urlPatternsSet || dispatchTypesSet) {
+            Set<FilterMap> fmap = fragment.getFilterMappings();
+            FilterMap descMap = null;
+            for (FilterMap map : fmap) {
+                if (filterName.equals(map.getFilterName())) {
+                    descMap = map;
+                    break;
+                }
+            }
+            if (descMap != null) {
+                String[] urlsPatterns = descMap.getURLPatterns();
+                if (urlPatternsSet
+                        && (urlsPatterns == null || urlsPatterns.length == 0)) {
+                    for (String urlPattern : filterMap.getURLPatterns()) {
+                        descMap.addURLPattern(urlPattern);
+                    }
+                }
+                String[] dispatcherNames = descMap.getDispatcherNames();
+                if (dispatchTypesSet
+                        && (dispatcherNames == null || dispatcherNames.length == 0)) {
+                    for (String dis : filterMap.getDispatcherNames()) {
+                        descMap.setDispatcher(dis);
+                    }
+                }
+            }
+        }
+
+    }
+
+    protected String[] processAnnotationsStringArray(ElementValue ev) {
+        ArrayList<String> values = new ArrayList<>();
+        if (ev instanceof ArrayElementValue) {
+            ElementValue[] arrayValues = ((ArrayElementValue) ev)
+                    .getElementValuesArray();
+            for (ElementValue value : arrayValues) {
+                values.add(value.stringifyValue());
+            }
+        } else {
+            values.add(ev.stringifyValue());
+        }
+        String[] result = new String[values.size()];
+        return values.toArray(result);
+    }
+
+    protected Map<String, String> processAnnotationWebInitParams(ElementValue ev) {
+        Map<String, String> result = new HashMap<>();
+        if (ev instanceof ArrayElementValue) {
+            ElementValue[] arrayValues = ((ArrayElementValue) ev)
+                    .getElementValuesArray();
+            for (ElementValue value : arrayValues) {
+                if (value instanceof AnnotationElementValue) {
+                    List<ElementValuePair> evps = ((AnnotationElementValue) value)
+                            .getAnnotationEntry().getElementValuePairs();
+                    String initParamName = null;
+                    String initParamValue = null;
+                    for (ElementValuePair evp : evps) {
+                        if ("name".equals(evp.getNameString())) {
+                            initParamName = evp.getValue().stringifyValue();
+                        } else if ("value".equals(evp.getNameString())) {
+                            initParamValue = evp.getValue().stringifyValue();
+                        } else {
+                            // Ignore
+                        }
+                    }
+                    result.put(initParamName, initParamValue);
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/java/org/apache/catalina/startup/ContextConfig.java
+++ b/java/org/apache/catalina/startup/ContextConfig.java
@@ -26,7 +26,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -67,19 +66,12 @@ import org.apache.catalina.authenticator.jaspic.provider.TomcatAuthConfigProvide
 import org.apache.catalina.core.StandardContext;
 import org.apache.catalina.core.StandardHost;
 import org.apache.catalina.util.ContextName;
-import org.apache.catalina.util.Introspection;
 import org.apache.juli.logging.Log;
 import org.apache.juli.logging.LogFactory;
 import org.apache.tomcat.JarScanType;
 import org.apache.tomcat.JarScanner;
 import org.apache.tomcat.util.ExceptionUtils;
-import org.apache.tomcat.util.bcel.classfile.AnnotationElementValue;
-import org.apache.tomcat.util.bcel.classfile.AnnotationEntry;
-import org.apache.tomcat.util.bcel.classfile.ArrayElementValue;
 import org.apache.tomcat.util.bcel.classfile.ClassFormatException;
-import org.apache.tomcat.util.bcel.classfile.ClassParser;
-import org.apache.tomcat.util.bcel.classfile.ElementValue;
-import org.apache.tomcat.util.bcel.classfile.ElementValuePair;
 import org.apache.tomcat.util.bcel.classfile.JavaClass;
 import org.apache.tomcat.util.descriptor.XmlErrorHandler;
 import org.apache.tomcat.util.descriptor.web.ContextEjb;
@@ -165,14 +157,6 @@ public class ContextConfig implements LifecycleListener {
     protected static final Map<Host,DefaultWebXmlCacheEntry> hostWebXmlCache =
             new ConcurrentHashMap<>();
 
-
-    /**
-     * Set used as the value for {@code JavaClassCacheEntry.sciSet} when there
-     * are no SCIs associated with a class.
-     */
-    private static final Set<ServletContainerInitializer> EMPTY_SCI_SET = Collections.emptySet();
-
-
     // ----------------------------------------------------- Instance Variables
     /**
      * Custom mappings of login methods to authenticators
@@ -245,7 +229,13 @@ public class ContextConfig implements LifecycleListener {
     protected boolean handlesTypesNonAnnotations = false;
 
     private WebXmlParser webXmlParser;
-
+    
+    /**
+     * AnnotationScanner to scan interested annotations from each web fragment or jar.
+     */
+    protected AnnotationScanner scanner = new AnnotationScanner(
+            initializerClassMap, javaClassCache, typeInitializerMap,
+            handlesTypesNonAnnotations, handlesTypesAnnotations, context);
 
     // ------------------------------------------------------------- Properties
 
@@ -1907,25 +1897,9 @@ public class ContextConfig implements LifecycleListener {
 
     protected void processAnnotations(Set<WebXml> fragments,
             boolean handlesTypesOnly) {
+        
         for(WebXml fragment : fragments) {
-            // Only need to scan for @HandlesTypes matches if any of the
-            // following are true:
-            // - it has already been determined only @HandlesTypes is required
-            //   (e.g. main web.xml has metadata-complete="true"
-            // - this fragment is for a container JAR (Servlet 3.1 section 8.1)
-            // - this fragment has metadata-complete="true"
-            boolean htOnly = handlesTypesOnly || !fragment.getWebappJar() ||
-                    fragment.isMetadataComplete();
-
-            WebXml annotations = new WebXml();
-            // no impact on distributable
-            annotations.setDistributable(true);
-            URL url = fragment.getURL();
-            processAnnotationsUrl(url, annotations, htOnly);
-            Set<WebXml> set = new HashSet<>();
-            set.add(annotations);
-            // Merge annotations into fragment - fragment takes priority
-            fragment.merge(set);
+            scanner.scan(fragment, handlesTypesOnly);
         }
     }
 
@@ -1942,7 +1916,7 @@ public class ContextConfig implements LifecycleListener {
         } else if (webResource.isFile() &&
                 webResource.getName().endsWith(".class")) {
             try (InputStream is = webResource.getInputStream()) {
-                processAnnotationsStream(is, fragment, handlesTypesOnly);
+                scanner.processAnnotationsStream(is, fragment, handlesTypesOnly);
             } catch (IOException e) {
                 log.error(sm.getString("contextConfig.inputStreamWebResource",
                         webResource.getWebappPath()),e);
@@ -1951,617 +1925,6 @@ public class ContextConfig implements LifecycleListener {
                         webResource.getWebappPath()),e);
             }
         }
-    }
-
-
-    protected void processAnnotationsUrl(URL url, WebXml fragment,
-            boolean handlesTypesOnly) {
-        if (url == null) {
-            // Nothing to do.
-            return;
-        } else if ("jar".equals(url.getProtocol())) {
-            processAnnotationsJar(url, fragment, handlesTypesOnly);
-        } else if ("file".equals(url.getProtocol())) {
-            try {
-                processAnnotationsFile(
-                        new File(url.toURI()), fragment, handlesTypesOnly);
-            } catch (URISyntaxException e) {
-                log.error(sm.getString("contextConfig.fileUrl", url), e);
-            }
-        } else {
-            log.error(sm.getString("contextConfig.unknownUrlProtocol",
-                    url.getProtocol(), url));
-        }
-
-    }
-
-
-    protected void processAnnotationsJar(URL url, WebXml fragment,
-            boolean handlesTypesOnly) {
-
-        try (Jar jar = JarFactory.newInstance(url)) {
-            jar.nextEntry();
-            String entryName = jar.getEntryName();
-            while (entryName != null) {
-                if (entryName.endsWith(".class")) {
-                    try (InputStream is = jar.getEntryInputStream()) {
-                        processAnnotationsStream(
-                                is, fragment, handlesTypesOnly);
-                    } catch (IOException e) {
-                        log.error(sm.getString("contextConfig.inputStreamJar",
-                                entryName, url),e);
-                    } catch (ClassFormatException e) {
-                        log.error(sm.getString("contextConfig.inputStreamJar",
-                                entryName, url),e);
-                    }
-                }
-                jar.nextEntry();
-                entryName = jar.getEntryName();
-            }
-        } catch (IOException e) {
-            log.error(sm.getString("contextConfig.jarFile", url), e);
-        }
-    }
-
-
-    protected void processAnnotationsFile(File file, WebXml fragment,
-            boolean handlesTypesOnly) {
-
-        if (file.isDirectory()) {
-            // Returns null if directory is not readable
-            String[] dirs = file.list();
-            if (dirs != null) {
-                for (String dir : dirs) {
-                    processAnnotationsFile(
-                            new File(file,dir), fragment, handlesTypesOnly);
-                }
-            }
-        } else if (file.canRead() && file.getName().endsWith(".class")) {
-            try (FileInputStream fis = new FileInputStream(file)) {
-                processAnnotationsStream(fis, fragment, handlesTypesOnly);
-            } catch (IOException e) {
-                log.error(sm.getString("contextConfig.inputStreamFile",
-                        file.getAbsolutePath()),e);
-            } catch (ClassFormatException e) {
-                log.error(sm.getString("contextConfig.inputStreamFile",
-                        file.getAbsolutePath()),e);
-            }
-        }
-    }
-
-
-    protected void processAnnotationsStream(InputStream is, WebXml fragment,
-            boolean handlesTypesOnly)
-            throws ClassFormatException, IOException {
-
-        ClassParser parser = new ClassParser(is);
-        JavaClass clazz = parser.parse();
-        checkHandlesTypes(clazz);
-
-        if (handlesTypesOnly) {
-            return;
-        }
-
-        AnnotationEntry[] annotationsEntries = clazz.getAnnotationEntries();
-        if (annotationsEntries != null) {
-            String className = clazz.getClassName();
-            for (AnnotationEntry ae : annotationsEntries) {
-                String type = ae.getAnnotationType();
-                if ("Ljavax/servlet/annotation/WebServlet;".equals(type)) {
-                    processAnnotationWebServlet(className, ae, fragment);
-                }else if ("Ljavax/servlet/annotation/WebFilter;".equals(type)) {
-                    processAnnotationWebFilter(className, ae, fragment);
-                }else if ("Ljavax/servlet/annotation/WebListener;".equals(type)) {
-                    fragment.addListener(className);
-                } else {
-                    // Unknown annotation - ignore
-                }
-            }
-        }
-    }
-
-    /**
-     * For classes packaged with the web application, the class and each
-     * super class needs to be checked for a match with {@link HandlesTypes} or
-     * for an annotation that matches {@link HandlesTypes}.
-     * @param javaClass
-     */
-    protected void checkHandlesTypes(JavaClass javaClass) {
-
-        // Skip this if we can
-        if (typeInitializerMap.size() == 0) {
-            return;
-        }
-
-        if ((javaClass.getAccessFlags() &
-                org.apache.tomcat.util.bcel.Constants.ACC_ANNOTATION) > 0) {
-            // Skip annotations.
-            return;
-        }
-
-        String className = javaClass.getClassName();
-
-        Class<?> clazz = null;
-        if (handlesTypesNonAnnotations) {
-            // This *might* be match for a HandlesType.
-            populateJavaClassCache(className, javaClass);
-            JavaClassCacheEntry entry = javaClassCache.get(className);
-            if (entry.getSciSet() == null) {
-                try {
-                    populateSCIsForCacheEntry(entry);
-                } catch (StackOverflowError soe) {
-                    throw new IllegalStateException(sm.getString(
-                            "contextConfig.annotationsStackOverflow",
-                            context.getName(),
-                            classHierarchyToString(className, entry)));
-                }
-            }
-            if (!entry.getSciSet().isEmpty()) {
-                // Need to try and load the class
-                clazz = Introspection.loadClass(context, className);
-                if (clazz == null) {
-                    // Can't load the class so no point continuing
-                    return;
-                }
-
-                for (ServletContainerInitializer sci : entry.getSciSet()) {
-                    Set<Class<?>> classes = initializerClassMap.get(sci);
-                    if (classes == null) {
-                        classes = new HashSet<>();
-                        initializerClassMap.put(sci, classes);
-                    }
-                    classes.add(clazz);
-                }
-            }
-        }
-
-        if (handlesTypesAnnotations) {
-            AnnotationEntry[] annotationEntries = javaClass.getAnnotationEntries();
-            if (annotationEntries != null) {
-                for (Map.Entry<Class<?>, Set<ServletContainerInitializer>> entry :
-                        typeInitializerMap.entrySet()) {
-                    if (entry.getKey().isAnnotation()) {
-                        String entryClassName = entry.getKey().getName();
-                        for (AnnotationEntry annotationEntry : annotationEntries) {
-                            if (entryClassName.equals(
-                                    getClassName(annotationEntry.getAnnotationType()))) {
-                                if (clazz == null) {
-                                    clazz = Introspection.loadClass(
-                                            context, className);
-                                    if (clazz == null) {
-                                        // Can't load the class so no point
-                                        // continuing
-                                        return;
-                                    }
-                                }
-                                for (ServletContainerInitializer sci : entry.getValue()) {
-                                    initializerClassMap.get(sci).add(clazz);
-                                }
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-
-    private String classHierarchyToString(String className,
-            JavaClassCacheEntry entry) {
-        JavaClassCacheEntry start = entry;
-        StringBuilder msg = new StringBuilder(className);
-        msg.append("->");
-
-        String parentName = entry.getSuperclassName();
-        JavaClassCacheEntry parent = javaClassCache.get(parentName);
-        int count = 0;
-
-        while (count < 100 && parent != null && parent != start) {
-            msg.append(parentName);
-            msg.append("->");
-
-            count ++;
-            parentName = parent.getSuperclassName();
-            parent = javaClassCache.get(parentName);
-        }
-
-        msg.append(parentName);
-
-        return msg.toString();
-    }
-
-    private void populateJavaClassCache(String className, JavaClass javaClass) {
-        if (javaClassCache.containsKey(className)) {
-            return;
-        }
-
-        // Add this class to the cache
-        javaClassCache.put(className, new JavaClassCacheEntry(javaClass));
-
-        populateJavaClassCache(javaClass.getSuperclassName());
-
-        for (String iterface : javaClass.getInterfaceNames()) {
-            populateJavaClassCache(iterface);
-        }
-    }
-
-    private void populateJavaClassCache(String className) {
-        if (!javaClassCache.containsKey(className)) {
-            String name = className.replace('.', '/') + ".class";
-            try (InputStream is = context.getLoader().getClassLoader().getResourceAsStream(name)) {
-                if (is == null) {
-                    return;
-                }
-                ClassParser parser = new ClassParser(is);
-                JavaClass clazz = parser.parse();
-                populateJavaClassCache(clazz.getClassName(), clazz);
-            } catch (ClassFormatException e) {
-                log.debug(sm.getString("contextConfig.invalidSciHandlesTypes",
-                        className), e);
-            } catch (IOException e) {
-                log.debug(sm.getString("contextConfig.invalidSciHandlesTypes",
-                        className), e);
-            }
-        }
-    }
-
-    private void populateSCIsForCacheEntry(JavaClassCacheEntry cacheEntry) {
-        Set<ServletContainerInitializer> result = new HashSet<>();
-
-        // Super class
-        String superClassName = cacheEntry.getSuperclassName();
-        JavaClassCacheEntry superClassCacheEntry =
-                javaClassCache.get(superClassName);
-
-        // Avoid an infinite loop with java.lang.Object
-        if (cacheEntry.equals(superClassCacheEntry)) {
-            cacheEntry.setSciSet(EMPTY_SCI_SET);
-            return;
-        }
-
-        // May be null of the class is not present or could not be loaded.
-        if (superClassCacheEntry != null) {
-            if (superClassCacheEntry.getSciSet() == null) {
-                populateSCIsForCacheEntry(superClassCacheEntry);
-            }
-            result.addAll(superClassCacheEntry.getSciSet());
-        }
-        result.addAll(getSCIsForClass(superClassName));
-
-        // Interfaces
-        for (String interfaceName : cacheEntry.getInterfaceNames()) {
-            JavaClassCacheEntry interfaceEntry =
-                    javaClassCache.get(interfaceName);
-            // A null could mean that the class not present in application or
-            // that there is nothing of interest. Either way, nothing to do here
-            // so move along
-            if (interfaceEntry != null) {
-                if (interfaceEntry.getSciSet() == null) {
-                    populateSCIsForCacheEntry(interfaceEntry);
-                }
-                result.addAll(interfaceEntry.getSciSet());
-            }
-            result.addAll(getSCIsForClass(interfaceName));
-        }
-
-        cacheEntry.setSciSet(result.isEmpty() ? EMPTY_SCI_SET : result);
-    }
-
-    private Set<ServletContainerInitializer> getSCIsForClass(String className) {
-        for (Map.Entry<Class<?>, Set<ServletContainerInitializer>> entry :
-                typeInitializerMap.entrySet()) {
-            Class<?> clazz = entry.getKey();
-            if (!clazz.isAnnotation()) {
-                if (clazz.getName().equals(className)) {
-                    return entry.getValue();
-                }
-            }
-        }
-        return EMPTY_SCI_SET;
-    }
-
-    private static final String getClassName(String internalForm) {
-        if (!internalForm.startsWith("L")) {
-            return internalForm;
-        }
-
-        // Assume starts with L, ends with ; and uses / rather than .
-        return internalForm.substring(1,
-                internalForm.length() - 1).replace('/', '.');
-    }
-
-    protected void processAnnotationWebServlet(String className,
-            AnnotationEntry ae, WebXml fragment) {
-        String servletName = null;
-        // must search for name s. Spec Servlet API 3.0 - 8.2.3.3.n.ii page 81
-        List<ElementValuePair> evps = ae.getElementValuePairs();
-        for (ElementValuePair evp : evps) {
-            String name = evp.getNameString();
-            if ("name".equals(name)) {
-                servletName = evp.getValue().stringifyValue();
-                break;
-            }
-        }
-        if (servletName == null) {
-            // classname is default servletName as annotation has no name!
-            servletName = className;
-        }
-        ServletDef servletDef = fragment.getServlets().get(servletName);
-
-        boolean isWebXMLservletDef;
-        if (servletDef == null) {
-            servletDef = new ServletDef();
-            servletDef.setServletName(servletName);
-            servletDef.setServletClass(className);
-            isWebXMLservletDef = false;
-        } else {
-            isWebXMLservletDef = true;
-        }
-
-        boolean urlPatternsSet = false;
-        String[] urlPatterns = null;
-
-        // List<ElementValuePair> evps = ae.getElementValuePairs();
-        for (ElementValuePair evp : evps) {
-            String name = evp.getNameString();
-            if ("value".equals(name) || "urlPatterns".equals(name)) {
-                if (urlPatternsSet) {
-                    throw new IllegalArgumentException(sm.getString(
-                            "contextConfig.urlPatternValue", className));
-                }
-                urlPatternsSet = true;
-                urlPatterns = processAnnotationsStringArray(evp.getValue());
-            } else if ("description".equals(name)) {
-                if (servletDef.getDescription() == null) {
-                    servletDef.setDescription(evp.getValue().stringifyValue());
-                }
-            } else if ("displayName".equals(name)) {
-                if (servletDef.getDisplayName() == null) {
-                    servletDef.setDisplayName(evp.getValue().stringifyValue());
-                }
-            } else if ("largeIcon".equals(name)) {
-                if (servletDef.getLargeIcon() == null) {
-                    servletDef.setLargeIcon(evp.getValue().stringifyValue());
-                }
-            } else if ("smallIcon".equals(name)) {
-                if (servletDef.getSmallIcon() == null) {
-                    servletDef.setSmallIcon(evp.getValue().stringifyValue());
-                }
-            } else if ("asyncSupported".equals(name)) {
-                if (servletDef.getAsyncSupported() == null) {
-                    servletDef.setAsyncSupported(evp.getValue()
-                            .stringifyValue());
-                }
-            } else if ("loadOnStartup".equals(name)) {
-                if (servletDef.getLoadOnStartup() == null) {
-                    servletDef
-                            .setLoadOnStartup(evp.getValue().stringifyValue());
-                }
-            } else if ("initParams".equals(name)) {
-                Map<String, String> initParams = processAnnotationWebInitParams(evp
-                        .getValue());
-                if (isWebXMLservletDef) {
-                    Map<String, String> webXMLInitParams = servletDef
-                            .getParameterMap();
-                    for (Map.Entry<String, String> entry : initParams
-                            .entrySet()) {
-                        if (webXMLInitParams.get(entry.getKey()) == null) {
-                            servletDef.addInitParameter(entry.getKey(), entry
-                                    .getValue());
-                        }
-                    }
-                } else {
-                    for (Map.Entry<String, String> entry : initParams
-                            .entrySet()) {
-                        servletDef.addInitParameter(entry.getKey(), entry
-                                .getValue());
-                    }
-                }
-            }
-        }
-        if (!isWebXMLservletDef && urlPatterns != null) {
-            fragment.addServlet(servletDef);
-        }
-        if (urlPatterns != null) {
-            if (!fragment.getServletMappings().containsValue(servletName)) {
-                for (String urlPattern : urlPatterns) {
-                    fragment.addServletMapping(urlPattern, servletName);
-                }
-            }
-        }
-
-    }
-
-    /**
-     * process filter annotation and merge with existing one!
-     * FIXME: refactoring method too long and has redundant subroutines with
-     *        processAnnotationWebServlet!
-     * @param className
-     * @param ae
-     * @param fragment
-     */
-    protected void processAnnotationWebFilter(String className,
-            AnnotationEntry ae, WebXml fragment) {
-        String filterName = null;
-        // must search for name s. Spec Servlet API 3.0 - 8.2.3.3.n.ii page 81
-        List<ElementValuePair> evps = ae.getElementValuePairs();
-        for (ElementValuePair evp : evps) {
-            String name = evp.getNameString();
-            if ("filterName".equals(name)) {
-                filterName = evp.getValue().stringifyValue();
-                break;
-            }
-        }
-        if (filterName == null) {
-            // classname is default filterName as annotation has no name!
-            filterName = className;
-        }
-        FilterDef filterDef = fragment.getFilters().get(filterName);
-        FilterMap filterMap = new FilterMap();
-
-        boolean isWebXMLfilterDef;
-        if (filterDef == null) {
-            filterDef = new FilterDef();
-            filterDef.setFilterName(filterName);
-            filterDef.setFilterClass(className);
-            isWebXMLfilterDef = false;
-        } else {
-            isWebXMLfilterDef = true;
-        }
-
-        boolean urlPatternsSet = false;
-        boolean servletNamesSet = false;
-        boolean dispatchTypesSet = false;
-        String[] urlPatterns = null;
-
-        for (ElementValuePair evp : evps) {
-            String name = evp.getNameString();
-            if ("value".equals(name) || "urlPatterns".equals(name)) {
-                if (urlPatternsSet) {
-                    throw new IllegalArgumentException(sm.getString(
-                            "contextConfig.urlPatternValue", className));
-                }
-                urlPatterns = processAnnotationsStringArray(evp.getValue());
-                urlPatternsSet = urlPatterns.length > 0;
-                for (String urlPattern : urlPatterns) {
-                    filterMap.addURLPattern(urlPattern);
-                }
-            } else if ("servletNames".equals(name)) {
-                String[] servletNames = processAnnotationsStringArray(evp
-                        .getValue());
-                servletNamesSet = servletNames.length > 0;
-                for (String servletName : servletNames) {
-                    filterMap.addServletName(servletName);
-                }
-            } else if ("dispatcherTypes".equals(name)) {
-                String[] dispatcherTypes = processAnnotationsStringArray(evp
-                        .getValue());
-                dispatchTypesSet = dispatcherTypes.length > 0;
-                for (String dispatcherType : dispatcherTypes) {
-                    filterMap.setDispatcher(dispatcherType);
-                }
-            } else if ("description".equals(name)) {
-                if (filterDef.getDescription() == null) {
-                    filterDef.setDescription(evp.getValue().stringifyValue());
-                }
-            } else if ("displayName".equals(name)) {
-                if (filterDef.getDisplayName() == null) {
-                    filterDef.setDisplayName(evp.getValue().stringifyValue());
-                }
-            } else if ("largeIcon".equals(name)) {
-                if (filterDef.getLargeIcon() == null) {
-                    filterDef.setLargeIcon(evp.getValue().stringifyValue());
-                }
-            } else if ("smallIcon".equals(name)) {
-                if (filterDef.getSmallIcon() == null) {
-                    filterDef.setSmallIcon(evp.getValue().stringifyValue());
-                }
-            } else if ("asyncSupported".equals(name)) {
-                if (filterDef.getAsyncSupported() == null) {
-                    filterDef
-                            .setAsyncSupported(evp.getValue().stringifyValue());
-                }
-            } else if ("initParams".equals(name)) {
-                Map<String, String> initParams = processAnnotationWebInitParams(evp
-                        .getValue());
-                if (isWebXMLfilterDef) {
-                    Map<String, String> webXMLInitParams = filterDef
-                            .getParameterMap();
-                    for (Map.Entry<String, String> entry : initParams
-                            .entrySet()) {
-                        if (webXMLInitParams.get(entry.getKey()) == null) {
-                            filterDef.addInitParameter(entry.getKey(), entry
-                                    .getValue());
-                        }
-                    }
-                } else {
-                    for (Map.Entry<String, String> entry : initParams
-                            .entrySet()) {
-                        filterDef.addInitParameter(entry.getKey(), entry
-                                .getValue());
-                    }
-                }
-
-            }
-        }
-        if (!isWebXMLfilterDef) {
-            fragment.addFilter(filterDef);
-            if (urlPatternsSet || servletNamesSet) {
-                filterMap.setFilterName(filterName);
-                fragment.addFilterMapping(filterMap);
-            }
-        }
-        if (urlPatternsSet || dispatchTypesSet) {
-            Set<FilterMap> fmap = fragment.getFilterMappings();
-            FilterMap descMap = null;
-            for (FilterMap map : fmap) {
-                if (filterName.equals(map.getFilterName())) {
-                    descMap = map;
-                    break;
-                }
-            }
-            if (descMap != null) {
-                String[] urlsPatterns = descMap.getURLPatterns();
-                if (urlPatternsSet
-                        && (urlsPatterns == null || urlsPatterns.length == 0)) {
-                    for (String urlPattern : filterMap.getURLPatterns()) {
-                        descMap.addURLPattern(urlPattern);
-                    }
-                }
-                String[] dispatcherNames = descMap.getDispatcherNames();
-                if (dispatchTypesSet
-                        && (dispatcherNames == null || dispatcherNames.length == 0)) {
-                    for (String dis : filterMap.getDispatcherNames()) {
-                        descMap.setDispatcher(dis);
-                    }
-                }
-            }
-        }
-
-    }
-
-    protected String[] processAnnotationsStringArray(ElementValue ev) {
-        ArrayList<String> values = new ArrayList<>();
-        if (ev instanceof ArrayElementValue) {
-            ElementValue[] arrayValues =
-                ((ArrayElementValue) ev).getElementValuesArray();
-            for (ElementValue value : arrayValues) {
-                values.add(value.stringifyValue());
-            }
-        } else {
-            values.add(ev.stringifyValue());
-        }
-        String[] result = new String[values.size()];
-        return values.toArray(result);
-    }
-
-    protected Map<String,String> processAnnotationWebInitParams(
-            ElementValue ev) {
-        Map<String, String> result = new HashMap<>();
-        if (ev instanceof ArrayElementValue) {
-            ElementValue[] arrayValues =
-                ((ArrayElementValue) ev).getElementValuesArray();
-            for (ElementValue value : arrayValues) {
-                if (value instanceof AnnotationElementValue) {
-                    List<ElementValuePair> evps = ((AnnotationElementValue) value)
-                            .getAnnotationEntry().getElementValuePairs();
-                    String initParamName = null;
-                    String initParamValue = null;
-                    for (ElementValuePair evp : evps) {
-                        if ("name".equals(evp.getNameString())) {
-                            initParamName = evp.getValue().stringifyValue();
-                        } else if ("value".equals(evp.getNameString())) {
-                            initParamValue = evp.getValue().stringifyValue();
-                        } else {
-                            // Ignore
-                        }
-                    }
-                    result.put(initParamName, initParamValue);
-                }
-            }
-        }
-        return result;
     }
 
     private static class DefaultWebXmlCacheEntry {
@@ -2589,7 +1952,7 @@ public class ContextConfig implements LifecycleListener {
         }
     }
 
-    private static class JavaClassCacheEntry {
+    protected static class JavaClassCacheEntry {
         public final String superclassName;
 
         public final String[] interfaceNames;


### PR DESCRIPTION
During tomcat startup, it takes most of time on annotation scanning.
For our case, our apps have over 500 jars in class path.
Tomcat startup takes 28 seconds and annotation scanning takes 23 seconds.

So idea is: scan jars in parallel, per our benchmark testing, it could save 9 seconds. And jetty9 already support this feature.

Per Mark Thomas comments:
New features are first added to trunk and then back-ported.

So file another PR for trunk.
