### PR TITLE
Clear up confusion about mbeans-descriptors.xml in docs; fix a type i…

### DIFF
--- a/java/org/apache/catalina/core/mbeans-descriptors.xml
+++ b/java/org/apache/catalina/core/mbeans-descriptors.xml
@@ -34,7 +34,7 @@
                 writeable="false"/>
 
      <attribute name="filterInitParameterMap"
-                description="Return the initiaization parameters associated with this filter"
+                description="Return the initialization parameters associated with this filter"
                 type="java.util.Map"
                 writeable="false" />
 

--- a/webapps/docs/index.xml
+++ b/webapps/docs/index.xml
@@ -101,7 +101,7 @@ Apache Tomcat, and using many of the Apache Tomcat features.</p>
 <li><a href="proxy-howto.html"><strong>Proxy Support</strong></a> -
     Configuring Apache Tomcat to run behind a proxy server (or a web server
     functioning as a proxy server).</li>
-<li><a href="mbeans-descriptor-howto.html"><strong>MBean Descriptor</strong></a> -
+<li><a href="mbeans-descriptors-howto.html"><strong>MBean Descriptors</strong></a> -
     Configuring MBean descriptors files for custom components.</li>
 <li><a href="default-servlet.html"><strong>Default Servlet</strong></a> -
     Configuring the default servlet and customizing directory listings.</li>

--- a/webapps/docs/mbeans-descriptors-howto.xml
+++ b/webapps/docs/mbeans-descriptors-howto.xml
@@ -18,13 +18,13 @@
 <!DOCTYPE document [
   <!ENTITY project SYSTEM "project.xml">
 ]>
-<document url="mbeans-descriptor-howto.html">
+<document url="mbeans-descriptors-howto.html">
 
     &project;
 
     <properties>
         <author email="amyroh@apache.org">Amy Roh</author>
-        <title>MBean Descriptor How To</title>
+        <title>MBeans Descriptors How To</title>
     </properties>
 
 <body>
@@ -38,7 +38,7 @@
 <p>Tomcat uses JMX MBeans as the technology for implementing
 manageability of Tomcat.</p>
 
-<p>The descriptions of JMX MBeans for Catalina are in the mbeans-descriptor.xml
+<p>The descriptions of JMX MBeans for Catalina are in the mbeans-descriptors.xml
 file in each package.</p>
 
 <p>You will need to add MBean descriptions for your custom components
@@ -49,7 +49,7 @@ in order to avoid a "ManagedBean is not found" exception.</p>
 <section name="Adding MBean descriptions">
 
 <p>You may also add MBean descriptions for custom components in
-a mbeans-descriptor.xml file, located in the same package as the class files
+a mbeans-descriptors.xml file, located in the same package as the class files
 it describes.</p>
 
 <source><![CDATA[  <mbean         name="LDAPRealm"

--- a/webapps/docs/project.xml
+++ b/webapps/docs/project.xml
@@ -52,7 +52,7 @@
         <item name="14) CGI"                href="cgi-howto.html"/>
         <item name="15) Proxy Support"      href="proxy-howto.html"/>
         <item name="16) MBean Descriptor"
-              href="mbeans-descriptor-howto.html"/>
+              href="mbeans-descriptors-howto.html"/>
         <item name="17) Default Servlet"    href="default-servlet.html"/>
         <item name="18) Clustering"         href="cluster-howto.html"/>
         <item name="19) Load Balancer"      href="balancer-howto.html"/>

--- a/webapps/docs/realm-howto.xml
+++ b/webapps/docs/realm-howto.xml
@@ -109,7 +109,7 @@ and integrate it with Tomcat.  To do so, you need to:</p>
   <li>Implement <code>org.apache.catalina.Realm</code>,</li>
   <li>Place your compiled realm in $CATALINA_HOME/lib,</li>
   <li>Declare your realm as described in the "Configuring a Realm" section below,</li>
-  <li>Declare your realm to the <a href="mbeans-descriptor-howto.html">MBeans Descriptor</a>.</li>
+  <li>Declare your realm to the <a href="mbeans-descriptors-howto.html">MBeans Descriptors</a>.</li>
 </ul>
 
 </subsection>


### PR DESCRIPTION
…n core descriptor

Lets make sure its everywhere called "mbeans-descriptors" otherwise one missing "s" can cost developers quite a while debugging what is wrong.