### PR TITLE
Fix cygpath is checking for empty path

### DIFF
--- a/bin/catalina.sh
+++ b/bin/catalina.sh
@@ -240,7 +240,7 @@ if $cygwin; then
   CATALINA_BASE=`cygpath --absolute --windows "$CATALINA_BASE"`
   CATALINA_TMPDIR=`cygpath --absolute --windows "$CATALINA_TMPDIR"`
   CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
-  JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+  [ -n "$JAVA_ENDORSED_DIRS" ] && JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
 fi
 
 if [ -z "$JSSE_OPTS" ] ; then


### PR DESCRIPTION
Hi, When running Tomcat under Cygwin shell, I see `cygpath: can't convert empty path` error message printed, but it will continue to work. Looking closely, it seems that `catalina.sh` script didn't check for empty string for the optional JAVA_ENDORSED_DIRS var before calling cygpath. I have created a PR that fix this minor bug. Please review.

```
$ bin/catalina.sh version
cygpath: can't convert empty path
Using CATALINA_BASE:   C:\Users\zemian\apps\apache-tomcat-8.5.29
Using CATALINA_HOME:   C:\Users\zemian\apps\apache-tomcat-8.5.29
Using CATALINA_TMPDIR: C:\Users\zemian\apps\apache-tomcat-8.5.29\temp
Using JRE_HOME:        C:\Users\zemian\apps\jdk-8u161
Using CLASSPATH:       C:\Users\zemian\apps\apache-tomcat-8.5.29\bin\bootstrap.jar;C:\Users\zemian\apps\apache-tomcat-8.5.29\bin\tomcat-juli.jar
Server version: Apache Tomcat/8.5.29
Server built:   Mar 5 2018 13:11:12 UTC
Server number:  8.5.29.0
OS Name:        Windows 7
OS Version:     6.1
Architecture:   amd64
JVM Version:    1.8.0_161-b12
JVM Vendor:     Oracle Corporation
```