### PR TITLE
Fix http parser

### DIFF
--- a/java/org/apache/tomcat/util/http/parser/HttpParser.java
+++ b/java/org/apache/tomcat/util/http/parser/HttpParser.java
@@ -566,7 +566,6 @@ public class HttpParser {
                     // Start of a new h16 block
                     precedingColonsCount = 0;
                     h16Count++;
-                    reader.mark(4);
                 }
                 h16Size++;
                 if (h16Size > 4) {
@@ -588,6 +587,8 @@ public class HttpParser {
                         h16Count++;
                     }
                     precedingColonsCount++;
+                    // mark if the next symbol is hex before the actual read
+                    reader.mark(4); 
                 } 
                 h16Size = 0;
             } else if (c == ']') {
@@ -595,6 +596,7 @@ public class HttpParser {
                     // Can't end on a single ':'
                     throw new IllegalArgumentException();
                 }
+                pos++;
                 break;
             } else if (c == '.') {
                 if (h16Count == 7 || h16Count < 7 && parsedDoubleColon) {
@@ -620,7 +622,7 @@ public class HttpParser {
 
         c = reader.read();
         if (c == ':') {
-            return pos + 1;
+            return pos;
         } else {
             if(c == -1) {
                 return -1;

--- a/java/org/apache/tomcat/util/http/parser/HttpParser.java
+++ b/java/org/apache/tomcat/util/http/parser/HttpParser.java
@@ -619,7 +619,10 @@ public class HttpParser {
         if (c == ':') {
             return pos + 1;
         } else {
-            return -1;
+            if(c == -1) {
+                return -1;
+            }
+            throw new IllegalArgumentException();
         }
     }
 

--- a/test/org/apache/tomcat/util/http/parser/TestHttpParserHost.java
+++ b/test/org/apache/tomcat/util/http/parser/TestHttpParserHost.java
@@ -136,6 +136,7 @@ public class TestHttpParserHost {
         result.add(new Object[] { TestType.IPv6, "[0::0::127.0.0.1]", Integer.valueOf(-1), IAE} );
         result.add(new Object[] { TestType.IPv6, "[0:0:G:0:0:0:127.0.0.1]", Integer.valueOf(-1), IAE} );
         result.add(new Object[] { TestType.IPv6, "[00000:0:0:0:0:0:127.0.0.1]", Integer.valueOf(-1), IAE} );
+        result.add(new Object[] { TestType.IPv6, "[::1]'", Integer.valueOf(-1), IAE} );
         return result;
     }
 

--- a/test/org/apache/tomcat/util/http/parser/TestHttpParserHost.java
+++ b/test/org/apache/tomcat/util/http/parser/TestHttpParserHost.java
@@ -137,6 +137,10 @@ public class TestHttpParserHost {
         result.add(new Object[] { TestType.IPv6, "[0:0:G:0:0:0:127.0.0.1]", Integer.valueOf(-1), IAE} );
         result.add(new Object[] { TestType.IPv6, "[00000:0:0:0:0:0:127.0.0.1]", Integer.valueOf(-1), IAE} );
         result.add(new Object[] { TestType.IPv6, "[::1]'", Integer.valueOf(-1), IAE} );
+        result.add(new Object[] { TestType.IPv6, "[:2222:3333:4444:5555:6666:7777:8888]",
+                Integer.valueOf(-1), IAE} );
+        result.add(new Object[] { TestType.IPv6, "[1111:::3333:4444:5555:6666:7777:8888]",
+                Integer.valueOf(-1), IAE} );
         return result;
     }
 

--- a/test/org/apache/tomcat/util/http/parser/TestHttpParserHost.java
+++ b/test/org/apache/tomcat/util/http/parser/TestHttpParserHost.java
@@ -179,6 +179,7 @@ public class TestHttpParserHost {
         if (expectedException == null) {
             Assert.assertNull(input, exceptionClass);
         } else {
+            Assert.assertNotNull(exceptionClass);
             Assert.assertTrue(input, expectedException.isAssignableFrom(exceptionClass));
         }
     }

--- a/test/org/apache/tomcat/util/http/parser/TestHttpParserHost.java
+++ b/test/org/apache/tomcat/util/http/parser/TestHttpParserHost.java
@@ -121,6 +121,7 @@ public class TestHttpParserHost {
         result.add(new Object[] { TestType.IPv6, "[0:0:0:0:0:0:127.0.0.1]", Integer.valueOf(-1), null} );
         result.add(new Object[] { TestType.IPv6, "[0:0:0:0:0:0:127.0.0.1]:8080",
                 Integer.valueOf(23), null} );
+        result.add(new Object[] { TestType.IPv6, "[::1.2.3.4]", Integer.valueOf(-1), null} );
         // IPv6 - invalid
         result.add(new Object[] { TestType.IPv6, "[1234:5678:90AB:CDEF:1234:127.0.0.1]",
                 Integer.valueOf(-1), IAE} );

--- a/test/org/apache/tomcat/util/http/parser/TestHttpParserHost.java
+++ b/test/org/apache/tomcat/util/http/parser/TestHttpParserHost.java
@@ -66,6 +66,7 @@ public class TestHttpParserHost {
         result.add(new Object[] { TestType.IPv4, "0.0.0.256", Integer.valueOf(-1), IAE} );
         result.add(new Object[] { TestType.IPv4, "0.a.0.0", Integer.valueOf(-1), IAE} );
         result.add(new Object[] { TestType.IPv4, "0..0.0", Integer.valueOf(-1), IAE} );
+        result.add(new Object[] { TestType.IPv4, "0]", Integer.valueOf(-1), IAE} );
         // Domain Name - valid
         result.add(new Object[] { TestType.DOMAIN_NAME, "localhost", Integer.valueOf(-1), null} );
         result.add(new Object[] { TestType.DOMAIN_NAME, "localhost:8080", Integer.valueOf(9), null} );
@@ -142,6 +143,13 @@ public class TestHttpParserHost {
                 Integer.valueOf(-1), IAE} );
         result.add(new Object[] { TestType.IPv6, "[1111:::3333:4444:5555:6666:7777:8888]",
                 Integer.valueOf(-1), IAE} );
+        result.add(new Object[] { TestType.IPv6, "::1]", Integer.valueOf(-1), IAE} );
+        result.add(new Object[] { TestType.IPv6, "[1111:2222:3333:4444:5555:6666:7777:8888:9999]",
+                Integer.valueOf(-1), IAE} );
+        result.add(new Object[] { TestType.IPv6, "[1111:2222:3333:4444:5555:6666:7777:1.2.3.4]",
+            Integer.valueOf(-1), IAE} );
+        result.add(new Object[] { TestType.IPv6, "[1111:2222:3333]",
+            Integer.valueOf(-1), IAE} );
         return result;
     }
 


### PR DESCRIPTION
Fix IPv6/IPv4 parsing for host header:
- chars other than : should not be allowed in IPv6 address after ]
- ::: should not present in IPv6 address
- IPv4 part of IPv6 address was not correctly parsed (1 symbol of IPv4 part was ignored)
- tests added to cover IPv4/6 parsing 
- parsed test class fixed not to throw NPE when an exception is expected but not thrown 