### PR TITLE
Fix parser to fail if leading zeros in IPv4 part of IPv6 address

### DIFF
--- a/java/org/apache/tomcat/util/http/parser/HttpParser.java
+++ b/java/org/apache/tomcat/util/http/parser/HttpParser.java
@@ -488,6 +488,7 @@ public class HttpParser {
         int octectCount = 1;
         int c;
         int pos = 0;
+        boolean octectLeadingZero = false;
 
         do {
             c = reader.read();
@@ -496,13 +497,20 @@ public class HttpParser {
                     // Valid
                     octectCount++;
                     octect = -1;
+                    octectLeadingZero = false;
                 } else {
                     throw new IllegalArgumentException();
                 }
             } else if (isNumeric(c)) {
                 if (octect == -1) {
                     octect = c - '0';
+                    if(c == '0') {
+                        octectLeadingZero = true;
+                    }
                 } else {
+                    if(octectLeadingZero && inIPv6) {
+                        throw new IllegalArgumentException();
+                    }
                     octect = octect * 10 + c - '0';
                 }
             } else if (c == ':') {

--- a/test/org/apache/tomcat/util/http/parser/TestHttpParserHost.java
+++ b/test/org/apache/tomcat/util/http/parser/TestHttpParserHost.java
@@ -54,6 +54,7 @@ public class TestHttpParserHost {
         result.add(new Object[] { TestType.IPv4, "127.0.0.1:8080", Integer.valueOf(9), null} );
         result.add(new Object[] { TestType.IPv4, "0.0.0.0", Integer.valueOf(-1), null} );
         result.add(new Object[] { TestType.IPv4, "0.0.0.0:8080", Integer.valueOf(7), null} );
+        result.add(new Object[] { TestType.IPv4, "01.02.03.04", Integer.valueOf(-1), null} );
         // IPv4 - invalid
         result.add(new Object[] { TestType.IPv4, "0", Integer.valueOf(-1), IAE} );
         result.add(new Object[] { TestType.IPv4, "0.0", Integer.valueOf(-1), IAE} );
@@ -136,6 +137,7 @@ public class TestHttpParserHost {
         result.add(new Object[] { TestType.IPv6, "[0::0::127.0.0.1]", Integer.valueOf(-1), IAE} );
         result.add(new Object[] { TestType.IPv6, "[0:0:G:0:0:0:127.0.0.1]", Integer.valueOf(-1), IAE} );
         result.add(new Object[] { TestType.IPv6, "[00000:0:0:0:0:0:127.0.0.1]", Integer.valueOf(-1), IAE} );
+        result.add(new Object[] { TestType.IPv6, "[a::01.02.03.04]", Integer.valueOf(-1), IAE} );
         return result;
     }
 


### PR DESCRIPTION
Leading zeros are not causing failure if in IPv4 addresses though.