### PR TITLE
Convert Cluster Manager human-readable channelSendOptions names to integer [61127/8]

### DIFF
--- a/java/org/apache/catalina/ha/session/BackupManager.java
+++ b/java/org/apache/catalina/ha/session/BackupManager.java
@@ -212,6 +212,14 @@ public class BackupManager extends ClusterManagerBase
         return mapSendOptions;
     }
 
+    /**
+     * returns the SendOptions as a comma separated list of names
+     * @return
+     */
+    public String getMapSendOptionsName(){
+        return Channel.getSendOptionsAsString(mapSendOptions);
+    }
+
     public void setRpcTimeout(long rpcTimeout) {
         this.rpcTimeout = rpcTimeout;
     }

--- a/java/org/apache/catalina/ha/session/BackupManager.java
+++ b/java/org/apache/catalina/ha/session/BackupManager.java
@@ -202,7 +202,7 @@ public class BackupManager extends ClusterManagerBase
 
     public void setMapSendOptions(String mapSendOptions) {
 
-        int value = Channel.parseChannelSendOptions(mapSendOptions);
+        int value = Channel.parseSendOptions(mapSendOptions);
         if (value > 0) {
             this.setMapSendOptions(value);
         }

--- a/java/org/apache/catalina/ha/session/BackupManager.java
+++ b/java/org/apache/catalina/ha/session/BackupManager.java
@@ -214,7 +214,7 @@ public class BackupManager extends ClusterManagerBase
 
     /**
      * returns the SendOptions as a comma separated list of names
-     * @return
+     * @return a comma separated list of the option names
      */
     public String getMapSendOptionsName(){
         return Channel.getSendOptionsAsString(mapSendOptions);

--- a/java/org/apache/catalina/ha/session/BackupManager.java
+++ b/java/org/apache/catalina/ha/session/BackupManager.java
@@ -200,6 +200,14 @@ public class BackupManager extends ClusterManagerBase
         this.mapSendOptions = mapSendOptions;
     }
 
+    public void setMapSendOptions(String mapSendOptions) {
+
+        int value = Channel.parseChannelSendOptions(mapSendOptions);
+        if (value > 0) {
+            this.setMapSendOptions(value);
+        }
+    }
+
     public int getMapSendOptions() {
         return mapSendOptions;
     }

--- a/java/org/apache/catalina/ha/session/mbeans-descriptors.xml
+++ b/java/org/apache/catalina/ha/session/mbeans-descriptors.xml
@@ -454,6 +454,11 @@
       type="int"
       writeable="false"/>
     <attribute
+      name="mapSendOptionsName"
+      description="mapSendOptions name."
+      writeable="false"
+      type="java.lang.String"/>
+    <attribute
       name="maxActive"
       description="Maximum number of active sessions so far"
       type="int"/>

--- a/java/org/apache/catalina/ha/tcp/SimpleTcpCluster.java
+++ b/java/org/apache/catalina/ha/tcp/SimpleTcpCluster.java
@@ -400,6 +400,14 @@ public class SimpleTcpCluster extends LifecycleMBeanBase
     }
 
     /**
+     * returns the SendOptions as a comma separated list of names for use by JMX
+     * @return
+     */
+    public String getChannelSendOptionsName(){
+        return Channel.getSendOptionsAsString(channelSendOptions);
+    }
+
+    /**
      * Create new Manager without add to cluster (comes with start the manager)
      *
      * @param name

--- a/java/org/apache/catalina/ha/tcp/SimpleTcpCluster.java
+++ b/java/org/apache/catalina/ha/tcp/SimpleTcpCluster.java
@@ -401,7 +401,7 @@ public class SimpleTcpCluster extends LifecycleMBeanBase
 
     /**
      * returns the SendOptions as a comma separated list of names for use by JMX
-     * @return
+     * @return a comma separated list of the option names
      */
     public String getChannelSendOptionsName(){
         return Channel.getSendOptionsAsString(channelSendOptions);

--- a/java/org/apache/catalina/ha/tcp/SimpleTcpCluster.java
+++ b/java/org/apache/catalina/ha/tcp/SimpleTcpCluster.java
@@ -339,6 +339,13 @@ public class SimpleTcpCluster extends LifecycleMBeanBase
         this.channelSendOptions = channelSendOptions;
     }
 
+    public void setChannelSendOptions(String channelSendOptions) {
+
+        int value = Channel.parseChannelSendOptions(channelSendOptions);
+        if (value > 0)
+            this.setChannelSendOptions(value);
+    }
+
     /**
      * has members
      */

--- a/java/org/apache/catalina/ha/tcp/SimpleTcpCluster.java
+++ b/java/org/apache/catalina/ha/tcp/SimpleTcpCluster.java
@@ -341,7 +341,7 @@ public class SimpleTcpCluster extends LifecycleMBeanBase
 
     public void setChannelSendOptions(String channelSendOptions) {
 
-        int value = Channel.parseChannelSendOptions(channelSendOptions);
+        int value = Channel.parseSendOptions(channelSendOptions);
         if (value > 0) {
             this.setChannelSendOptions(value);
         }

--- a/java/org/apache/catalina/ha/tcp/SimpleTcpCluster.java
+++ b/java/org/apache/catalina/ha/tcp/SimpleTcpCluster.java
@@ -342,8 +342,9 @@ public class SimpleTcpCluster extends LifecycleMBeanBase
     public void setChannelSendOptions(String channelSendOptions) {
 
         int value = Channel.parseChannelSendOptions(channelSendOptions);
-        if (value > 0)
+        if (value > 0) {
             this.setChannelSendOptions(value);
+        }
     }
 
     /**

--- a/java/org/apache/catalina/ha/tcp/mbeans-descriptors.xml
+++ b/java/org/apache/catalina/ha/tcp/mbeans-descriptors.xml
@@ -28,7 +28,7 @@
     <attribute
       name="channelSendOptions"
       description="This sets channel behaviour on sent messages."
-      type="int"/>
+      type="java.lang.String"/>
     <attribute
       name="channelStartOptions"
       description="This sets channel start behaviour."

--- a/java/org/apache/catalina/ha/tcp/mbeans-descriptors.xml
+++ b/java/org/apache/catalina/ha/tcp/mbeans-descriptors.xml
@@ -30,6 +30,11 @@
       description="This sets channel behaviour on sent messages."
       type="java.lang.String"/>
     <attribute
+      name="channelSendOptionsName"
+      description="channelStartOptions name."
+      writeable="false"
+      type="java.lang.String"/>
+    <attribute
       name="channelStartOptions"
       description="This sets channel start behaviour."
       type="java.lang.String"/>

--- a/java/org/apache/catalina/ha/tcp/mbeans-descriptors.xml
+++ b/java/org/apache/catalina/ha/tcp/mbeans-descriptors.xml
@@ -31,7 +31,7 @@
       type="java.lang.String"/>
     <attribute
       name="channelSendOptionsName"
-      description="channelStartOptions name."
+      description="channelSendOptions name."
       writeable="false"
       type="java.lang.String"/>
     <attribute

--- a/java/org/apache/catalina/tribes/Channel.java
+++ b/java/org/apache/catalina/tribes/Channel.java
@@ -369,4 +369,52 @@ public interface Channel {
      */
     public void setName(String name);
 
+    /**
+     * Translates the name of an option to its integer value
+     * @param opt The name of the option
+     * @return
+     */
+    public static int getOptionValue(String opt){
+
+        if ("asynchronous".equals(opt) || "async".equals(opt))
+            return SEND_OPTIONS_ASYNCHRONOUS;
+
+        if ("byte_message".equals(opt) || "byte".equals(opt))
+            return SEND_OPTIONS_BYTE_MESSAGE;
+
+        if ("multicast".equals(opt))
+            return SEND_OPTIONS_MULTICAST;
+
+        if ("secure".equals(opt))
+            return SEND_OPTIONS_SECURE;
+
+        if ("synchronized_ack".equals(opt) || "sync".equals(opt))
+            return SEND_OPTIONS_SYNCHRONIZED_ACK;
+
+        if ("udp".equals(opt))
+            return SEND_OPTIONS_UDP;
+
+        if ("use_ack".equals(opt))
+            return SEND_OPTIONS_USE_ACK;
+
+        return 0;
+    }
+
+    /**
+     * Translates a comma separated list of option names to their bitwise-ORd value
+     * @param input A comma separated list of options, e.g. "async,multicast"
+     * @return
+     */
+    public static int getOptionsFromString(String input){
+
+        int result = 0;
+
+        String[] options = input.split(",");
+
+        for (String opt : options)
+            result |= getOptionValue(opt);
+
+        return result;
+    }
+
 }

--- a/java/org/apache/catalina/tribes/Channel.java
+++ b/java/org/apache/catalina/tribes/Channel.java
@@ -435,7 +435,6 @@ public interface Channel {
         return result;
     }
 
-
     /**
      * Translates an integer value of SendOptions to its human-friendly comma separated value list for use in JMX and such.
      * @param input the int value of SendOptions
@@ -449,8 +448,8 @@ public interface Channel {
         StringJoiner names = new StringJoiner(", ");
         for (int bit=allOptionNames.length - 1; bit >= 0; bit--){
 
-            // if (2^bit & input) yields a positive value then the bit is set
-            if (((int)Math.pow(2, bit) & input) > 0){
+            // if the bit is set then add the name to the result
+            if (((1 << bit) & input) > 0){
                 names.add(allOptionNames[bit]);
             }
         }

--- a/java/org/apache/catalina/tribes/Channel.java
+++ b/java/org/apache/catalina/tribes/Channel.java
@@ -410,15 +410,15 @@ public interface Channel {
         try {
 
             return Integer.parseInt(input);
-        }
-        catch (NumberFormatException nfe){}
+        } catch (NumberFormatException nfe){}
 
         int result = 0;
 
         String[] options = input.split(",");
 
-        for (String opt : options)
+        for (String opt : options) {
             result |= getOptionValue(opt);
+        }
 
         return result;
     }

--- a/java/org/apache/catalina/tribes/Channel.java
+++ b/java/org/apache/catalina/tribes/Channel.java
@@ -378,7 +378,7 @@ public interface Channel {
      * @param opt The name of the option
      * @return
      */
-    public static int getOptionValue(String opt){
+    public static int getSendOptionValue(String opt){
 
         switch (opt){
 
@@ -415,7 +415,7 @@ public interface Channel {
      * @param input A comma separated list of options, e.g. "async,multicast"
      * @return
      */
-    public static int parseChannelSendOptions(String input){
+    public static int parseSendOptions(String input){
 
         try {
             return Integer.parseInt(input);
@@ -428,7 +428,7 @@ public interface Channel {
 
         int result = 0;
         for (String opt : options) {
-            result |= getOptionValue(opt);
+            result |= getSendOptionValue(opt);
         }
 
         return result;

--- a/java/org/apache/catalina/tribes/Channel.java
+++ b/java/org/apache/catalina/tribes/Channel.java
@@ -405,7 +405,13 @@ public interface Channel {
      * @param input A comma separated list of options, e.g. "async,multicast"
      * @return
      */
-    public static int getOptionsFromString(String input){
+    public static int parseChannelSendOptions(String input){
+
+        try {
+
+            return Integer.parseInt(input);
+        }
+        catch (NumberFormatException nfe){}
 
         int result = 0;
 

--- a/java/org/apache/catalina/tribes/Channel.java
+++ b/java/org/apache/catalina/tribes/Channel.java
@@ -16,6 +16,9 @@
  */
 package org.apache.catalina.tribes;
 
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
+
 import java.io.Serializable;
 
 /**
@@ -370,34 +373,41 @@ public interface Channel {
     public void setName(String name);
 
     /**
-     * Translates the name of an option to its integer value
+     * Translates the name of an option to its integer value.  Valid option names are "asynchronous" (alias "async"),
+     * "byte_message" (alias "byte"), "multicast", "secure", "synchronized_ack" (alias "sync"), "udp", "use_ack"
      * @param opt The name of the option
      * @return
      */
     public static int getOptionValue(String opt){
 
-        if ("asynchronous".equals(opt) || "async".equals(opt))
-            return SEND_OPTIONS_ASYNCHRONOUS;
+        switch (opt){
 
-        if ("byte_message".equals(opt) || "byte".equals(opt))
-            return SEND_OPTIONS_BYTE_MESSAGE;
+            case "asynchronous":
+            case "async":
+                return SEND_OPTIONS_ASYNCHRONOUS;
 
-        if ("multicast".equals(opt))
-            return SEND_OPTIONS_MULTICAST;
+            case "byte_message":
+            case "byte":
+                return SEND_OPTIONS_BYTE_MESSAGE;
 
-        if ("secure".equals(opt))
-            return SEND_OPTIONS_SECURE;
+            case "multicast":
+                return SEND_OPTIONS_MULTICAST;
 
-        if ("synchronized_ack".equals(opt) || "sync".equals(opt))
-            return SEND_OPTIONS_SYNCHRONIZED_ACK;
+            case "secure":
+                return SEND_OPTIONS_SECURE;
 
-        if ("udp".equals(opt))
-            return SEND_OPTIONS_UDP;
+            case "synchronized_ack":
+            case "sync":
+                return SEND_OPTIONS_SYNCHRONIZED_ACK;
 
-        if ("use_ack".equals(opt))
-            return SEND_OPTIONS_USE_ACK;
+            case "udp":
+                return SEND_OPTIONS_UDP;
 
-        return 0;
+            case "use_ack":
+                return SEND_OPTIONS_USE_ACK;
+        }
+
+        throw new IllegalArgumentException(String.format("[%s] is not a valid option", opt));
     }
 
     /**
@@ -408,14 +418,15 @@ public interface Channel {
     public static int parseChannelSendOptions(String input){
 
         try {
-
             return Integer.parseInt(input);
-        } catch (NumberFormatException nfe){}
+        } catch (NumberFormatException nfe){
+            final Log log = LogFactory.getLog(Channel.class);
+            log.trace(String.format("Failed to parse [%s] as integer, channelSendOptions possibly set by name(s)", input));
+        }
+
+        String[] options = input.split("\\s*,\\s*");
 
         int result = 0;
-
-        String[] options = input.split(",");
-
         for (String opt : options) {
             result |= getOptionValue(opt);
         }

--- a/java/org/apache/catalina/tribes/Channel.java
+++ b/java/org/apache/catalina/tribes/Channel.java
@@ -20,6 +20,7 @@ import org.apache.juli.logging.Log;
 import org.apache.juli.logging.LogFactory;
 
 import java.io.Serializable;
+import java.util.StringJoiner;
 
 /**
  * Channel interface<br>
@@ -376,7 +377,7 @@ public interface Channel {
      * Translates the name of an option to its integer value.  Valid option names are "asynchronous" (alias "async"),
      * "byte_message" (alias "byte"), "multicast", "secure", "synchronized_ack" (alias "sync"), "udp", "use_ack"
      * @param opt The name of the option
-     * @return
+     * @return the int value of the passed option name
      */
     public static int getSendOptionValue(String opt){
 
@@ -412,8 +413,8 @@ public interface Channel {
 
     /**
      * Translates a comma separated list of option names to their bitwise-ORd value
-     * @param input A comma separated list of options, e.g. "async,multicast"
-     * @return
+     * @param input A comma separated list of options, e.g. "async, multicast"
+     * @return a bitwise ORd value of the passed option names
      */
     public static int parseSendOptions(String input){
 
@@ -432,6 +433,29 @@ public interface Channel {
         }
 
         return result;
+    }
+
+
+    /**
+     * Translates an integer value of SendOptions to its human-friendly comma separated value list for use in JMX and such.
+     * @param input the int value of SendOptions
+     * @return the human-friendly string representation in a reverse order (i.e. the last option will be shown first)
+     */
+    public static String getSendOptionsAsString(int input){
+
+        // allOptionNames must be in order of the bits of the available options
+        final String[] allOptionNames = new String[]{ "byte", "use_ack", "sync", "async", "secure", "udp", "multicast" };
+
+        StringJoiner names = new StringJoiner(", ");
+        for (int bit=allOptionNames.length - 1; bit >= 0; bit--){
+
+            // if (2^bit & input) yields a positive value then the bit is set
+            if (((int)Math.pow(2, bit) & input) > 0){
+                names.add(allOptionNames[bit]);
+            }
+        }
+
+        return names.toString();
     }
 
 }

--- a/test/org/apache/catalina/tribes/test/channel/TestChannelConfig.java
+++ b/test/org/apache/catalina/tribes/test/channel/TestChannelConfig.java
@@ -51,6 +51,15 @@ public class TestChannelConfig {
     }
 
     @Test
+    public void testStringRepresentationOfIntValue() {
+
+        String options = "multicast, async";
+        SimpleTcpCluster cluster = new SimpleTcpCluster();
+        cluster.setChannelSendOptions(options);
+        assertEquals(options, cluster.getChannelSendOptionsName());
+    }
+
+    @Test
     public void testStringInputForMapSendOptions() {
 
         BackupManager manager = new BackupManager();

--- a/test/org/apache/catalina/tribes/test/channel/TestChannelConfig.java
+++ b/test/org/apache/catalina/tribes/test/channel/TestChannelConfig.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.catalina.tribes.test.channel;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.catalina.tribes.Channel;
+import org.apache.catalina.ha.tcp.SimpleTcpCluster;
+import org.junit.Test;
+
+
+public class TestChannelConfig {
+
+    @Test
+    public void testIntInput() {
+
+        SimpleTcpCluster cluster = new SimpleTcpCluster();
+        cluster.setChannelSendOptions(Channel.SEND_OPTIONS_ASYNCHRONOUS | Channel.SEND_OPTIONS_MULTICAST);
+        assertEquals(Channel.SEND_OPTIONS_ASYNCHRONOUS | Channel.SEND_OPTIONS_MULTICAST, cluster.getChannelSendOptions());
+    }
+
+    @Test
+    public void testStringInputSimple() {
+
+        SimpleTcpCluster cluster = new SimpleTcpCluster();
+        cluster.setChannelSendOptions("multicast");
+        assertEquals(Channel.SEND_OPTIONS_MULTICAST, cluster.getChannelSendOptions());
+    }
+
+    @Test
+    public void testStringInputCompound() {
+
+        SimpleTcpCluster cluster = new SimpleTcpCluster();
+        cluster.setChannelSendOptions("async, multicast");
+        assertEquals(Channel.SEND_OPTIONS_ASYNCHRONOUS | Channel.SEND_OPTIONS_MULTICAST, cluster.getChannelSendOptions());
+    }
+}

--- a/test/org/apache/catalina/tribes/test/channel/TestChannelConfig.java
+++ b/test/org/apache/catalina/tribes/test/channel/TestChannelConfig.java
@@ -18,6 +18,7 @@ package org.apache.catalina.tribes.test.channel;
 
 import static org.junit.Assert.assertEquals;
 
+import org.apache.catalina.ha.session.BackupManager;
 import org.apache.catalina.tribes.Channel;
 import org.apache.catalina.ha.tcp.SimpleTcpCluster;
 import org.junit.Test;
@@ -48,4 +49,13 @@ public class TestChannelConfig {
         cluster.setChannelSendOptions("async, multicast");
         assertEquals(Channel.SEND_OPTIONS_ASYNCHRONOUS | Channel.SEND_OPTIONS_MULTICAST, cluster.getChannelSendOptions());
     }
+
+    @Test
+    public void testStringInputForMapSendOptions() {
+
+        BackupManager manager = new BackupManager();
+        manager.setMapSendOptions("async, multicast");
+        assertEquals(Channel.SEND_OPTIONS_ASYNCHRONOUS | Channel.SEND_OPTIONS_MULTICAST, manager.getMapSendOptions());
+    }
+
 }

--- a/webapps/docs/cluster-howto.xml
+++ b/webapps/docs/cluster-howto.xml
@@ -221,8 +221,11 @@ should be completed:</p>
     <code>SEND_OPTIONS_ASYNCHRONOUS</code> | <code>SEND_OPTIONS_MULTICAST</code>.
 </p>
 <p>
-  You can read more on the <a href="tribes/introduction.html">send flag(overview)</a> or the <doc path="/api/org/apache/catalina/tribes/Channel.html">send flag(javadoc)</doc>.
-    During async replication, the request is returned before the data has been replicated. async replication yields shorter request times, and synchronous replication guarantees the session to be replicated before the request returns.
+  You can read more on the <a href="tribes/introduction.html">send flag(overview)</a> or the
+  <doc path="/api/org/apache/catalina/tribes/Channel.html">send flag(javadoc)</doc>.
+  During async replication, the request is returned before the data has been replicated. async
+  replication yields shorter request times, and synchronous replication guarantees the session
+  to be replicated before the request returns.
 </p>
 </section>
 

--- a/webapps/docs/cluster-howto.xml
+++ b/webapps/docs/cluster-howto.xml
@@ -210,10 +210,19 @@ should be completed:</p>
     sent over the wire and reinstantiated on all the other cluster nodes.
     Synchronous vs. asynchronous is configured using the <code>channelSendOptions</code>
     flag and is an integer value. The default value for the <code>SimpleTcpCluster/DeltaManager</code> combo is
-    8, which is asynchronous. You can read more on the <a href="tribes/introduction.html">send flag(overview)</a> or the
-    <doc path="/api/org/apache/catalina/tribes/Channel.html">send flag(javadoc)</doc>.
-    During async replication, the request is returned before the data has been replicated. async replication yields shorter
-    request times, and synchronous replication guarantees the session to be replicated before the request returns.
+    8, which is asynchronous.
+</p>
+<p>
+    For convenience, <code>channelSendOptions</code> can be set by name(s) rather than integer,
+    which are then translated to their integer value upon startup.  The valid option names are:
+    "asynchronous" (alias "async"), "byte_message" (alias "byte"), "multicast", "secure",
+    "synchronized_ack" (alias "sync"), "udp", "use_ack".  Use comma to separate multiple names,
+    e.g. pass "async, multicast" for the options
+    <code>SEND_OPTIONS_ASYNCHRONOUS</code> | <code>SEND_OPTIONS_MULTICAST</code>.
+</p>
+<p>
+  You can read more on the <a href="tribes/introduction.html">send flag(overview)</a> or the <doc path="/api/org/apache/catalina/tribes/Channel.html">send flag(javadoc)</doc>.
+    During async replication, the request is returned before the data has been replicated. async replication yields shorter request times, and synchronous replication guarantees the session to be replicated before the request returns.
 </p>
 </section>
 

--- a/webapps/docs/cluster-howto.xml
+++ b/webapps/docs/cluster-howto.xml
@@ -218,7 +218,7 @@ should be completed:</p>
     "asynchronous" (alias "async"), "byte_message" (alias "byte"), "multicast", "secure",
     "synchronized_ack" (alias "sync"), "udp", "use_ack".  Use comma to separate multiple names,
     e.g. pass "async, multicast" for the options
-    <code>SEND_OPTIONS_ASYNCHRONOUS</code> | <code>SEND_OPTIONS_MULTICAST</code>.
+    <code>SEND_OPTIONS_ASYNCHRONOUS | SEND_OPTIONS_MULTICAST</code>.
 </p>
 <p>
   You can read more on the <a href="tribes/introduction.html">send flag(overview)</a> or the

--- a/webapps/docs/config/cluster.xml
+++ b/webapps/docs/config/cluster.xml
@@ -142,7 +142,15 @@ Tomcat cluster. These include:</p>
       <br/>
       Note that if you use ASYNC messaging it is possible for update messages
       for a session to be processed by the receiving nodes in a different order
-      to the order in which they were sent.</p>
+      to the order in which they were sent.
+      </p>
+      <p>
+      You may also set these options as a comma separated string, e.g. "async, multicast", which
+      will be translated into <code>Channel.SEND_OPTIONS_ASYNCHRONOUS | Channel.SEND_OPTIONS_MULTICAST</code>
+      <br/>
+      The valid option names are "asynchronous" (alias "async"), "byte_message" (alias "byte")
+      , "multicast", "secure", "synchronized_ack" (alias "sync"), "udp", "use_ack"
+      </p>
     </attribute>
     <attribute name="channelStartOptions" required="false">
       <p>Sets the start and stop flags for the &lt;Channel&gt; object used by the cluster.


### PR DESCRIPTION
This is the basis for tickets
https://bz.apache.org/bugzilla/show_bug.cgi?id=61127
https://bz.apache.org/bugzilla/show_bug.cgi?id=61128
With the added static method `int Channel.getOptionsFromString(String input)`

Calling that method with a String input would translate it to the the equivalent bitwise-ORd integer of the options in the comma-separated input, so that for example `Channel.getOptionsFromString("async,multicast")` would return `72`.

I am not sure yet where the value is read from the configuration file, but it would be simple to use the methods added here, e.g. in any Class that already has 

```
    public void setChannelSendOptions(int channelSendOptions) {
        this.channelSendOptions = channelSendOptions;
    }
```

We can add

```
    public void setChannelSendOptions(String channelSendOptions) {
        this.setChannelSendOptions( Channel.getOptionsFromString(channelSendOptions) );
    }
```

Or perhaps simply translate the input in the method(s) that calls `setChannelSendOptions(int channelSendOptions)` without modifying the classes themselves.