### PR TITLE
Improve undeployment in parallel deployment scenario

### DIFF
--- a/java/org/apache/catalina/startup/HostConfig.java
+++ b/java/org/apache/catalina/startup/HostConfig.java
@@ -39,17 +39,14 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.function.Supplier;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collector;
 
 import javax.management.ObjectName;
 
@@ -1663,10 +1660,10 @@ public class HostConfig implements LifecycleListener {
         }
 
         // Need ordered set of names
-        SortedSet<ContextName> sortedAppNames = deployed.keySet().stream().
-                map(name -> new ContextName(name, false)).
-                collect(Collector.of((Supplier<SortedSet<ContextName>>) TreeSet::new, SortedSet::add,
-                        (left, right) -> { left.addAll(right); return left; }));
+        TreeSet<ContextName> sortedAppNames = new TreeSet<>();
+        for (String name : deployed.keySet()) {
+            sortedAppNames.add(new ContextName(name, false));
+        }
         Iterator<ContextName> iter = sortedAppNames.iterator();
 
         ContextName previous = iter.next();

--- a/java/org/apache/catalina/util/ContextName.java
+++ b/java/org/apache/catalina/util/ContextName.java
@@ -26,6 +26,7 @@ import java.util.regex.Pattern;
 public final class ContextName implements Comparable {
     public static final String ROOT_NAME = "ROOT";
     private static final String VERSION_MARKER = "##";
+    private static final Pattern VERSION_PATTERN = Pattern.compile("(\\d+\\.)*\\d+");
     private static final String FWD_SLASH_REPLACEMENT = "#";
 
     private final String baseName;
@@ -209,9 +210,8 @@ public final class ContextName implements Comparable {
             return 0;
         }
 
-        Pattern versionPattern = Pattern.compile("(\\d+\\.)*\\d+");
-        if (versionPattern.matcher(version).matches() &&
-                versionPattern.matcher(other.version).matches()) {
+        if (VERSION_PATTERN.matcher(version).matches() &&
+                VERSION_PATTERN.matcher(other.version).matches()) {
             String[] versionTokens = version.split("\\.");
             String[] otherVersionTokens = other.version.split("\\.");
 

--- a/java/org/apache/catalina/util/ContextName.java
+++ b/java/org/apache/catalina/util/ContextName.java
@@ -27,6 +27,7 @@ public final class ContextName implements Comparable {
     public static final String ROOT_NAME = "ROOT";
     private static final String VERSION_MARKER = "##";
     private static final Pattern VERSION_PATTERN = Pattern.compile("(\\d+\\.)*\\d+");
+    private static final Pattern VERSION_DOT_PATTERN = Pattern.compile("\\.");
     private static final String FWD_SLASH_REPLACEMENT = "#";
 
     private final String baseName;
@@ -212,8 +213,8 @@ public final class ContextName implements Comparable {
 
         if (VERSION_PATTERN.matcher(version).matches() &&
                 VERSION_PATTERN.matcher(other.version).matches()) {
-            String[] versionTokens = version.split("\\.");
-            String[] otherVersionTokens = other.version.split("\\.");
+            String[] versionTokens = VERSION_DOT_PATTERN.split(version);
+            String[] otherVersionTokens = VERSION_DOT_PATTERN.split(other.version);
 
             int i = 0;
             while (versionTokens.length > i && otherVersionTokens.length > i) {

--- a/java/org/apache/catalina/util/ContextName.java
+++ b/java/org/apache/catalina/util/ContextName.java
@@ -34,6 +34,7 @@ public final class ContextName implements Comparable {
     private final String path;
     private final String version;
     private final String name;
+    private String versionCode;
 
 
     /**
@@ -84,6 +85,8 @@ public final class ContextName implements Comparable {
             tmp2 = baseName;
         }
 
+        buildVersionCode();
+
         if (ROOT_NAME.equals(tmp2)) {
             path = "";
         } else {
@@ -118,6 +121,8 @@ public final class ContextName implements Comparable {
             this.version = version;
         }
 
+        buildVersionCode();
+
         // Name is path + version
         if ("".equals(this.version)) {
             name = this.path;
@@ -138,6 +143,25 @@ public final class ContextName implements Comparable {
             tmp.append(this.version);
         }
         this.baseName = tmp.toString();
+    }
+
+    /**
+     * Build a condensed string of common version numbers, e.g. 1.2.34
+     *
+     * This converts individual components of a version number into UTF-16
+     * code points and concatenates them into a string. This string can be
+     * used for comparison later on.
+     */
+    private void buildVersionCode() {
+        if (VERSION_PATTERN.matcher(version).matches()) {
+            StringBuilder versionCodeBuilder = new StringBuilder();
+            for (String versionPart : VERSION_DOT_PATTERN.split(version)) {
+                versionCodeBuilder.append(Character.toChars(Integer.valueOf(versionPart)));
+            }
+            versionCode = versionCodeBuilder.toString();
+        } else {
+            versionCode = null;
+        }
     }
 
     public String getBaseName() {
@@ -207,32 +231,11 @@ public final class ContextName implements Comparable {
             return pathResult;
         }
 
-        if (version.equals(other.version)) {
-            return 0;
+        if (versionCode != null && other.versionCode != null) {
+            return versionCode.compareTo(other.versionCode);
         }
 
-        if (VERSION_PATTERN.matcher(version).matches() &&
-                VERSION_PATTERN.matcher(other.version).matches()) {
-            String[] versionTokens = VERSION_DOT_PATTERN.split(version);
-            String[] otherVersionTokens = VERSION_DOT_PATTERN.split(other.version);
-
-            int i = 0;
-            while (versionTokens.length > i && otherVersionTokens.length > i) {
-                Integer versionPart = Integer.parseInt(versionTokens[i]);
-                Integer otherVersionPart = Integer.parseInt(otherVersionTokens[i]);
-
-                int partResult = versionPart.compareTo(otherVersionPart);
-                if (partResult != 0) {
-                    return partResult;
-                }
-
-                i ++;
-            }
-
-            return 0;
-        } else {
-            return name.compareTo(other.name);
-        }
+        return version.compareTo(other.version);
     }
 
 

--- a/test/org/apache/catalina/util/TestContextName.java
+++ b/test/org/apache/catalina/util/TestContextName.java
@@ -20,6 +20,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+
 
 public class TestContextName {
 
@@ -49,6 +52,9 @@ public class TestContextName {
     private ContextName cn24;
     private ContextName cn25;
     private ContextName cn26;
+    private ContextName cn27;
+    private ContextName cn28;
+    private ContextName cn29;
 
     @Before
     public void setUp() throws Exception {
@@ -75,9 +81,12 @@ public class TestContextName {
         cn21 = new ContextName("foo.war", false);
         cn22 = new ContextName("foo.war", true);
         cn23 = new ContextName("foo##1.0.0", false);
-        cn24 = new ContextName("foo##1.2.3", false);
-        cn25 = new ContextName("foo##1.2.12", false);
-        cn26 = new ContextName("foo##10.1.0", false);
+        cn24 = new ContextName("foo##1.2.beta2", false);
+        cn25 = new ContextName("foo##1.2.3.pre4", false);
+        cn26 = new ContextName("foo##1.2.3-SNAPSHOT", false);
+        cn27 = new ContextName("foo##1.2.3", false);
+        cn28 = new ContextName("foo##1.2.12", false);
+        cn29 = new ContextName("foo##10.1.0", false);
     }
 
     @Test
@@ -236,25 +245,30 @@ public class TestContextName {
         doTestConstructorString(cn22);
     }
 
-    @SuppressWarnings("EqualsWithItself")
+    @SuppressWarnings("unchecked")
     @Test
     public void testCompareTo() {
-        Assert.assertEquals(0, cn23.compareTo(cn23));
-        Assert.assertEquals(-2, cn23.compareTo(cn24));
-        Assert.assertEquals(-2, cn23.compareTo(cn25));
-        Assert.assertEquals(2, cn24.compareTo(cn23));
-        Assert.assertEquals(0, cn24.compareTo(cn24));
-        Assert.assertEquals(-9, cn24.compareTo(cn25));
-        Assert.assertEquals(2, cn25.compareTo(cn23));
-        Assert.assertEquals(9, cn25.compareTo(cn24));
-        Assert.assertEquals(0, cn25.compareTo(cn25));
-        Assert.assertEquals(9, cn26.compareTo(cn23));
-        Assert.assertEquals(9, cn26.compareTo(cn24));
-        Assert.assertEquals(0, cn26.compareTo(cn26));
+        ArrayList<ContextName> contextNames = new ArrayList<>();
+        contextNames.add(cn23);
+        contextNames.add(cn25);
+        contextNames.add(cn27);
+        contextNames.add(cn24);
+        contextNames.add(cn23);
+        contextNames.add(cn26);
+        contextNames.add(cn24);
+        contextNames.add(cn28);
+        contextNames.add(cn29);
+        contextNames.sort(Comparator.naturalOrder());
 
-        Assert.assertEquals(-4, cn23.compareTo(cn13));
-        Assert.assertEquals(-4, cn24.compareTo(cn13));
-        Assert.assertEquals(-4, cn25.compareTo(cn13));
+        Assert.assertEquals(contextNames.get(0), cn23);
+        Assert.assertEquals(contextNames.get(1), cn23);
+        Assert.assertEquals(contextNames.get(2), cn24);
+        Assert.assertEquals(contextNames.get(3), cn24);
+        Assert.assertEquals(contextNames.get(4), cn25);
+        Assert.assertEquals(contextNames.get(5), cn26);
+        Assert.assertEquals(contextNames.get(6), cn27);
+        Assert.assertEquals(contextNames.get(7), cn28);
+        Assert.assertEquals(contextNames.get(8), cn29);
     }
 
     private void doTestConstructorString(ContextName src) {

--- a/test/org/apache/catalina/util/TestContextName.java
+++ b/test/org/apache/catalina/util/TestContextName.java
@@ -48,6 +48,7 @@ public class TestContextName {
     private ContextName cn23;
     private ContextName cn24;
     private ContextName cn25;
+    private ContextName cn26;
 
     @Before
     public void setUp() throws Exception {
@@ -76,6 +77,7 @@ public class TestContextName {
         cn23 = new ContextName("foo##1.0.0", false);
         cn24 = new ContextName("foo##1.2.3", false);
         cn25 = new ContextName("foo##1.2.12", false);
+        cn26 = new ContextName("foo##10.1.0", false);
     }
 
     @Test
@@ -246,6 +248,9 @@ public class TestContextName {
         Assert.assertEquals(2, cn25.compareTo(cn23));
         Assert.assertEquals(9, cn25.compareTo(cn24));
         Assert.assertEquals(0, cn25.compareTo(cn25));
+        Assert.assertEquals(9, cn26.compareTo(cn23));
+        Assert.assertEquals(9, cn26.compareTo(cn24));
+        Assert.assertEquals(0, cn26.compareTo(cn26));
 
         Assert.assertEquals(-4, cn23.compareTo(cn13));
         Assert.assertEquals(-4, cn24.compareTo(cn13));

--- a/test/org/apache/catalina/util/TestContextName.java
+++ b/test/org/apache/catalina/util/TestContextName.java
@@ -45,6 +45,9 @@ public class TestContextName {
     private ContextName cn20;
     private ContextName cn21;
     private ContextName cn22;
+    private ContextName cn23;
+    private ContextName cn24;
+    private ContextName cn25;
 
     @Before
     public void setUp() throws Exception {
@@ -70,6 +73,9 @@ public class TestContextName {
         cn20 = new ContextName("/ROOT##A", false);
         cn21 = new ContextName("foo.war", false);
         cn22 = new ContextName("foo.war", true);
+        cn23 = new ContextName("foo##1.0.0", false);
+        cn24 = new ContextName("foo##1.2.3", false);
+        cn25 = new ContextName("foo##1.2.12", false);
     }
 
     @Test
@@ -226,6 +232,24 @@ public class TestContextName {
         doTestConstructorString(cn20);
         doTestConstructorString(cn21);
         doTestConstructorString(cn22);
+    }
+
+    @SuppressWarnings("EqualsWithItself")
+    @Test
+    public void testCompareTo() {
+        Assert.assertEquals(0, cn23.compareTo(cn23));
+        Assert.assertEquals(-1, cn23.compareTo(cn24));
+        Assert.assertEquals(-1, cn23.compareTo(cn25));
+        Assert.assertEquals(1, cn24.compareTo(cn23));
+        Assert.assertEquals(0, cn24.compareTo(cn24));
+        Assert.assertEquals(-1, cn24.compareTo(cn25));
+        Assert.assertEquals(1, cn25.compareTo(cn23));
+        Assert.assertEquals(1, cn25.compareTo(cn24));
+        Assert.assertEquals(0, cn25.compareTo(cn25));
+
+        Assert.assertEquals(-4, cn23.compareTo(cn13));
+        Assert.assertEquals(-4, cn24.compareTo(cn13));
+        Assert.assertEquals(-4, cn25.compareTo(cn13));
     }
 
     private void doTestConstructorString(ContextName src) {

--- a/test/org/apache/catalina/util/TestContextName.java
+++ b/test/org/apache/catalina/util/TestContextName.java
@@ -238,13 +238,13 @@ public class TestContextName {
     @Test
     public void testCompareTo() {
         Assert.assertEquals(0, cn23.compareTo(cn23));
-        Assert.assertEquals(-1, cn23.compareTo(cn24));
-        Assert.assertEquals(-1, cn23.compareTo(cn25));
-        Assert.assertEquals(1, cn24.compareTo(cn23));
+        Assert.assertEquals(-2, cn23.compareTo(cn24));
+        Assert.assertEquals(-2, cn23.compareTo(cn25));
+        Assert.assertEquals(2, cn24.compareTo(cn23));
         Assert.assertEquals(0, cn24.compareTo(cn24));
-        Assert.assertEquals(-1, cn24.compareTo(cn25));
-        Assert.assertEquals(1, cn25.compareTo(cn23));
-        Assert.assertEquals(1, cn25.compareTo(cn24));
+        Assert.assertEquals(-9, cn24.compareTo(cn25));
+        Assert.assertEquals(2, cn25.compareTo(cn23));
+        Assert.assertEquals(9, cn25.compareTo(cn24));
         Assert.assertEquals(0, cn25.compareTo(cn25));
 
         Assert.assertEquals(-4, cn23.compareTo(cn13));


### PR DESCRIPTION
Main reason for this pull request is to improve automatic undeployment of applications when using common version numbers, e.g. `application##1.2.3`.

Currently, `HostConfig#checkUndeploy()` uses plain sorting of the context names without any special handling of the version identifier. When having a version `1.0.9` deployed, deploying `1.0.10` will lead to immediate undeployment of `1.0.10` because the ordering is wrong.

This change introduces `ContextName#compareTo()` which knows how to handle commons version numbers.