### PR TITLE
Added a default value for ApplicationSessionCookieConfig#name

### DIFF
--- a/java/org/apache/catalina/core/ApplicationSessionCookieConfig.java
+++ b/java/org/apache/catalina/core/ApplicationSessionCookieConfig.java
@@ -38,7 +38,7 @@ public class ApplicationSessionCookieConfig implements SessionCookieConfig {
     private int maxAge = -1;
     private String comment;
     private String domain;
-    private String name;
+    private String name = "JSESSIONID";
     private String path;
     private StandardContext context;
 


### PR DESCRIPTION
By spec. javax.servlet.SessionCookieConfig#getName should return 'JSESSIONID' as default value (see https://docs.oracle.com/javaee/7/api/javax/servlet/SessionCookieConfig.html). 
However, ApplicationSessionCookieConfig has no default value for this field and returns 'null' if not set.
This PR set  'JSESSIONID'  as default value.