### PR TITLE
added SessionInitializerFilter

### DIFF
--- a/java/org/apache/catalina/filters/SessionInitializerFilter.java
+++ b/java/org/apache/catalina/filters/SessionInitializerFilter.java
@@ -16,8 +16,8 @@
  */
 package org.apache.catalina.filters;
 
+import javax.servlet.Filter;
 import javax.servlet.FilterChain;
-import javax.servlet.GenericFilter;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
@@ -35,7 +35,7 @@ import java.io.IOException;
  * does not provide a way to do so.
  * </p>
  */
-public class SessionInitializerFilter extends GenericFilter {
+public class SessionInitializerFilter implements Filter {
 
     /**
      * Calls {@link HttpServletRequest}'s getSession() to initialize the HttpSession

--- a/java/org/apache/catalina/filters/SessionInitializerFilter.java
+++ b/java/org/apache/catalina/filters/SessionInitializerFilter.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.catalina.filters;
+
+import javax.servlet.FilterChain;
+import javax.servlet.GenericFilter;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import java.io.IOException;
+
+/**
+ * <p>
+ * A {@link javax.servlet.Filter} that initializes the {@link HttpSession} for the
+ * {@link HttpServletRequest} by calling its getSession() method.
+ *
+ * This is required for some operations with WebSocket requests, where it is too late
+ * to initialize the HttpSession object, and the current Java WebSocket specification
+ * does not provide a way to do so.
+ * </p>
+ */
+public class SessionInitializerFilter extends GenericFilter {
+
+    /**
+     * Calls {@link HttpServletRequest}'s getSession() to initialize the HttpSession
+     * and continues processing the chain.
+     *
+     * @param request  The request to process
+     * @param response The response associated with the request
+     * @param chain    Provides access to the next filter in the chain for this
+     *                 filter to pass the request and response to for further
+     *                 processing
+     * @throws IOException      if an I/O error occurs during this filter's
+     *                          processing of the request
+     * @throws ServletException if the processing fails for any other reason
+     */
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        ((HttpServletRequest)request).getSession();
+
+        chain.doFilter(request, response);
+    }
+
+}

--- a/webapps/docs/config/filter.xml
+++ b/webapps/docs/config/filter.xml
@@ -1592,6 +1592,46 @@ org.apache.catalina.filters.RequestDumperFilter.handlers = \
   </subsection>
 </section>
 
+<section name="Session Initializer Filter">
+
+  <subsection name="Introduction">
+    <p>The Session Initializer Filter initializes the <code>javax.servlet.http.HttpSession</code>
+    before the Request is processed.  This is required for JSR-356 compliant WebSocket implementations,
+    if the <code>HttpSession</code> is needed during the HandShake phase.</p>
+
+    <p>The Java API for WebSocket does not mandate that an <code>HttpSession</code> would
+    be initialized upon request, and thus <code>javax.servlet.http.HttpServletRequest</code>'s
+    <code>getSession()</code> returns <code>null</code> if the <code>HttpSession</code> was not
+    initialized in advance.</p>
+
+    <p>This filter solves that problem by initializing the HttpSession for any <code>HttpServletRequest</code>
+    that matches its <code>url-pattern</code>.</p>
+  </subsection>
+
+  <subsection name="Filter Class Name">
+    <p>The filter class name for the Session Initializer Filter is
+    <strong><code>org.apache.catalina.filters.SessionInitializerFilter</code></strong>.</p>
+  </subsection>
+
+  <subsection name="Initialisation parameters">
+    <p>The Session Initializer Filter does not support any initialization parameters.</p>
+  </subsection>
+
+  <subsection name="Sample Configuration">
+    <p>The following entries in the Web Application Deployment Descriptor, <strong>web.xml</strong>,
+    would enable the Session Initializer Filter for requests that match the given URL pattern
+    (in this example, "/ws/*").</p>
+
+    <source><![CDATA[<filter>
+    <filter-name>SessionInitializer</filter-name>
+    <filter-class>org.apache.catalina.filters.SessionInitializerFilter</filter-class>
+</filter>
+<filter-mapping>
+    <filter-name>SessionInitializer</filter-name>
+    <url-pattern>/ws/*</url-pattern>
+</filter-mapping>]]></source>
+    </subsection>
+</section>
 
 <section name="Set Character Encoding Filter">
 


### PR DESCRIPTION
This Filter initializes the HttpSession object for the Request, which is required for certain operations with WebSocket requests where it is too late to initialize the HttpSession, but the HttpSession object is required to retrieve information during the Handshake process.

One common use case is to retrieve the `ServletContext` during a WebSocket Handshake by calling `handshakeRequest.getHttpSession().getServletContext()`.  According to the WebSocket specification a call to getHttpSession() should not initialize one if one does not exist.  If the HttpSession is not initalized then this call throws an NPE.

Hopefully the WebSocket EG will offer a better way in the future, but until such time the HttpSession needs to be initialized by a Filter like this one,or a Listener which will run for all URIs and is therefore less optimal.