### PR TITLE
Removed findbugs bad practice warnings by making classes final

### DIFF
--- a/java/org/apache/catalina/tribes/io/ChannelData.java
+++ b/java/org/apache/catalina/tribes/io/ChannelData.java
@@ -32,7 +32,7 @@ import org.apache.catalina.tribes.util.UUIDGenerator;
  * interceptors, the message data can be manipulated as each interceptor seems appropriate.
  * @author Peter Rossbach
  */
-public class ChannelData implements ChannelMessage {
+public final class ChannelData implements ChannelMessage {
     private static final long serialVersionUID = 1L;
 
     public static final ChannelData[] EMPTY_DATA_ARRAY = new ChannelData[0];

--- a/java/org/apache/catalina/tribes/membership/Membership.java
+++ b/java/org/apache/catalina/tribes/membership/Membership.java
@@ -32,7 +32,7 @@ import org.apache.catalina.tribes.Member;
  *
  * @author Peter Rossbach
  */
-public class Membership implements Cloneable {
+public final class Membership implements Cloneable {
 
     protected static final Member[] EMPTY_MEMBERS = new Member[0];
 

--- a/java/org/apache/catalina/tribes/tipis/AbstractReplicatedMap.java
+++ b/java/org/apache/catalina/tribes/tipis/AbstractReplicatedMap.java
@@ -1385,7 +1385,7 @@ public abstract class AbstractReplicatedMap<K,V>
 //                map message to send to and from other maps
 //------------------------------------------------------------------------------
 
-    public static class MapMessage implements Serializable, Cloneable {
+    public static final class MapMessage implements Serializable, Cloneable {
         private static final long serialVersionUID = 1L;
         public static final int MSG_BACKUP = 1;
         public static final int MSG_RETRIEVE_BACKUP = 2;

--- a/java/org/apache/catalina/util/URLEncoder.java
+++ b/java/org/apache/catalina/util/URLEncoder.java
@@ -34,7 +34,7 @@ import java.util.BitSet;
  * @author Craig R. McClanahan
  * @author Remy Maucherat
  */
-public class URLEncoder implements Cloneable {
+public final class URLEncoder implements Cloneable {
 
     private static final char[] hexadecimal =
             {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};


### PR DESCRIPTION
CN org.apache.catalina.tribes.io.ChannelData.clone() does not call super.clone()
CN org.apache.catalina.tribes.membership.Membership.clone() does not call super.clone()
CN org.apache.catalina.tribes.tipis.AbstractReplicatedMap$MapMessage.clone() does not call super.clone()
CN org.apache.catalina.util.URLEncoder.clone() does not call super.clone()