### PR TITLE
Fix typos detected by github.com/client9/misspell

### DIFF
--- a/java/javax/servlet/resources/XMLSchema.dtd
+++ b/java/javax/servlet/resources/XMLSchema.dtd
@@ -33,7 +33,7 @@
      are defined in XML Schema: Part 2: Datatypes -->
 <!ENTITY % xs-datatypes PUBLIC 'datatypes' 'datatypes.dtd' >
 
-<!ENTITY % p 'xs:'> <!-- can be overriden in the internal subset of a
+<!ENTITY % p 'xs:'> <!-- can be overridden in the internal subset of a
                          schema document to establish a different
                          namespace prefix -->
 <!ENTITY % s ':xs'> <!-- if %p is defined (e.g. as foo:) then you must
@@ -170,7 +170,7 @@
           %complexTypeAttrs;>
 
 <!-- particleAndAttrs is shorthand for a root type -->
-<!-- mixed is disallowed if simpleContent, overriden if complexContent
+<!-- mixed is disallowed if simpleContent, overridden if complexContent
      has one too. -->
 
 <!-- If anyAttribute appears in one or more referenced attributeGroups

--- a/java/javax/servlet/resources/j2ee_web_services_client_1_1.xsd
+++ b/java/javax/servlet/resources/j2ee_web_services_client_1_1.xsd
@@ -188,7 +188,7 @@
           <xsd:documentation>
 
             The service-qname element declares the specific WSDL service
-            element that is being refered to.  It is not specified if no
+            element that is being referred to.  It is not specified if no
             wsdl-file is declared.
 
           </xsd:documentation>

--- a/java/javax/servlet/resources/javaee_web_services_client_1_2.xsd
+++ b/java/javax/servlet/resources/javaee_web_services_client_1_2.xsd
@@ -260,7 +260,7 @@
           <xsd:documentation>
 
             The service-qname element declares the specific WSDL service
-            element that is being refered to.  It is not specified if no
+            element that is being referred to.  It is not specified if no
             wsdl-file is declared.
 
           </xsd:documentation>

--- a/java/javax/servlet/resources/javaee_web_services_client_1_3.xsd
+++ b/java/javax/servlet/resources/javaee_web_services_client_1_3.xsd
@@ -170,7 +170,7 @@
           <xsd:documentation>
 
             The service-qname element declares the specific WSDL service
-            element that is being refered to.  It is not specified if no
+            element that is being referred to.  It is not specified if no
             wsdl-file is declared.
 
           </xsd:documentation>

--- a/java/javax/servlet/resources/javaee_web_services_client_1_4.xsd
+++ b/java/javax/servlet/resources/javaee_web_services_client_1_4.xsd
@@ -166,7 +166,7 @@
           <xsd:documentation>
 
             The service-qname element declares the specific WSDL service
-            element that is being refered to.  It is not specified if no
+            element that is being referred to.  It is not specified if no
             wsdl-file is declared.
 
           </xsd:documentation>

--- a/java/javax/servlet/resources/web-app_3_0.xsd
+++ b/java/javax/servlet/resources/web-app_3_0.xsd
@@ -126,7 +126,7 @@
         file must not contain multiple elements of session-config,
         jsp-config, and login-config. When there are multiple elements of
         welcome-file-list or locale-encoding-mapping-list, the container
-        must concatenate the element contents.  The multiple occurence
+        must concatenate the element contents.  The multiple occurrence
         of the element distributable is redundant and the container
         treats that case exactly in the same way when there is only
         one distributable.

--- a/java/javax/servlet/resources/web-app_3_1.xsd
+++ b/java/javax/servlet/resources/web-app_3_1.xsd
@@ -126,7 +126,7 @@
         file must not contain multiple elements of session-config,
         jsp-config, and login-config. When there are multiple elements of
         welcome-file-list or locale-encoding-mapping-list, the container
-        must concatenate the element contents.  The multiple occurence
+        must concatenate the element contents.  The multiple occurrence
         of the element distributable is redundant and the container
         treats that case exactly in the same way when there is only
         one distributable.

--- a/java/javax/servlet/resources/web-app_4_0.xsd
+++ b/java/javax/servlet/resources/web-app_4_0.xsd
@@ -122,7 +122,7 @@
         file must not contain multiple elements of session-config,
         jsp-config, and login-config. When there are multiple elements of
         welcome-file-list or locale-encoding-mapping-list, the container
-        must concatenate the element contents.  The multiple occurence
+        must concatenate the element contents.  The multiple occurrence
         of the element distributable is redundant and the container
         treats that case exactly in the same way when there is only
         one distributable.

--- a/java/javax/servlet/resources/web-fragment_3_0.xsd
+++ b/java/javax/servlet/resources/web-fragment_3_0.xsd
@@ -126,7 +126,7 @@
         file must not contain multiple elements of session-config,
         jsp-config, and login-config. When there are multiple elements of
         welcome-file-list or locale-encoding-mapping-list, the container
-        must concatenate the element contents.  The multiple occurence
+        must concatenate the element contents.  The multiple occurrence
         of the element distributable is redundant and the container
         treats that case exactly in the same way when there is only
         one distributable.

--- a/java/javax/servlet/resources/web-fragment_3_1.xsd
+++ b/java/javax/servlet/resources/web-fragment_3_1.xsd
@@ -126,7 +126,7 @@
         file must not contain multiple elements of session-config,
         jsp-config, and login-config. When there are multiple elements of
         welcome-file-list or locale-encoding-mapping-list, the container
-        must concatenate the element contents.  The multiple occurence
+        must concatenate the element contents.  The multiple occurrence
         of the element distributable is redundant and the container
         treats that case exactly in the same way when there is only
         one distributable.

--- a/java/javax/servlet/resources/web-fragment_4_0.xsd
+++ b/java/javax/servlet/resources/web-fragment_4_0.xsd
@@ -122,7 +122,7 @@
         file must not contain multiple elements of session-config,
         jsp-config, and login-config. When there are multiple elements of
         welcome-file-list or locale-encoding-mapping-list, the container
-        must concatenate the element contents.  The multiple occurence
+        must concatenate the element contents.  The multiple occurrence
         of the element distributable is redundant and the container
         treats that case exactly in the same way when there is only
         one distributable.

--- a/java/javax/servlet/resources/web-jsptaglibrary_1_1.dtd
+++ b/java/javax/servlet/resources/web-jsptaglibrary_1_1.dtd
@@ -35,7 +35,7 @@ jspversion  the version of JSP the tag library depends upon
 
 shortname   a simple default short name that could be used by
             a JSP authoring tool to create names with a mnemonic
-            value; for example, the it may be used as the prefered
+            value; for example, the it may be used as the preferred
             prefix value in taglib directives
 uri         a uri uniquely identifying this taglib
 info        a simple string describing the "use" of this taglib,

--- a/java/javax/servlet/resources/web-jsptaglibrary_1_2.dtd
+++ b/java/javax/servlet/resources/web-jsptaglibrary_1_2.dtd
@@ -50,7 +50,7 @@ jsp-version     the version of JSP the tag library depends upon
 
 short-name      a simple default short name that could be used by
                 a JSP authoring tool to create names with a mnemonic
-                value; for example, the it may be used as the prefered
+                value; for example, the it may be used as the preferred
                 prefix value in taglib directives
 
 uri             a uri uniquely identifying this taglib

--- a/java/javax/servlet/resources/web-jsptaglibrary_2_0.xsd
+++ b/java/javax/servlet/resources/web-jsptaglibrary_2_0.xsd
@@ -682,7 +682,7 @@
         short-name      a simple default short name that could be
                         used by a JSP authoring tool to create
                         names with a mnemonic value; for example,
-                        the it may be used as the prefered prefix
+                        the it may be used as the preferred prefix
                         value in taglib directives
 
         uri             a uri uniquely identifying this taglib

--- a/java/org/apache/catalina/connector/CoyoteInputStream.java
+++ b/java/org/apache/catalina/connector/CoyoteInputStream.java
@@ -138,7 +138,7 @@ public class CoyoteInputStream extends ServletInputStream {
      * Transfers bytes from the buffer to the specified ByteBuffer. After the
      * operation the position of the ByteBuffer will be returned to the one
      * before the operation, the limit will be the position incremented by
-     * the number of the transfered bytes.
+     * the number of the transferred bytes.
      *
      * @param b the ByteBuffer into which bytes are to be written.
      * @return an integer specifying the actual number of bytes read, or -1 if

--- a/java/org/apache/catalina/connector/InputBuffer.java
+++ b/java/org/apache/catalina/connector/InputBuffer.java
@@ -351,7 +351,7 @@ public class InputBuffer extends Reader
      * Transfers bytes from the buffer to the specified ByteBuffer. After the
      * operation the position of the ByteBuffer will be returned to the one
      * before the operation, the limit will be the position incremented by
-     * the number of the transfered bytes.
+     * the number of the transferred bytes.
      *
      * @param to the ByteBuffer into which bytes are to be written.
      * @return an integer specifying the actual number of bytes read, or -1 if

--- a/java/org/apache/catalina/filters/ExpiresFilter.java
+++ b/java/org/apache/catalina/filters/ExpiresFilter.java
@@ -1170,7 +1170,7 @@ public class ExpiresFilter extends FilterBase {
 
     /**
      * @return the subset of the given {@code str} that is before the first
-     * occurence of the given {@code separator}. Return {@code null}
+     * occurrence of the given {@code separator}. Return {@code null}
      * if the given {@code str} or the given {@code separator} is
      * null. Return and empty string if the {@code separator} is empty.
      *

--- a/java/org/apache/catalina/ha/session/DeltaManager.java
+++ b/java/org/apache/catalina/ha/session/DeltaManager.java
@@ -296,7 +296,7 @@ public class DeltaManager extends ClusterManagerBase{
     }
 
     /**
-     * Set that state transfered is complete
+     * Set that state transferred is complete
      * @param stateTransfered Fag value
      */
     public void setStateTransfered(boolean stateTransfered) {
@@ -802,8 +802,8 @@ public class DeltaManager extends ClusterManagerBase{
     }
 
     /**
-     * Wait that cluster session state is transfered or timeout after 60 Sec
-     * With stateTransferTimeout == -1 wait that backup is transfered (forever mode)
+     * Wait that cluster session state is transferred or timeout after 60 Sec
+     * With stateTransferTimeout == -1 wait that backup is transferred (forever mode)
      * @param beforeSendTime Start instant of the operation
      */
     protected void waitForSendAllSessions(long beforeSendTime) {
@@ -811,7 +811,7 @@ public class DeltaManager extends ClusterManagerBase{
         long reqNow = reqStart ;
         boolean isTimeout = false;
         if(getStateTransferTimeout() > 0) {
-            // wait that state is transfered with timeout check
+            // wait that state is transferred with timeout check
             do {
                 try {
                     Thread.sleep(100);
@@ -823,7 +823,7 @@ public class DeltaManager extends ClusterManagerBase{
             } while ((!getStateTransfered()) && (!isTimeout) && (!isNoContextManagerReceived()));
         } else {
             if(getStateTransferTimeout() == -1) {
-                // wait that state is transfered
+                // wait that state is transferred
                 do {
                     try {
                         Thread.sleep(100);
@@ -1197,7 +1197,7 @@ public class DeltaManager extends ClusterManagerBase{
 
 
     /**
-     * handle receive session state is complete transfered
+     * handle receive session state is complete transferred
      * @param msg Session message
      * @param sender Member which sent the message
      */
@@ -1331,7 +1331,7 @@ public class DeltaManager extends ClusterManagerBase{
      * handle receive that other node want all sessions ( restart )
      * a) send all sessions with one message
      * b) send session at blocks
-     * After sending send state is complete transfered
+     * After sending send state is complete transferred
      * @param msg Session message
      * @param sender Member which sent the message
      * @throws IOException IO error sending messages
@@ -1369,8 +1369,8 @@ public class DeltaManager extends ClusterManagerBase{
         }//end if
 
         SessionMessage newmsg = new SessionMessageImpl(name,
-                SessionMessage.EVT_ALL_SESSION_TRANSFERCOMPLETE, null, "SESSION-STATE-TRANSFERED",
-                "SESSION-STATE-TRANSFERED" + getName());
+                SessionMessage.EVT_ALL_SESSION_TRANSFERCOMPLETE, null, "SESSION-STATE-TRANSFERRED",
+                "SESSION-STATE-TRANSFERRED" + getName());
         newmsg.setTimestamp(findSessionTimestamp);
         if (log.isDebugEnabled()) {
             log.debug(sm.getString("deltaManager.createMessage.allSessionTransfered",getName()));

--- a/java/org/apache/catalina/ha/session/SessionMessageImpl.java
+++ b/java/org/apache/catalina/ha/session/SessionMessageImpl.java
@@ -71,7 +71,7 @@ public class SessionMessageImpl extends ClusterMessageBase implements SessionMes
      * <B>EVT_ALL_SESSION_DATA</B><BR>
      *    Send complete serializes session list<BR>
      * <B>EVT_ALL_SESSION_TRANSFERCOMPLETE</B><BR>
-     *    send that all session state information are transfered
+     *    send that all session state information are transferred
      *    after GET_ALL_SESSION received from this sender.<BR>
      * <B>EVT_CHANGE_SESSION_ID</B><BR>
      *    send original sessionID and new sessionID.<BR>
@@ -144,7 +144,7 @@ public class SessionMessageImpl extends ClusterMessageBase implements SessionMes
             case EVT_GET_ALL_SESSIONS : return "SESSION-GET-ALL";
             case EVT_SESSION_DELTA : return "SESSION-DELTA";
             case EVT_ALL_SESSION_DATA : return "ALL-SESSION-DATA";
-            case EVT_ALL_SESSION_TRANSFERCOMPLETE : return "SESSION-STATE-TRANSFERED";
+            case EVT_ALL_SESSION_TRANSFERCOMPLETE : return "SESSION-STATE-TRANSFERRED";
             case EVT_CHANGE_SESSION_ID : return "SESSION-ID-CHANGED";
             case EVT_ALL_SESSION_NOCONTEXTMANAGER : return "NO-CONTEXT-MANAGER";
             default : return "UNKNOWN-EVENT-TYPE";

--- a/java/org/apache/catalina/ha/session/mbeans-descriptors.xml
+++ b/java/org/apache/catalina/ha/session/mbeans-descriptors.xml
@@ -259,7 +259,7 @@
       writeable="false"/>
     <attribute
       name="stateTransfered"
-      description="Is session state transfered complete? "
+      description="Is session state transferred complete? "
       type="boolean"/>
     <attribute
       name="stateTransferTimeout"

--- a/java/org/apache/catalina/ha/tcp/SimpleTcpCluster.java
+++ b/java/org/apache/catalina/ha/tcp/SimpleTcpCluster.java
@@ -796,7 +796,7 @@ public class SimpleTcpCluster extends LifecycleMBeanBase
                 if (log.isDebugEnabled()) {
                     log.debug("Message " + message.toString() + " from type "
                             + message.getClass().getName()
-                            + " transfered but no listener registered");
+                            + " transferred but no listener registered");
                 }
             }
         }

--- a/java/org/apache/catalina/servlets/CGIServlet.java
+++ b/java/org/apache/catalina/servlets/CGIServlet.java
@@ -1161,7 +1161,7 @@ public final class CGIServlet extends HttpServlet {
                 sb.append(System.lineSeparator());
                 sb.append("Check the HttpServletRequest pathInfo property to see if it is what ");
                 sb.append(System.lineSeparator());
-                sb.append("you meant it to be. You must specify an existant and executable file ");
+                sb.append("you meant it to be. You must specify an existent and executable file ");
                 sb.append(System.lineSeparator());
                 sb.append("as part of the path-info.");
                 sb.append(System.lineSeparator());
@@ -1425,7 +1425,7 @@ public final class CGIServlet extends HttpServlet {
          * directory, and input/output streams
          *
          * <p>
-         * This implements the following CGI specification recommedations:
+         * This implements the following CGI specification recommendations:
          * </p>
          * <UL>
          * <LI> Servers SHOULD provide the "<code>query</code>" component of

--- a/java/org/apache/catalina/storeconfig/StandardContextSF.java
+++ b/java/org/apache/catalina/storeconfig/StandardContextSF.java
@@ -161,7 +161,7 @@ public class StandardContextSF extends StoreFactoryBase {
                             !mover.getConfigOld().canWrite())) {
                 log.error("Cannot move orignal context output file at "
                         + mover.getConfigOld());
-                throw new IOException("Context orginal file at "
+                throw new IOException("Context original file at "
                         + mover.getConfigOld()
                         + " is null, not a file or not writable.");
             }

--- a/java/org/apache/catalina/storeconfig/StoreAppender.java
+++ b/java/org/apache/catalina/storeconfig/StoreAppender.java
@@ -292,7 +292,7 @@ public class StoreAppender {
      * Determine if the attribute value needs to be stored.
      *
      * @param bean
-     *            orginal bean
+     *            original bean
      * @param bean2
      *            default bean
      * @param attrName

--- a/java/org/apache/catalina/tribes/transport/bio/BioSender.java
+++ b/java/org/apache/catalina/tribes/transport/bio/BioSender.java
@@ -101,7 +101,7 @@ public class BioSender extends AbstractSender {
      * Send message.
      * @param data The data to send
      * @param waitForAck Wait for an ack
-     * @throws IOException An IO error occured sending the message
+     * @throws IOException An IO error occurred sending the message
      */
     public  void sendMessage(byte[] data, boolean waitForAck) throws IOException {
         IOException exception = null;

--- a/java/org/apache/catalina/users/mbeans-descriptors.xml
+++ b/java/org/apache/catalina/users/mbeans-descriptors.xml
@@ -43,7 +43,7 @@
             writeable="false"/>
 
     <attribute   name="readonly"
-          description="No persistant save of the user database"
+          description="No persistent save of the user database"
                  type="boolean"
             writeable="false"/>
 

--- a/java/org/apache/catalina/valves/StuckThreadDetectionValve.java
+++ b/java/org/apache/catalina/valves/StuckThreadDetectionValve.java
@@ -353,7 +353,7 @@ public class StuckThreadDetectionValve extends ValveBase {
                 // no need to release the semaphore, it will be GCed
             }
             //else the request went through before being marked as stuck, no need
-            //to sync agains the semaphore
+            //to sync against the semaphore
             return threadState;
         }
 

--- a/java/org/apache/coyote/Response.java
+++ b/java/org/apache/coyote/Response.java
@@ -98,7 +98,7 @@ public final class Response {
     /**
      * Committed flag.
      */
-    volatile boolean commited = false;
+    volatile boolean committed = false;
 
 
     /**
@@ -252,15 +252,15 @@ public final class Response {
 
 
     public boolean isCommitted() {
-        return commited;
+        return committed;
     }
 
 
     public void setCommitted(boolean v) {
-        if (v && !this.commited) {
+        if (v && !this.committed) {
             this.commitTime = System.currentTimeMillis();
         }
-        this.commited = v;
+        this.committed = v;
     }
 
     /**
@@ -333,7 +333,7 @@ public final class Response {
 
     public void reset() throws IllegalStateException {
 
-        if (commited) {
+        if (committed) {
             throw new IllegalStateException();
         }
 
@@ -612,7 +612,7 @@ public final class Response {
         contentLength = -1;
         status = 200;
         message = null;
-        commited = false;
+        committed = false;
         commitTime = -1;
         errorException = null;
         errorState.set(0);

--- a/java/org/apache/tomcat/dbcp/dbcp2/DriverManagerConnectionFactory.java
+++ b/java/org/apache/tomcat/dbcp/dbcp2/DriverManagerConnectionFactory.java
@@ -47,7 +47,7 @@ public class DriverManagerConnectionFactory implements ConnectionFactory {
      */
     public DriverManagerConnectionFactory(final String connectionUri) {
         this.connectionUri = connectionUri;
-        this.propeties = new Properties();
+        this.properties = new Properties();
     }
 
     /**
@@ -61,7 +61,7 @@ public class DriverManagerConnectionFactory implements ConnectionFactory {
      */
     public DriverManagerConnectionFactory(final String connectionUri, final Properties properties) {
         this.connectionUri = connectionUri;
-        this.propeties = properties;
+        this.properties = properties;
     }
 
     /**
@@ -83,17 +83,17 @@ public class DriverManagerConnectionFactory implements ConnectionFactory {
 
     @Override
     public Connection createConnection() throws SQLException {
-        if (null == propeties) {
+        if (null == properties) {
             if (userName == null && userPassword == null) {
                 return DriverManager.getConnection(connectionUri);
             }
             return DriverManager.getConnection(connectionUri, userName, userPassword);
         }
-        return DriverManager.getConnection(connectionUri, propeties);
+        return DriverManager.getConnection(connectionUri, properties);
     }
 
     private final String connectionUri;
     private String userName;
     private String userPassword;
-    private Properties propeties;
+    private Properties properties;
 }

--- a/java/org/apache/tomcat/dbcp/dbcp2/managed/ManagedConnection.java
+++ b/java/org/apache/tomcat/dbcp/dbcp2/managed/ManagedConnection.java
@@ -1,4 +1,4 @@
-/**
+vi /**
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -204,7 +204,7 @@ public class ManagedConnection<C extends Connection> extends DelegatingConnectio
      */
     protected class CompletionListener implements TransactionContextListener {
         @Override
-        public void afterCompletion(final TransactionContext completedContext, final boolean commited) {
+        public void afterCompletion(final TransactionContext completedContext, final boolean committed) {
             if (completedContext == transactionContext) {
                 transactionComplete();
             }

--- a/java/org/apache/tomcat/dbcp/dbcp2/managed/TransactionContext.java
+++ b/java/org/apache/tomcat/dbcp/dbcp2/managed/TransactionContext.java
@@ -67,7 +67,7 @@ public class TransactionContext {
     }
 
     /**
-     * Provided for backwards compatability
+     * Provided for backwards compatibility
      *
      * @param transactionRegistry the TransactionRegistry used to obtain the XAResource for the
      * shared connection

--- a/java/org/apache/tomcat/dbcp/dbcp2/managed/TransactionContextListener.java
+++ b/java/org/apache/tomcat/dbcp/dbcp2/managed/TransactionContextListener.java
@@ -28,8 +28,8 @@ public interface TransactionContextListener {
      *
      * @param transactionContext
      *            the transaction context that completed
-     * @param commited
+     * @param committed
      *            true if the transaction committed; false otherwise
      */
-    void afterCompletion(TransactionContext transactionContext, boolean commited);
+    void afterCompletion(TransactionContext transactionContext, boolean committed);
 }

--- a/java/org/apache/tomcat/dbcp/dbcp2/managed/TransactionRegistry.java
+++ b/java/org/apache/tomcat/dbcp/dbcp2/managed/TransactionRegistry.java
@@ -61,7 +61,7 @@ public class TransactionRegistry {
     }
 
     /**
-     * Provided for backwards compatability
+     * Provided for backwards compatibility
      * @param transactionManager the transaction manager used to enlist connections
      */
     public TransactionRegistry(final TransactionManager transactionManager) {

--- a/java/org/apache/tomcat/util/bcel/classfile/ClassParser.java
+++ b/java/org/apache/tomcat/util/bcel/classfile/ClassParser.java
@@ -29,7 +29,7 @@ import org.apache.tomcat.util.bcel.Const;
  * Wrapper class that parses a given Java .class file. The method <A
  * href ="#parse">parse</A> returns a <A href ="JavaClass.html">
  * JavaClass</A> object on success. When an I/O error or an
- * inconsistency occurs an appropiate exception is propagated back to
+ * inconsistency occurs an appropriate exception is propagated back to
  * the caller.
  *
  * The structure and the names comply, except for a few conveniences,
@@ -141,7 +141,7 @@ public final class ClassParser {
      */
     private void readClassInfo() throws IOException, ClassFormatException {
         access_flags = dataInputStream.readUnsignedShort();
-        /* Interfaces are implicitely abstract, the flag should be set
+        /* Interfaces are implicitly abstract, the flag should be set
          * according to the JVM specification.
          */
         if ((access_flags & Const.ACC_INTERFACE) != 0) {

--- a/java/org/apache/tomcat/util/digester/RulesBase.java
+++ b/java/org/apache/tomcat/util/digester/RulesBase.java
@@ -97,7 +97,7 @@ public class RulesBase implements Rules {
      */
     @Override
     public void add(String pattern, Rule rule) {
-        // to help users who accidently add '/' to the end of their patterns
+        // to help users who accidentally add '/' to the end of their patterns
         int patternLength = pattern.length();
         if (patternLength>1 && pattern.endsWith("/")) {
             pattern = pattern.substring(0, patternLength-1);

--- a/java/org/apache/tomcat/util/digester/package.html
+++ b/java/org/apache/tomcat/util/digester/package.html
@@ -1028,7 +1028,7 @@ can be downloaded.
 URLs may be local or remote but if the URL is chosen to be local, it is likely only
 to function correctly on a small number of machines (which are configured precisely
 to allow the xml to be parsed). This is usually unsatisfactory and so a universally
-accessable URL is preferred. This usually means an internet URL.
+accessible URL is preferred. This usually means an internet URL.
 </p>
 <p>
 To recap, in practice the <code><em>system-identifier</em></code> will (most likely) be an

--- a/java/org/apache/tomcat/util/http/fileupload/MultipartStream.java
+++ b/java/org/apache/tomcat/util/http/fileupload/MultipartStream.java
@@ -605,7 +605,7 @@ public class MultipartStream {
      * @throws IOException if an i/o error occurs.
      */
     public boolean skipPreamble() throws IOException {
-        // First delimiter may be not preceeded with a CRLF.
+        // First delimiter may be not preceded with a CRLF.
         System.arraycopy(boundary, 2, boundary, 0, boundary.length - 2);
         boundaryLength = boundary.length - 2;
         computeBoundaryTable();

--- a/java/org/apache/tomcat/util/http/fileupload/ParameterParser.java
+++ b/java/org/apache/tomcat/util/http/fileupload/ParameterParser.java
@@ -119,7 +119,7 @@ public class ParameterParser {
     /**
      * Tests if the given character is present in the array of characters.
      *
-     * @param ch the character to test for presense in the array of characters
+     * @param ch the character to test for presence in the array of characters
      * @param charray the array of characters to test against
      *
      * @return {@code true} if the character is present in the array of

--- a/java/org/apache/tomcat/util/net/SecureNioChannel.java
+++ b/java/org/apache/tomcat/util/net/SecureNioChannel.java
@@ -387,7 +387,7 @@ public class SecureNioChannel extends NioChannel  {
                             selector = Selector.open();
                             key = getIOChannel().register(selector, hsStatus);
                         } else {
-                            key.interestOps(hsStatus); // null warning supressed
+                            key.interestOps(hsStatus); // null warning suppressed
                         }
                         int keyCount = selector.select(timeout);
                         if (keyCount == 0 && ((System.currentTimeMillis()-now) >= timeout)) {

--- a/res/findbugs/filter-false-positives.xml
+++ b/res/findbugs/filter-false-positives.xml
@@ -1007,7 +1007,7 @@
     <Bug pattern="NP_EQUALS_SHOULD_HANDLE_NULL_ARGUMENT" />
   </Match>
   <Match>
-    <!-- Natural ordering behavoiur is docuemented in Javadoc -->
+    <!-- Natural ordering behaviour is docuemented in Javadoc -->
     <Class name="org.apache.tomcat.dbcp.pool2.impl.DefaultPooledObject" />
     <Bug pattern="EQ_COMPARETO_USE_OBJECT_EQUALS" />
   </Match>

--- a/res/rat/rat-excludes.txt
+++ b/res/rat/rat-excludes.txt
@@ -51,7 +51,7 @@
     (*.gif, *.jpg are also binary, but are automatically detected by RAT as
     ones, so no explicit configuration is needed)
 
-  - Markdown files for display in ther GitHub UI
+  - Markdown files for display in their GitHub UI
 
   - Temporary cache files used by Checkstle
 

--- a/test/org/apache/catalina/tribes/demos/MapDemo.java
+++ b/test/org/apache/catalina/tribes/demos/MapDemo.java
@@ -136,7 +136,7 @@ public class MapDemo implements ChannelListener, MembershipListener{
         long start = System.currentTimeMillis();
         //create a channel object
         ManagedChannel channel = (ManagedChannel) ChannelCreator.createChannel(args);
-        //define a map name, unless one is defined as a paramters
+        //define a map name, unless one is defined as a parameters
         String mapName = "MapDemo";
         if ( args.length > 0 && (!args[args.length-1].startsWith("-"))) {
             mapName = args[args.length-1];

--- a/test/org/apache/tomcat/util/descriptor/web/TestWebXmlOrdering.java
+++ b/test/org/apache/tomcat/util/descriptor/web/TestWebXmlOrdering.java
@@ -328,7 +328,7 @@ public class TestWebXmlOrdering {
 
     @Test
     public void testOrderWebFragmentsRelative11() {
-        // Test references to non-existant fragments
+        // Test references to non-existent fragments
         doRelativeOrderingTest(new RelativeTestRunner11());
     }
 

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -661,7 +661,7 @@
         <code>1.9</code> is still supported. (markt)
       </update>
       <add>
-        Add support for specifing Java 10 (with the value <code>10</code>) as
+        Add support for specifying Java 10 (with the value <code>10</code>) as
         the compiler source and/or compiler target for JSP compilation. (markt)
       </add>
       <fix>

--- a/webapps/docs/config/context.xml
+++ b/webapps/docs/config/context.xml
@@ -813,7 +813,7 @@
 
       <attribute name="skipMemoryLeakChecksOnJvmShutdown" required="false">
         <p>If <code>true</code>, Tomcat will not perform the usual memory leak
-        checks when the web applicaiton is stopped if that web application is
+        checks when the web application is stopped if that web application is
         stopped as part of a JVM shutdown. If not specified, the default value
         of <code>false</code> will be used.</p>
       </attribute>

--- a/webapps/docs/config/http.xml
+++ b/webapps/docs/config/http.xml
@@ -566,7 +566,7 @@
       browsers are not compliant with this specification and use these
       characters in unencoded form. To prevent Tomcat rejecting such requests,
       this attribute may be used to specify the additional characters to allow.
-      If not specified, no addtional characters will be allowed. The value may
+      If not specified, no additional characters will be allowed. The value may
       be any combination of the following characters:
       <code>&quot; &lt; &gt; [ \ ] ^ ` { | }</code> . Any other characters
       present in the value will be ignored.</p>
@@ -579,7 +579,7 @@
       the major browsers are not compliant with this specification and use these
       characters in unencoded form. To prevent Tomcat rejecting such requests,
       this attribute may be used to specify the additional characters to allow.
-      If not specified, no addtional characters will be allowed. The value may
+      If not specified, no additional characters will be allowed. The value may
       be any combination of the following characters:
       <code>&quot; &lt; &gt; [ \ ] ^ ` { | }</code> . Any other characters
       present in the value will be ignored.</p>

--- a/webapps/docs/host-manager-howto.xml
+++ b/webapps/docs/host-manager-howto.xml
@@ -111,7 +111,7 @@ OK - Listed hosts
 localhost:</source>
   </p>
   <p>
-    Note that in case you retreive your users using the
+    Note that in case you retrieve your users using the
     <code>DataSourceRealm</code>, <code>JDBCRealm</code>, or
     <code>JNDIRealm</code> mechanism, add the appropriate role in the database
     or the directory server respectively.

--- a/webapps/docs/html-host-manager-howto.xml
+++ b/webapps/docs/html-host-manager-howto.xml
@@ -111,7 +111,7 @@
       log in with the created credentials.
     </p>
     <p>
-      Note that in case you retreive your users using the
+      Note that in case you retrieve your users using the
       <code>DataSourceRealm</code>, <code>JDBCRealm</code>, or
       <code>JNDIRealm</code> mechanism, add the appropriate role in the database
       or the directory server respectively.

--- a/webapps/docs/monitoring.xml
+++ b/webapps/docs/monitoring.xml
@@ -1004,7 +1004,7 @@ List of Attributes
 </table>
 
 <p>
-Wait for server connection and that cluster backup node is accessable
+Wait for server connection and that cluster backup node is accessible
 </p>
 <source><![CDATA[<target name="wait">
   <waitfor maxwait="${maxwait}" maxwaitunit="second" timeoutproperty="server.timeout" >


### PR DESCRIPTION
Fixing typos is sometimes very hard. It's not so easy to visually review them. Recently, I discovered a very useful tool for it, [misspell](https://github.com/client9/misspell). 

This pull request fixes minor typos detected by [misspell](https://github.com/client9/misspell) except for the false positives. If you would like me to work on other files as well, let me know. 

## before 

```
$ misspell . | grep -v 'LocalStrings'
java/javax/servlet/resources/XMLSchema.dtd:36:32: "overriden" is a misspelling of "overridden"
java/javax/servlet/resources/XMLSchema.dtd:173:43: "overriden" is a misspelling of "overridden"
java/javax/servlet/resources/j2ee_web_services_client_1_1.xsd:191:34: "refered" is a misspelling of "referred"
java/javax/servlet/resources/javaee_web_services_client_1_2.xsd:263:34: "refered" is a misspelling of "referred"
java/javax/servlet/resources/javaee_web_services_client_1_3.xsd:173:34: "refered" is a misspelling of "referred"
java/javax/servlet/resources/javaee_web_services_client_1_4.xsd:169:34: "refered" is a misspelling of "referred"
java/javax/servlet/resources/web-app_3_0.xsd:129:61: "occurence" is a misspelling of "occurrence"
java/javax/servlet/resources/web-app_4_0.xsd:125:61: "occurence" is a misspelling of "occurrence"
java/javax/servlet/resources/web-app_3_1.xsd:129:61: "occurence" is a misspelling of "occurrence"
java/javax/servlet/resources/web-fragment_3_0.xsd:129:61: "occurence" is a misspelling of "occurrence"
java/javax/servlet/resources/web-fragment_3_1.xsd:129:61: "occurence" is a misspelling of "occurrence"
java/javax/servlet/resources/web-jsptaglibrary_1_1.dtd:38:58: "prefered" is a misspelling of "preferred"
java/javax/servlet/resources/web-fragment_4_0.xsd:125:61: "occurence" is a misspelling of "occurrence"
java/javax/servlet/resources/web-jsptaglibrary_1_2.dtd:53:62: "prefered" is a misspelling of "preferred"
java/javax/servlet/resources/web-jsptaglibrary_2_0.xsd:685:50: "prefered" is a misspelling of "preferred"
java/org/apache/catalina/connector/CoyoteInputStream.java:141:25: "transfered" is a misspelling of "transferred"
java/org/apache/catalina/connector/InputBuffer.java:354:25: "transfered" is a misspelling of "transferred"
java/org/apache/catalina/filters/ExpiresFilter.java:1173:7: "occurence" is a misspelling of "occurrence"
java/org/apache/catalina/ha/session/SessionMessageImpl.java:74:54: "transfered" is a misspelling of "transferred"
java/org/apache/catalina/ha/session/SessionMessageImpl.java:147:74: "TRANSFERED" is a misspelling of "TRANSFERRED"
java/org/apache/catalina/ha/session/DeltaManager.java:299:22: "transfered" is a misspelling of "transferred"
java/org/apache/catalina/ha/session/DeltaManager.java:805:42: "transfered" is a misspelling of "transferred"
java/org/apache/catalina/ha/session/DeltaManager.java:806:59: "transfered" is a misspelling of "transferred"
java/org/apache/catalina/ha/session/DeltaManager.java:814:34: "transfered" is a misspelling of "transferred"
java/org/apache/catalina/ha/session/DeltaManager.java:826:38: "transfered" is a misspelling of "transferred"
java/org/apache/catalina/ha/session/DeltaManager.java:1200:48: "transfered" is a misspelling of "transferred"
java/org/apache/catalina/ha/session/DeltaManager.java:1334:44: "transfered" is a misspelling of "transferred"
java/org/apache/catalina/ha/session/DeltaManager.java:1372:86: "TRANSFERED" is a misspelling of "TRANSFERRED"
java/org/apache/catalina/ha/session/DeltaManager.java:1373:31: "TRANSFERED" is a misspelling of "TRANSFERRED"
java/org/apache/catalina/ha/tcp/SimpleTcpCluster.java:799:32: "transfered" is a misspelling of "transferred"
java/org/apache/catalina/ha/session/mbeans-descriptors.xml:262:36: "transfered" is a misspelling of "transferred"
java/org/apache/catalina/servlets/CGIServlet.java:1164:67: "existant" is a misspelling of "existent"
java/org/apache/catalina/servlets/CGIServlet.java:1428:59: "recommedations" is a misspelling of "recommendations"
java/org/apache/catalina/storeconfig/StandardContextSF.java:164:47: "orginal" is a misspelling of "original"
java/org/apache/catalina/storeconfig/StoreAppender.java:295:18: "orginal" is a misspelling of "original"
java/org/apache/catalina/tribes/transport/bio/BioSender.java:104:39: "occured" is a misspelling of "occurred"
java/org/apache/catalina/users/mbeans-descriptors.xml:46:26: "persistant" is a misspelling of "persistent"
java/org/apache/catalina/valves/StuckThreadDetectionValve.java:356:22: "agains" is a misspelling of "against"
java/org/apache/coyote/Response.java:101:21: "commited" is a misspelling of "committed"
java/org/apache/coyote/Response.java:255:15: "commited" is a misspelling of "committed"
java/org/apache/coyote/Response.java:336:12: "commited" is a misspelling of "committed"
java/org/apache/coyote/Response.java:615:8: "commited" is a misspelling of "committed"
java/org/apache/el/Messages_es.properties:18:17: "Problemas" is a misspelling of "Problems"
java/org/apache/el/lang/VariableMapperFactory.java:26:27: "momento" is a misspelling of "memento"
java/org/apache/tomcat/dbcp/dbcp2/DriverManagerConnectionFactory.java:86:20: "propeties" is a misspelling of "properties"
java/org/apache/tomcat/dbcp/dbcp2/DriverManagerConnectionFactory.java:92:58: "propeties" is a misspelling of "properties"
java/org/apache/tomcat/dbcp/dbcp2/DriverManagerConnectionFactory.java:98:23: "propeties" is a misspelling of "properties"
java/org/apache/tomcat/dbcp/dbcp2/managed/TransactionContextListener.java:31:14: "commited" is a misspelling of "committed"
java/org/apache/tomcat/dbcp/dbcp2/managed/TransactionContextListener.java:34:72: "commited" is a misspelling of "committed"
java/org/apache/tomcat/dbcp/dbcp2/managed/ManagedConnection.java:207:93: "commited" is a misspelling of "committed"
java/org/apache/tomcat/dbcp/dbcp2/managed/TransactionContext.java:70:30: "compatability" is a misspelling of "compatibility"
java/org/apache/tomcat/dbcp/dbcp2/managed/TransactionRegistry.java:64:30: "compatability" is a misspelling of "compatibility"
java/org/apache/tomcat/util/bcel/classfile/ClassParser.java:32:27: "appropiate" is a misspelling of "appropriate"
java/org/apache/tomcat/util/bcel/classfile/ClassParser.java:144:26: "implicitely" is a misspelling of "implicitly"
java/org/apache/tomcat/util/buf/CharChunk.java:293:15: "substract" is a misspelling of "subtract"
java/org/apache/tomcat/util/buf/CharChunk.java:301:15: "substract" is a misspelling of "subtract"
java/org/apache/tomcat/util/buf/ByteChunk.java:392:15: "substract" is a misspelling of "subtract"
java/org/apache/tomcat/util/buf/ByteChunk.java:408:15: "substract" is a misspelling of "subtract"
java/org/apache/tomcat/util/buf/ByteChunk.java:426:21: "transfered" is a misspelling of "transferred"
java/org/apache/tomcat/util/buf/ByteChunk.java:433:15: "substract" is a misspelling of "subtract"
java/org/apache/tomcat/util/digester/RulesBase.java:100:29: "accidently" is a misspelling of "accidentally"
java/org/apache/tomcat/util/http/fileupload/ParameterParser.java:122:43: "presense" is a misspelling of "presence"
java/org/apache/tomcat/util/http/fileupload/MultipartStream.java:608:38: "preceeded" is a misspelling of "preceded"
java/org/apache/tomcat/util/digester/package.html:1031:0: "accessable" is a misspelling of "accessible"
java/org/apache/tomcat/util/net/SecureNioChannel.java:390:71: "supressed" is a misspelling of "suppressed"
res/rat/rat-excludes.txt:54:34: "ther" is a misspelling of "there"
res/findbugs/filter-false-positives.xml:1010:26: "behavoiur" is a misspelling of "behaviour"
test/org/apache/catalina/tribes/demos/MapDemo.java:139:56: "paramters" is a misspelling of "parameters"
test/org/apache/tomcat/util/descriptor/web/TestWebXmlOrdering.java:331:34: "existant" is a misspelling of "existent"
webapps/docs/config/context.xml:816:28: "applicaiton" is a misspelling of "application"
webapps/docs/config/http.xml:569:27: "addtional" is a misspelling of "additional"
webapps/docs/config/http.xml:582:27: "addtional" is a misspelling of "additional"
webapps/docs/changelog.xml:664:24: "specifing" is a misspelling of "specifying"
webapps/docs/host-manager-howto.xml:114:26: "retreive" is a misspelling of "retrieve"
webapps/docs/html-host-manager-howto.xml:114:28: "retreive" is a misspelling of "retrieve"
webapps/docs/monitoring.xml:1007:59: "accessable" is a misspelling of "accessible"
webapps/examples/WEB-INF/classes/jsp2/examples/simpletag/FindBookSimpleTag.java:34:56: "Tolkein" is a misspelling of "Tolkien"
```

## after

```
$ misspell . | grep -v 'LocalStrings'
java/org/apache/el/Messages_es.properties:18:17: "Problemas" is a misspelling of "Problems"
java/org/apache/el/lang/VariableMapperFactory.java:26:27: "momento" is a misspelling of "memento"
java/org/apache/tomcat/util/buf/CharChunk.java:293:15: "substract" is a misspelling of "subtract"
java/org/apache/tomcat/util/buf/CharChunk.java:301:15: "substract" is a misspelling of "subtract"
java/org/apache/tomcat/util/buf/ByteChunk.java:392:15: "substract" is a misspelling of "subtract"
java/org/apache/tomcat/util/buf/ByteChunk.java:408:15: "substract" is a misspelling of "subtract"
java/org/apache/tomcat/util/buf/ByteChunk.java:426:21: "transfered" is a misspelling of "transferred"
java/org/apache/tomcat/util/buf/ByteChunk.java:433:15: "substract" is a misspelling of "subtract"
webapps/examples/WEB-INF/classes/jsp2/examples/simpletag/FindBookSimpleTag.java:34:56: "Tolkein" is a misspelling of "Tolkien"
```