### PR TITLE
Always store the authenticated Subject on the Request

### DIFF
--- a/java/org/apache/catalina/authenticator/AuthenticatorBase.java
+++ b/java/org/apache/catalina/authenticator/AuthenticatorBase.java
@@ -810,7 +810,6 @@ public abstract class AuthenticatorBase extends ValveBase
                     !principal.getUserPrincipal().equals(request.getUserPrincipal())) {
                 // Skip registration if authentication credentials were
                 // cached and the Principal did not change.
-                request.setNote(Constants.REQ_JASPIC_SUBJECT_NOTE, client);
                 @SuppressWarnings("rawtypes")// JASPIC API uses raw types
                 Map map = state.messageInfo.getMap();
                 if (map != null && map.containsKey("javax.servlet.http.registerSession")) {
@@ -819,6 +818,7 @@ public abstract class AuthenticatorBase extends ValveBase
                     register(request, response, principal, "JASPIC", null, null);
                 }
             }
+            request.setNote(Constants.REQ_JASPIC_SUBJECT_NOTE, client);
             return true;
         }
         return false;


### PR DESCRIPTION
Client Subject needs to be stored on the request even when the authentication data was cached. Fixes https://bz.apache.org/bugzilla/show_bug.cgi?id=62547

The issue is present on both Tomcat 8.5.X and 9.X and the fix should easily backported.