### PR TITLE
Setting Timezone to GMT for Expires Header as per RFC1123

### DIFF
--- a/java/org/apache/catalina/authenticator/AuthenticatorBase.java
+++ b/java/org/apache/catalina/authenticator/AuthenticatorBase.java
@@ -19,12 +19,14 @@ package org.apache.catalina.authenticator;
 import java.io.IOException;
 import java.security.Principal;
 import java.security.cert.X509Certificate;
+import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TimeZone;
 
 import javax.security.auth.Subject;
 import javax.security.auth.callback.CallbackHandler;
@@ -91,12 +93,25 @@ public abstract class AuthenticatorBase extends ValveBase
         implements Authenticator, RegistrationListener {
 
     private final Log log = LogFactory.getLog(AuthenticatorBase.class); // must not be static
-
+    
+    /**
+     * Date format object for setting Expires header
+     */
+    private static final DateFormat RFC1123_FORMAT;
+    
+    /**
+     * Pattern following the RFC1123
+     */
+    private static final String RFC1123_PATTERN = "EEE, dd MMM yyyy HH:mm:ss z";
+    
+	static {
+		RFC1123_FORMAT = new SimpleDateFormat(RFC1123_PATTERN, Locale.US);
+		RFC1123_FORMAT.setTimeZone(TimeZone.getTimeZone("GMT"));
+	}
     /**
      * "Expires" header always set to Date(1), so generate once only
      */
-    private static final String DATE_ONE =
-            (new SimpleDateFormat(FastHttpDateFormat.RFC1123_DATE, Locale.US)).format(new Date(1));
+	private static final String DATE_ONE = RFC1123_FORMAT.format(new Date(1));
 
     /**
      * The string manager for this package.


### PR DESCRIPTION
Tomcat response header 'Expires' is getting formatted into timezone based string and not just 'GMT' as specified under RFC 1123.

I was facing issues with cache reload for my webapp specifically in Chrome and found out the response headers were like Cache-Control:private and Expires:Thu, 01 Jan 1970 05:30:00 IST

I searched for few threads and found browsers only understand GMT.

I've used the same code and format as used for setting Last-Modified as per the tomcat source code.

