### PR TITLE
Fix https://bz.apache.org/bugzilla/show_bug.cgi?id=59901

### DIFF
--- a/java/org/apache/jasper/compiler/JspReader.java
+++ b/java/org/apache/jasper/compiler/JspReader.java
@@ -20,6 +20,7 @@ import java.io.CharArrayWriter;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.Reader;
 
 import org.apache.jasper.JasperException;
 import org.apache.jasper.JspCompilationContext;
@@ -102,7 +103,7 @@ class JspReader {
      */
     public JspReader(JspCompilationContext ctxt,
                      String fname,
-                     InputStreamReader reader,
+                     Reader reader,
                      ErrorDispatcher err)
             throws JasperException {
 

--- a/java/org/apache/jasper/compiler/JspUtil.java
+++ b/java/org/apache/jasper/compiler/JspUtil.java
@@ -21,6 +21,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.util.Vector;
 
@@ -683,15 +684,15 @@ public class JspUtil {
         return new BufferedInputStream(in, JspUtil.JSP_INPUT_STREAM_BUFFER_SIZE);
     }
 
-    public static InputSource getInputSource(String fname, Jar jar, JspCompilationContext ctxt)
+    /** The reader parameter is expected to contain the actual input source, while jar and ctxt parameters are only
+     * used to determine the systemId value instead of reading actual stream from them. */
+    public static InputSource getInputSource(Reader reader, String fname, Jar jar, JspCompilationContext ctxt)
         throws IOException {
-        InputSource source;
+        InputSource source = new InputSource(reader);
         if (jar != null) {
             String jarEntryName = fname.substring(1, fname.length());
-            source = new InputSource(jar.getInputStream(jarEntryName));
             source.setSystemId(jar.getURL(jarEntryName));
         } else {
-            source = new InputSource(ctxt.getResourceAsStream(fname));
             source.setSystemId(ctxt.getResource(fname).toExternalForm());
         }
         return source;


### PR DESCRIPTION
Caching jsp file read to improve performance

Hi, I added jsp file content cache inside ParserController for this enhancement. This reduced two read I found during the parsing for both XML jsp and standard jsp. 

Impl notes: The ParserController instance seems to be bounded to JspServletWrapper lifecycle though, so this will cache only per JspServletWrapper instance context as well. I have seen that some tag file processing will create nested instances of JspServletWrapper, and in this case, we still not able to use the cache. I wasn't sure was there a better place to add the cache that can reuse by multiple JspServletWrapper instances at this point. Please let me know what you think what you think so far.