### PR TITLE
Fix compressibleMimeType handling for compression="on"

### DIFF
--- a/java/org/apache/coyote/CompressionConfig.java
+++ b/java/org/apache/coyote/CompressionConfig.java
@@ -203,7 +203,7 @@ public class CompressionConfig {
             }
 
             // Check for compatible MIME-TYPE
-            String[] compressibleMimeTypes = this.compressibleMimeTypes;
+            String[] compressibleMimeTypes = this.getCompressibleMimeTypes();
             if (compressibleMimeTypes != null &&
                     !startsWithStringArray(compressibleMimeTypes, response.getContentType())) {
                 return false;


### PR DESCRIPTION
This change fixes a regression introduced by 913cb6d / r1816549
"Refactor: Move compression code to new class to allow re-use with HTTP/2",
which (among other things) consolidates isCompressible() and useCompression()
into a single functions.

Unfortunately, the call to getCompressibleMimeTypes(), got lost in the process,
leaving the compressibleMimeTypes array uninitialized, disabling the mimetype check
in useCompression(), effectively turning it into compression="force".

Signed-off-by: Stefan Knoblich <s.knoblich@praxino.de>