### PR TITLE
Checking the signing service response

### DIFF
--- a/java/org/apache/tomcat/buildutil/SignCode.java
+++ b/java/org/apache/tomcat/buildutil/SignCode.java
@@ -397,7 +397,9 @@ public class SignCode extends Task {
             byte[] buf = new byte[32 * 1024];
             for (int i = 0; i < files.size(); i ++) {
                 try (FileOutputStream fos = new FileOutputStream(files.get(i))) {
-                    zis.getNextEntry();
+                    if (zis.getNextEntry() == null) {
+                        throw new BuildException("Signing failed. Malformed service reply.");
+                    }
                     int numRead;
                     while ( (numRead = zis.read(buf)) >= 0) {
                         fos.write(buf, 0 , numRead);


### PR DESCRIPTION
The code at lines [398](https://github.com/apache/tomcat/blob/1fde5d696a5d23ed589d05fb6cf6307d5adb563c/java/org/apache/tomcat/buildutil/SignCode.java#L398) --- [403](https://github.com/apache/tomcat/blob/1fde5d696a5d23ed589d05fb6cf6307d5adb563c/java/org/apache/tomcat/buildutil/SignCode.java#L403) in file [SignCode.java](https://github.com/apache/tomcat/blob/trunk/java/org/apache/tomcat/buildutil/SignCode.java) assumes, without
checking, that the signing service will return the same number of
files and in the same order as in the `List<File>` files parameter ([line 393](https://github.com/apache/tomcat/blob/1fde5d696a5d23ed589d05fb6cf6307d5adb563c/java/org/apache/tomcat/buildutil/SignCode.java#L393)).

If the signing service returns fewer file, then

`zis.getNextEntry()` ([line 400](https://github.com/apache/tomcat/blob/1fde5d696a5d23ed589d05fb6cf6307d5adb563c/java/org/apache/tomcat/buildutil/SignCode.java#L400))

will return `null`

and 

`zis.read(buf)` ([line 402](https://github.com/apache/tomcat/blob/1fde5d696a5d23ed589d05fb6cf6307d5adb563c/java/org/apache/tomcat/buildutil/SignCode.java#L402))

will fail (because there is no entry to read from).

Similarly, if the order is different, 

`fos.write(buf, 0 , numRead);`   ([line 403](https://github.com/apache/tomcat/blob/1fde5d696a5d23ed589d05fb6cf6307d5adb563c/java/org/apache/tomcat/buildutil/SignCode.java#L403))

will overwrite the wrong files.

The above two assumptions about the signing service are fine, but it
is best to have a sanity check for them.

This pull request adds a sanity check for the number of files.

The full check (which also checks for the name equality) is:

```
ZipEntry zisEntry;
if (((zisEntry = zis.getNextEntry()) == null) || !zisEntry.getName().equals(files.get(i).getName())) {
    throw new BuildException("Signing failed. Malformed service reply.");
}
```

I am not familiar enough with Tomcat code to be sure the
`zisEntry.getName()` and `files.get(i).getName()` calls are correct,
so this pull request does not have name checks (but you can just
copy-paste the above code for the name checks).