### PR TITLE
Fix https://bz.apache.org/bugzilla/show_bug.cgi?id=61232

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1328,6 +1328,7 @@
         <fileset dir="test">
           <include name="META-INF/**"/>
           <include name="**/service-config.txt"/>
+          <include name="**/logging-non-rotatable.properties"/>
         </fileset>
     </copy>
   </target>

--- a/java/org/apache/juli/FileHandler.java
+++ b/java/org/apache/juli/FileHandler.java
@@ -380,6 +380,14 @@ public class FileHandler extends Handler {
         if (suffix == null) {
             suffix = getProperty(className + ".suffix", ".log");
         }
+
+        //https://bz.apache.org/bugzilla/show_bug.cgi?id=61232
+        boolean shouldCheckForRedundantSeparator = !rotatable && !prefix.isEmpty() && !suffix.isEmpty();
+        //assuming separator is just one char, if there are use cases with more, the notion of separator might be introduced
+        if(shouldCheckForRedundantSeparator && (prefix.charAt(prefix.length() - 1) == suffix.charAt(0))) {
+            suffix = suffix.substring(1);
+        }
+
         pattern = Pattern.compile("^(" + Pattern.quote(prefix) + ")\\d{4}-\\d{1,2}-\\d{1,2}("
                 + Pattern.quote(suffix) + ")$");
         String sMaxDays = getProperty(className + ".maxDays", String.valueOf(DEFAULT_MAX_DAYS));

--- a/test/org/apache/juli/TestFileHandlerNonRotatable.java
+++ b/test/org/apache/juli/TestFileHandlerNonRotatable.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.juli;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.net.URLDecoder;
+
+import org.apache.catalina.startup.LoggingBaseTest;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestFileHandlerNonRotatable extends LoggingBaseTest {
+    private FileHandler testHandler;
+
+    @BeforeClass
+    public static void setUpPerTestClass() throws Exception {
+        System.setProperty("java.util.logging.manager",
+                "org.apache.juli.ClassLoaderLogManager");
+        String configLoggingPath = TestFileHandlerNonRotatable.class
+                .getResource("logging-non-rotatable.properties")
+                .getFile(); 
+        System.setProperty("java.util.logging.config.file",
+                URLDecoder.decode(configLoggingPath, java.nio.charset.StandardCharsets.UTF_8.toString()));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (testHandler != null) {
+            testHandler.close();
+        }
+        super.tearDown();
+    }
+
+    @Test
+    public void testBug61232() throws Exception {
+        testHandler = new FileHandler(this.getTemporaryDirectory().toString(),
+                "juli.", ".log");
+
+        File logFile = new File(this.getTemporaryDirectory(), "juli.log");
+        assertTrue(logFile.exists());
+    }
+
+    @Test
+    public void testCustomSuffixWithoutSeparator() throws Exception {
+        testHandler = new FileHandler(this.getTemporaryDirectory().toString(),
+                "juli.", "log");
+
+        File logFile = new File(this.getTemporaryDirectory(), "juli.log");
+        assertTrue(logFile.exists());
+    }
+
+    @Test
+    public void testCustomPrefixWithoutSeparator() throws Exception {
+        testHandler = new FileHandler(this.getTemporaryDirectory().toString(),
+                "juli", ".log");
+
+        File logFile = new File(this.getTemporaryDirectory(), "juli.log");
+        assertTrue(logFile.exists());
+    }
+}

--- a/test/org/apache/juli/logging-non-rotatable.properties
+++ b/test/org/apache/juli/logging-non-rotatable.properties
@@ -1,0 +1,1 @@
+org.apache.juli.FileHandler.rotatable = false


### PR DESCRIPTION
Checks for one char separator only, not specifically for "."