### PR TITLE
Remove throws declaration of an exception which is not thrown

### DIFF
--- a/java/org/apache/catalina/startup/Tomcat.java
+++ b/java/org/apache/catalina/startup/Tomcat.java
@@ -218,9 +218,8 @@ public class Tomcat {
      * @param docBase Base directory for the context, for static files.
      *  Must exist, relative to the server home
      * @return the deployed context
-     * @throws ServletException if a deployment error occurs
      */
-    public Context addWebapp(String contextPath, String docBase) throws ServletException {
+    public Context addWebapp(String contextPath, String docBase) {
         return addWebapp(getHost(), contextPath, docBase);
     }
 


### PR DESCRIPTION
ServletException is a checked exception and it is not thrown by any method invoked by this method.

Declaring it, makes user code more complex for no need