### PR TITLE
Debug log for pool's db properties

### DIFF
--- a/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/PooledConnection.java
+++ b/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/PooledConnection.java
@@ -20,6 +20,7 @@ package org.apache.tomcat.jdbc.pool;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -311,7 +312,9 @@ public class PooledConnection implements PooledConnectionMBean {
         Properties properties = PoolUtilities.clone(poolProperties.getDbProperties());
         if (usr != null) properties.setProperty(PROP_USER, usr);
         if (pwd != null) properties.setProperty(PROP_PASSWORD, pwd);
-
+        if (log.isDebugEnabled()) {
+			debugProperties("Database properties",properties);
+		}
         try {
             if (driver==null) {
                 connection = DriverManager.getConnection(driverURL, properties);
@@ -339,6 +342,23 @@ public class PooledConnection implements PooledConnectionMBean {
         }
     }
 
+	private void debugProperties(String description, Properties properties) {
+		StringBuilder sb = new StringBuilder();
+		Enumeration<?> propertyNames = properties.propertyNames();
+		while (propertyNames.hasMoreElements()){
+			Object propertyName = propertyNames.nextElement();
+			if (propertyName instanceof String){
+				String sPropertyName = (String) propertyName;
+				sb.append(sPropertyName).append("=").append(
+						sPropertyName.equalsIgnoreCase(PROP_PASSWORD)?"********":properties.getProperty(sPropertyName)
+				).append(", ");
+			} else {
+				sb.append(propertyName).append("=<???>, ");
+			}
+		}
+		log.debug(description+": {"+sb.toString()+"}");
+	}
+    
     /**
      *
      * @return true if connect() was called successfully and disconnect has not yet been called

--- a/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/PooledConnection.java
+++ b/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/PooledConnection.java
@@ -313,8 +313,8 @@ public class PooledConnection implements PooledConnectionMBean {
         if (usr != null) properties.setProperty(PROP_USER, usr);
         if (pwd != null) properties.setProperty(PROP_PASSWORD, pwd);
         if (log.isDebugEnabled()) {
-			debugProperties("Database properties",properties);
-		}
+            debugProperties("Database properties",properties);
+        }
         try {
             if (driver==null) {
                 connection = DriverManager.getConnection(driverURL, properties);
@@ -342,22 +342,22 @@ public class PooledConnection implements PooledConnectionMBean {
         }
     }
 
-	private void debugProperties(String description, Properties properties) {
-		StringBuilder sb = new StringBuilder();
-		Enumeration<?> propertyNames = properties.propertyNames();
-		while (propertyNames.hasMoreElements()){
-			Object propertyName = propertyNames.nextElement();
-			if (propertyName instanceof String){
-				String sPropertyName = (String) propertyName;
-				sb.append(sPropertyName).append("=").append(
-						sPropertyName.equalsIgnoreCase(PROP_PASSWORD)?"********":properties.getProperty(sPropertyName)
-				).append(", ");
-			} else {
-				sb.append(propertyName).append("=<???>, ");
-			}
-		}
-		log.debug(description+": {"+sb.toString()+"}");
-	}
+    private void debugProperties(String description, Properties properties) {
+        StringBuilder sb = new StringBuilder();
+        Enumeration<?> propertyNames = properties.propertyNames();
+        while (propertyNames.hasMoreElements()){
+            Object propertyName = propertyNames.nextElement();
+            if (propertyName instanceof String){
+                String sPropertyName = (String) propertyName;
+                sb.append(sPropertyName).append("=").append(
+                        sPropertyName.equalsIgnoreCase(PROP_PASSWORD)?"********":properties.getProperty(sPropertyName)
+                ).append(", ");
+            } else {
+                sb.append(propertyName).append("=<???>, ");
+            }
+        }
+        log.debug(description+": {"+sb.toString()+"}");
+    }
     
     /**
      *


### PR DESCRIPTION
I found that all non-string values are ignored by [java.util.Properties.java](https://github.com/JetBrains/jdk8u_jdk/blob/master/src/share/classes/java/util/Properties.java#L970) and sometime we don't know what exactly properties are passed to the driver. 
The way to log these properties out would be helpful...

For example yaml:
- ` db-properties.oracle.net.CONNECT_TIMEOUT: "30000"` - works
- ` db-properties.oracle.net.CONNECT_TIMEOUT: 30000` - doesn't work :(