### PR TITLE
Corrected addWebapp default web xml listener reference

### DIFF
--- a/java/org/apache/catalina/startup/Tomcat.java
+++ b/java/org/apache/catalina/startup/Tomcat.java
@@ -593,7 +593,7 @@ public class Tomcat {
         Context ctx = createContext(host, contextPath);
         ctx.setPath(contextPath);
         ctx.setDocBase(docBase);
-        ctx.addLifecycleListener(new DefaultWebXmlListener());
+        ctx.addLifecycleListener(getDefaultWebXmlListener());
         ctx.setConfigFile(getWebappConfigFile(docBase, contextPath));
 
         ctx.addLifecycleListener(config);


### PR DESCRIPTION
I am trying to subclass Tomcat as documented to define the default web xml settings for a packaged WAR application without JSP support but this direct instantiation is blocking my attempt. 