### PR TITLE
Don't gzip brotli compressed content

### DIFF
--- a/java/org/apache/coyote/CompressionConfig.java
+++ b/java/org/apache/coyote/CompressionConfig.java
@@ -186,9 +186,11 @@ public class CompressionConfig {
 
         MimeHeaders responseHeaders = response.getMimeHeaders();
 
-        // Check if content is not already gzipped
+        // Check if content is not already compressed
         MessageBytes contentEncodingMB = responseHeaders.getValue("Content-Encoding");
-        if ((contentEncodingMB != null) && (contentEncodingMB.indexOf("gzip") != -1)) {
+        if ((contentEncodingMB != null) &&
+                    (contentEncodingMB.indexOf("gzip") != -1) &&
+                    (contentEncodingMB.indexOf("br") != -1)) {
             return false;
         }
 


### PR DESCRIPTION
We try to serve brotli compressed static files while setting `Http11Protocol.COMPRESSION` to `on` (because we have some other files that benefit a lot from that.) 

That doesn't work because Tomcat compresses anything but gzip compressed content. 

This patch will allow brotli compressed content (`Content-Encoding: br`) to pass untouched :-) 
