### PR TITLE
Change response character encoding

### DIFF
--- a/java/org/apache/catalina/filters/AddDefaultCharsetFilter.java
+++ b/java/org/apache/catalina/filters/AddDefaultCharsetFilter.java
@@ -80,9 +80,10 @@ public class AddDefaultCharsetFilter extends FilterBase {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response,
             FilterChain chain) throws IOException, ServletException {
-
+        
         // Wrap the response
         if (response instanceof HttpServletResponse) {
+            response.setCharacterEncoding(encoding);
             ResponseWrapper wrapped =
                 new ResponseWrapper((HttpServletResponse)response, encoding);
             chain.doFilter(request, wrapped);


### PR DESCRIPTION
It seems that encoding was forgotten to be changed in function doFilter().

When I set AddDefaultCharsetFilter in web.xml, like the following:
```xml
<filter>
  <filter-name>addDefaultCharsetFilter</filter-name>
  <filter-class>org.apache.catalina.filters.AddDefaultCharsetFilter</filter-class>
  <init-param>
    <param-name>encoding</param-name>
    <param-value>utf-8</param-value>
  </init-param>
  <async-supported>true</async-supported>
</filter>
<filter-mapping>
  <filter-name>addDefaultCharsetFilter</filter-name>
  <url-pattern>/*</url-pattern>
</filter-mapping>
```
response encoding is still ISO-8859-1