### PR TITLE
BUG 61736 - Fix NIO BlockPoller bug for it's too busy handling events

### DIFF
--- a/java/org/apache/tomcat/util/net/NioBlockingSelector.java
+++ b/java/org/apache/tomcat/util/net/NioBlockingSelector.java
@@ -263,10 +263,20 @@ public class NioBlockingSelector {
             boolean result = false;
             Runnable r = null;
             result = (events.size() > 0);
-            while ( (r = events.poll()) != null ) {
+
+            // We only poll and run the runnable events when we start this method.
+            // Further events added to the queue later will be delayed to the next execution of this method.
+            //
+            // We do in this way, because running event from the events queue may lead the working thread to
+            // add more events to the queue (for example, the worker thread may add another RunnableAdd event
+            // when waken up by a previous RunnableAdd event who got an invalid SelectionKey).
+            // Trying to consume all the events in an increasing queue till it's empty, will make the loop hard to
+            // be terminated, which will kill a lot of time, and greatly affect performance of the poller loop.
+            for (int i = 0, size = events.size(); i < size && (r = events.poll()) != null; i++) {
                 r.run();
                 result = true;
             }
+
             return result;
         }
 

--- a/java/org/apache/tomcat/util/net/NioEndpoint.java
+++ b/java/org/apache/tomcat/util/net/NioEndpoint.java
@@ -595,7 +595,7 @@ public class NioEndpoint extends AbstractJsseEndpoint<NioChannel,SocketChannel> 
             boolean result = false;
 
             PollerEvent pe = null;
-            while ( (pe = events.poll()) != null ) {
+            for (int i = 0, size = events.size(); i < size && (pe = events.poll()) != null; i++ ) {
                 result = true;
                 try {
                     pe.run();


### PR DESCRIPTION
When I use tomcat as my server to receive files, and transfer some files via a non-stable network, I found the traffic always hang for a great while with [`zero window`](https://wiki.wireshark.org/TCP%20ZeroWindow) reported from server. Following are the steps to reproduce the problem. 

1. Configure the server tcp receive window size.

```bash
$ cat /proc/sys/net/ipv4/tcp_rmem
1024	2048	8192
```

2. Put the following JSP into the ROOT project. i.e. in the path `$CATALINA_HOME/webapps/ROOT/consume.jsp`

```jsp
<%@ page import="org.apache.commons.io.IOUtils" %><%
    final ServletInputStream inputStream = request.getInputStream();
    byte[] content = IOUtils.toByteArray(inputStream);
%>ok
```

> The `IOUtils` is a class from [commons-io](https://mvnrepository.com/artifact/commons-io/commons-io/2.5)

3. Start tomcat with the following settings

```
Server version:        Apache Tomcat/8.0.46
Server built:          Aug 10 2017 10:10:31 UTC
Server number:         8.0.46.0
OS Name:               Linux
OS Version:            3.10.0-229.el7.x86_64
Architecture:          amd64
Java Home:             /usr/jdk1.8.0_121/jre
JVM Version:           1.8.0_121-b13
JVM Vendor:            Oracle Corporation
Command line argument: -Xms256m
Command line argument: -Xmx256m
Command line argument: -Xmn128m
Command line argument: -Xss1m
```

4. Capture the TCP traffics.

```
tcpdump -i any -w tcp.cap port 8080
```

5. Start a client. sending data with http in chunks (see [codes](https://gist.github.com/xnslong/48d961cfa10dad2f174c63734e393106)) with the following settings:

```
chunk size                   1024 byte
rest between chunks          50 ms
chunk count per request      100
parallel requests            100
total requests               10000
```

6. Then we will got a lot of zero window packets, which lasts several seconds. 

```
No.     stream     Time               Source              Destination         ack        win        Length Info
 469817 3201       15:09:04.175309    172.16.1.4          172.16.1.5          1          29696      57     [TCP segment of a reassembled PDU]
 469904 3201       15:09:04.214945    172.16.1.5          172.16.1.4          4238       1024       54     8080→58750 [ACK] Seq=1 Ack=4238 Win=1024 Len=0
 470091 3201       15:09:04.437137    172.16.1.4          172.16.1.5          1          29696      1078   [TCP Window Full] [TCP segment of a reassembled PDU]
 470092 3201       15:09:04.437142    172.16.1.5          172.16.1.4          5262       0          54     [TCP ZeroWindow] 8080→58750 [ACK] Seq=1 Ack=5262 Win=0 Len=0
 470334 3201       15:09:04.657120    172.16.1.4          172.16.1.5          1          29696      54     [TCP Keep-Alive] 58750→8080 [ACK] Seq=5261 Ack=1 Win=29696 Len=0
 470335 3201       15:09:04.657123    172.16.1.5          172.16.1.4          5262       0          54     [TCP ZeroWindow] 8080→58750 [ACK] Seq=1 Ack=5262 Win=0 Len=0
 470620 3201       15:09:05.098135    172.16.1.4          172.16.1.5          1          29696      54     [TCP Keep-Alive] 58750→8080 [ACK] Seq=5261 Ack=1 Win=29696 Len=0
 470621 3201       15:09:05.098141    172.16.1.5          172.16.1.4          5262       0          54     [TCP ZeroWindow] 8080→58750 [ACK] Seq=1 Ack=5262 Win=0 Len=0
 471017 3201       15:09:05.979136    172.16.1.4          172.16.1.5          1          29696      54     [TCP Keep-Alive] 58750→8080 [ACK] Seq=5261 Ack=1 Win=29696 Len=0
 471018 3201       15:09:05.979140    172.16.1.5          172.16.1.4          5262       0          54     [TCP ZeroWindow] 8080→58750 [ACK] Seq=1 Ack=5262 Win=0 Len=0
 471619 3201       15:09:07.743148    172.16.1.4          172.16.1.5          1          29696      54     [TCP Keep-Alive] 58750→8080 [ACK] Seq=5261 Ack=1 Win=29696 Len=0
 471620 3201       15:09:07.743151    172.16.1.5          172.16.1.4          5262       0          54     [TCP ZeroWindow] 8080→58750 [ACK] Seq=1 Ack=5262 Win=0 Len=0
 475765 3201       15:09:08.545625    172.16.1.5          172.16.1.4          5262       3072       54     [TCP Window Update] 8080→58750 [ACK] Seq=1 Ack=5262 Win=3072 Len=0
 475781 3201       15:09:08.545815    172.16.1.4          172.16.1.5          1          29696      490    [TCP segment of a reassembled PDU]
 475782 3201       15:09:08.545821    172.16.1.5          172.16.1.4          5698       3072       54     8080→58750 [ACK] Seq=1 Ack=5698 Win=3072 Len=0
 475784 3201       15:09:08.545825    172.16.1.4          172.16.1.5          1          29696      1514   [TCP segment of a reassembled PDU]
```

After a lot of study, I found this is because of a BUG in the BlockPoller, which will slow down the speed of polling cycle a lot.

The `BlockPoller` will alway register the interests for `Channel`s with the `SelectionKey`s. When the `BlockPoller` has selected an interest operation for a `SelectionKey`, the worker thread for this `SelectionKey` handles the event, and turn this key into invalid state. Then the worker thread will add another event to the queue for the interest operations if data is not finished. So the `SelectionKey` is designed to be an one-time `SelectionKey`.

But the JDK has cached the `SelectionKey` for each channel (in fact the class is `AbstractSelectableChannel`) and `Selector`, that's to say before the cache is cleared, the same channel and selector will always got the same `SelectionKey`, even it's invalid. The cached invalid keys will be cleared when the `Selector.select...()` method is called. So if the `SelectionKey` turned invalid, it will always get the same invalid key before the `select()` method is called. So the handling the further events offered by the worker thread whose `SelectionKey` has turned invalid before the `select()` method, it will still got an invalid `SelectionKey`.

Let's take a look on the following code, it's the main logic of the `BlockPoller`. The `BlockPoller` will always walk repeatedly in the polling cycle (loop `C`) again and again. And during the loop, it will first handle all events from the queue until the queue is empty (loop `E`), and the call the `select()` method to perform a event polling from the OS (see line at label `S`), and then wake corresponding worker threads (see line at label `W`)

```java
public boolean events() {
    boolean result = false;
    Runnable r = null;
    result = (events.size() > 0);
E:  while ( (r = events.poll()) != null ) {
        r.run();  
        // the line above may wake the worker thread,
        // and the worker thread will add another event to the events queue.
        // so this loop may be very busy handling the endless events
        //  from the endlessly woken worker threads.
        result = true;
    }
    return result;
}

public void run() {
C:  while (run) {
        try {
            events(); // <-- handle all events
            int keyCount = 0;
            ...
            wakeupCounter.set(-1);
S:          keyCount = selector.select(1000); // <-- do selection,
            // this select step will clear all invalid SelectionKeys.
            // until this step, SelectionKey for the same Channel, 
            // will always get the same SelectionKey.
             ...
W:          Iterator<SelectionKey> iterator = keyCount > 0 ? selector.selectedKeys().iterator() : null;
            while (run && iterator != null && iterator.hasNext()) {
                SelectionKey sk = iterator.next();
                NioSocketWrapper attachment = (NioSocketWrapper)sk.attachment();
                try {
                    iterator.remove();
                    sk.interestOps(sk.interestOps() & (~sk.readyOps()));
                    if ( sk.isReadable() ) {
                        countDown(attachment.getReadLatch());
                    }
                    ...
                }catch (CancelledKeyException ckx) {
                    ...
                }
            }//while
        }catch ( Throwable t ) {
            log.error("",t);
        }
    }
    ....
}
```

Since the `SelectionKey`s are designed one-time keys, they will turn invalid when the interest events have been notified by the OS, and the worker will offer another event to the queue. So when the polling cycle (loop `C`) enter the next cycle, and starts to handle all the events in the queue (loop `E`), including the event offered by the former worker thread. However this time, the `SelectionKey` got for the channel and selector is still the invalid key as previously handled in the loop `C` after the select method, because from then on, the next `Selector.select()` method is not yet called, so the buffer still take effects. 

Then the `BlockPoller` will reject the event (line `R` in the following code), and wake up the worker thread. The worker thread will still offer another event to the queue. If this happens before the current loop `E` ends, the newly added event will still be handled in the current loop `E` again, and get the same `SelectionKey` as previous run in the current loop `E`. So it will be rejected again in the current loop `E`, which may cause more events from the worker thread to be added to the queue. 

If the queue is large enough, the phenomenon will happen again and again in the current loop `E`, then the poller will be very busy handling the invalid `SelectionKey`s for the same channel again and again, which will kill a lot of time, and make the next select operation start very late. So the IO events from the OS cannot be notified to the worker threads very timely.

```java
// An Add event
SelectionKey sk = ch.keyFor(selector); 
// if the SelectionKey has turned invalid keys for ch, 
// then this method will still get an invalid SelectionKey before the next select() method is called
// that's to say, sk will remain invalid
try {
    if (sk == null) {
        sk = ch.register(selector, ops, key);
        ref.key = sk;
    } else if (!sk.isValid()) {
R:      cancel(sk, key, ops);  // <-- it will enter this branch when sk is invalid, and will wake the corresponding worker thread
    } else {
        sk.interestOps(sk.interestOps() | ops);
    }
} catch (CancelledKeyException cx) {
    cancel(sk, key, ops);
} catch (ClosedChannelException cx) {
    cancel(null, key, ops);
}
```

In fact the events added with invalid keys when the loop `E` is processing should not be handled right now, they should be handled after the `select()` method have cleared the invalid keys from buffer. This PR brought about a solution that for each polling cycle (loop `C`), the `events()` method (loop `E`) will not try to empty the queue, instead just read and executes all the events in the queue when it enters the method, events came later be delayed to the next polling cycle (the loop `C`). So the loop will only handle a definitely limited events, and will not be slow. When on yet another next loop `C`, the invalid key will have been cleared by the `select()` method already. So the next time, it will add the event with a very healthy `SelectionKey`.

After this PR, some events added after the loop `E` in the `events()` method has started will  be delayed to the next polling cycle (the loop `C`), but the speed of loop `C` will be improved a lot when even on heavy loads. I tried the reproduction steps on the code of this PR, the zero window packets never appear again.