### PR TITLE
Fixed UnsupportedOperationException when releasing an user-provided URLStreamHandlerFactory

### DIFF
--- a/java/org/apache/catalina/webresources/TomcatURLStreamHandlerFactory.java
+++ b/java/org/apache/catalina/webresources/TomcatURLStreamHandlerFactory.java
@@ -102,10 +102,11 @@ public class TomcatURLStreamHandlerFactory implements URLStreamHandlerFactory {
     public static void release(ClassLoader classLoader) {
         Iterator<URLStreamHandlerFactory> iter = instance.userFactories.iterator();
         while (iter.hasNext()) {
-            ClassLoader factoryLoader = iter.next().getClass().getClassLoader();
+            URLStreamHandlerFactory candidate = iter.next();
+            ClassLoader factoryLoader = candidate.getClass().getClassLoader();
             while (factoryLoader != null) {
                 if (classLoader.equals(factoryLoader)) {
-                    iter.remove();
+                    instance.userFactories.remove(candidate); 
                     break;
                 }
                 factoryLoader = factoryLoader.getParent();

--- a/test/org/apache/catalina/webresources/TestTomcatURLStreamHandlerFactory.java
+++ b/test/org/apache/catalina/webresources/TestTomcatURLStreamHandlerFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.catalina.webresources;
+
+import java.net.URLStreamHandler;
+import java.net.URLStreamHandlerFactory;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestTomcatURLStreamHandlerFactory {
+
+    @Before
+    public void register() {
+        TomcatURLStreamHandlerFactory.register();
+    }
+
+
+    @Test
+    public void testUserFactory() throws Exception {
+        URLStreamHandlerFactory factory = new URLStreamHandlerFactory() {
+            @Override
+            public URLStreamHandler createURLStreamHandler(String protocol) {
+                return null;
+            }
+        };
+        TomcatURLStreamHandlerFactory.getInstance().addUserFactory(factory);
+        TomcatURLStreamHandlerFactory.release(factory.getClass().getClassLoader());
+    }
+}


### PR DESCRIPTION
CopyOnWriterArrayList iterator remove operation was invoked when
de-registering a user-provided URLStreamHandlerFactory.

I also added a test case for that.