### PR TITLE
fixed retrieval org.apache.catalina.startup.EXIT_ON_INIT_FAILURE

### DIFF
--- a/java/org/apache/catalina/startup/Catalina.java
+++ b/java/org/apache/catalina/startup/Catalina.java
@@ -605,7 +605,7 @@ public class Catalina {
         try {
             getServer().init();
         } catch (LifecycleException e) {
-            if (Boolean.getBoolean("org.apache.catalina.startup.EXIT_ON_INIT_FAILURE")) {
+            if (Boolean.getBoolean(System.getProperty("org.apache.catalina.startup.EXIT_ON_INIT_FAILURE"))) {
                 throw new java.lang.Error(e);
             } else {
                 log.error("Catalina.start", e);


### PR DESCRIPTION
  This property was incorrectly tried to be retrieved: it converted the
  proprety name directly into boolean instead of its value from System
  properties.