### PR TITLE
spelling: deprecate misspelled protected functions

### DIFF
--- a/java/org/apache/catalina/storeconfig/ConnectorStoreAppender.java
+++ b/java/org/apache/catalina/storeconfig/ConnectorStoreAppender.java
@@ -208,11 +208,28 @@ public class ConnectorStoreAppender extends StoreAppender {
      * @param aDesc The connector description
      * @throws Exception Store error occurred
      */
-    protected void storeConnectorAttribtues(PrintWriter aWriter, int indent,
+    protected void storeConnectorAttributes(PrintWriter aWriter, int indent,
             Object bean, StoreDescription aDesc) throws Exception {
         if (aDesc.isAttributes()) {
             printAttributes(aWriter, indent, false, bean, aDesc);
         }
+    }
+
+    /**
+     * Print Attributes for the connector
+     *
+     * @param aWriter Current writer
+     * @param indent Indentation level
+     * @param bean The connector bean
+     * @param aDesc The connector description
+     * @throws Exception Store error occurred
+     *
+     * @deprecated  Use {@link #storeConnectorAttribtues()}
+     */
+    @Deprecated
+    protected void storeConnectorAttribtues(PrintWriter aWriter, int indent,
+            Object bean, StoreDescription aDesc) throws Exception {
+        storeConnectorAttributes(aWriter, indent, bean, aDesc);
     }
 
     /**
@@ -227,7 +244,7 @@ public class ConnectorStoreAppender extends StoreAppender {
             StoreDescription aDesc) throws Exception {
         aWriter.print("<");
         aWriter.print(aDesc.getTag());
-        storeConnectorAttribtues(aWriter, indent, bean, aDesc);
+        storeConnectorAttributes(aWriter, indent, bean, aDesc);
         aWriter.println(">");
     }
 
@@ -243,7 +260,7 @@ public class ConnectorStoreAppender extends StoreAppender {
             StoreDescription aDesc) throws Exception {
         aWriter.print("<");
         aWriter.print(aDesc.getTag());
-        storeConnectorAttribtues(aWriter, indent, bean, aDesc);
+        storeConnectorAttributes(aWriter, indent, bean, aDesc);
         aWriter.println("/>");
     }
 

--- a/java/org/apache/coyote/http11/AbstractHttp11JsseProtocol.java
+++ b/java/org/apache/coyote/http11/AbstractHttp11JsseProtocol.java
@@ -34,11 +34,19 @@ public abstract class AbstractHttp11JsseProtocol<S>
     }
 
 
-    protected String getSslImplemenationShortName() {
+    protected String getSslImplementationShortName() {
         if (OpenSSLImplementation.class.getName().equals(getSslImplementationName())) {
             return "openssl";
         }
         return "jsse";
+    }
+
+    /*
+     * @deprecated  Use {@link #getSslImplementationShortName()}
+     */
+    @Deprecated
+    protected String getSslImplemenationShortName() {
+        return getSslImplementationShortName();
     }
 
     public String getSslImplementationName() { return getEndpoint().getSslImplementationName(); }

--- a/java/org/apache/coyote/http11/Http11Nio2Protocol.java
+++ b/java/org/apache/coyote/http11/Http11Nio2Protocol.java
@@ -44,7 +44,7 @@ public class Http11Nio2Protocol extends AbstractHttp11JsseProtocol<Nio2Channel> 
     @Override
     protected String getNamePrefix() {
         if (isSSLEnabled()) {
-            return ("https-" + getSslImplemenationShortName()+ "-nio2");
+            return ("https-" + getSslImplementationShortName()+ "-nio2");
         } else {
             return ("http-nio2");
         }

--- a/java/org/apache/coyote/http11/Http11NioProtocol.java
+++ b/java/org/apache/coyote/http11/Http11NioProtocol.java
@@ -76,7 +76,7 @@ public class Http11NioProtocol extends AbstractHttp11JsseProtocol<NioChannel> {
     @Override
     protected String getNamePrefix() {
         if (isSSLEnabled()) {
-            return ("https-" + getSslImplemenationShortName()+ "-nio");
+            return ("https-" + getSslImplementationShortName()+ "-nio");
         } else {
             return ("http-nio");
         }


### PR DESCRIPTION
I think this does what @markt-asf suggested