### PR TITLE
Add tomcat in the cloud abstract implementation

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -374,6 +374,7 @@
     <include name="org/apache/tomcat/util/res/**" />
     <include name="org/apache/tomcat/util/security/**" />
     <include name="org/apache/tomcat/util/threads/**" />
+    <include name="org/apache/tomcat/util/providers/**" />
     <include name="org/apache/tomcat/util/*" />
     <exclude name="org/apache/tomcat/util/bcel" />
     <exclude name="org/apache/tomcat/util/descriptor" />

--- a/java/org/apache/tomcat/util/providers/member/AbstractMemberProvider.java
+++ b/java/org/apache/tomcat/util/providers/member/AbstractMemberProvider.java
@@ -1,0 +1,68 @@
+/**
+ *  Copyright 2017 Ismaïl Senhaji, Guillaume Pythoud, Maxime Beck
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.tomcat.util.providers.member;
+
+import java.security.AccessController;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivilegedAction;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import org.apache.tomcat.util.providers.stream.StreamProvider;
+
+public abstract class AbstractMemberProvider implements MemberProvider {
+    private static final Logger log = Logger.getLogger(AbstractMemberProvider.class.getName());
+
+    private String url;
+    private StreamProvider streamProvider;
+    private int connectionTimeout;
+    private int readTimeout;
+
+    private Instant startTime;
+    private MessageDigest md5;
+
+    private Map<String, String> headers = new HashMap<>();
+
+    private int port;
+    private String hostName;
+
+    public AbstractMemberProvider() {
+        try {
+            md5 = MessageDigest.getInstance("md5");
+        } catch (NoSuchAlgorithmException e) {
+            // Ignore
+        }
+    }
+
+    // Get value of environment variable named keys[0]
+    // If keys[0] isn't found, try keys[1], keys[2], ...
+    // If nothing is found, return null
+    private static String getEnv(String... keys) {
+        String val = null;
+
+        for (String key : keys) {
+            val = AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getenv(key));
+            if (val != null)
+                break;
+        }
+
+        return val;
+    }
+}

--- a/java/org/apache/tomcat/util/providers/member/MemberProvider.java
+++ b/java/org/apache/tomcat/util/providers/member/MemberProvider.java
@@ -1,0 +1,28 @@
+/**
+ *  Copyright 2017 Ismaïl Senhaji, Guillaume Pythoud
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.tomcat.util.providers.member;
+
+import org.apache.catalina.tribes.Member;
+
+import java.util.List;
+import java.util.Properties;
+
+public interface MemberProvider {
+    void init(Properties properties) throws Exception;
+
+    List<? extends Member> getMembers() throws Exception;
+}

--- a/java/org/apache/tomcat/util/providers/stream/AbstractStreamProvider.java
+++ b/java/org/apache/tomcat/util/providers/stream/AbstractStreamProvider.java
@@ -1,0 +1,48 @@
+/**
+ *  Copyright 2017 Ismaïl Senhaji, Guillaume Pythoud, Maxime Beck
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.tomcat.util.providers.stream;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public abstract class AbstractStreamProvider implements StreamProvider {
+    private static final Logger log = Logger.getLogger(AbstractStreamProvider.class.getName());
+
+    public URLConnection openConnection(String url, Map<String, String> headers, int connectTimeout, int readTimeout) throws IOException {
+        if (log.isLoggable(Level.FINE)) {
+            log.log(Level.FINE, String.format("%s opening connection: url [%s], headers [%s], connectTimeout [%s], readTimeout [%s]", getClass().getSimpleName(), url, headers, connectTimeout, readTimeout));
+        }
+        URLConnection connection = new URL(url).openConnection();
+        if (headers != null) {
+            for (Map.Entry<String, String> entry : headers.entrySet()) {
+                connection.addRequestProperty(entry.getKey(), entry.getValue());
+            }
+        }
+        if (connectTimeout < 0 || readTimeout < 0) {
+            throw new IllegalArgumentException(
+                String.format("Neither connectTimeout [%s] nor readTimeout [%s] can be less than 0 for URLConnection.", connectTimeout, readTimeout));
+        }
+        connection.setConnectTimeout(connectTimeout);
+        connection.setReadTimeout(readTimeout);
+        return connection;
+    }
+
+}

--- a/java/org/apache/tomcat/util/providers/stream/StreamProvider.java
+++ b/java/org/apache/tomcat/util/providers/stream/StreamProvider.java
@@ -1,0 +1,31 @@
+/**
+ *  Copyright 2015 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package org.apache.tomcat.util.providers.stream;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+
+/**
+ * @author <a href="mailto:kconner@redhat.com">Kevin Conner</a>
+ */
+public interface StreamProvider {
+
+    public InputStream openStream(String url, Map<String, String> headers, int connectTimeout, int readTimeout) throws IOException;
+
+}


### PR DESCRIPTION
## Tomcat in the Cloud
_Tomcat in the Cloud_ is a project that seeks to add support for clustering into a cloud environment for a variety of cloud service providers such as OpenShift, Kubernetes, Azure and more.

This commit is the first of many related to this project. It adds the abstract implementation of both **_MemberProvider_** and **_StreamProvider_**.

### MemberProvider
Discovers all running instances of Tomcat in the cloud environment.

### StreamProvider
Establish connection throughout the cloud network to provide multi-casting in the cloud environment.