### PR TITLE
Provide port offset functionality (BZ-61171)

### DIFF
--- a/java/org/apache/catalina/Server.java
+++ b/java/org/apache/catalina/Server.java
@@ -84,6 +84,33 @@ public interface Server extends Lifecycle {
      */
     public void setPort(int port);
 
+    /**
+     * Get the number that offsets the port used for shutdown commands.
+     * For example, if port is 8005, and portOffset is 1000,
+     * the server listens at 9005.
+     *
+     * @return the port offset
+     */
+    public int getPortOffset();
+
+    /**
+     * Set the number that offsets the server port used for shutdown commands.
+     * For example, if port is 8005, and you set portOffset to 1000,
+     * connector listens at 9005.
+     *
+     * @param portOffset sets the port offset
+     */
+    public void setPortOffset(int portOffset);
+
+    /**
+     * Get the actual port on which server is listening for the shutdown commands.
+     * If you do not set port offset, port is returned. If you set
+     * port offset, port offset + port is returned.
+     *
+     * @return the port with offset
+     */
+    public int getPortWithOffset();
+
 
     /**
      * @return the address on which we listen to for shutdown commands.

--- a/java/org/apache/catalina/Server.java
+++ b/java/org/apache/catalina/Server.java
@@ -111,7 +111,6 @@ public interface Server extends Lifecycle {
      */
     public int getPortWithOffset();
 
-
     /**
      * @return the address on which we listen to for shutdown commands.
      */

--- a/java/org/apache/catalina/connector/Connector.java
+++ b/java/org/apache/catalina/connector/Connector.java
@@ -150,6 +150,10 @@ public class Connector extends LifecycleMBeanBase  {
      */
     protected int port = -1;
 
+    /**
+    * The number that offsets the port. If set, we listen at port + portOffset.
+    */
+    protected int portOffset = 0;
 
     /**
      * The server name to which we should pretend requests to this Connector
@@ -1019,6 +1023,10 @@ public class Connector extends LifecycleMBeanBase  {
             sb.append("auto-");
             sb.append(getProperty("nameIndex"));
         }
+        if(this.portOffset > 0) {
+            sb.append("-offset-");
+            sb.append(this.portOffset);
+        }
         sb.append(']');
         return sb.toString();
     }
@@ -1041,4 +1049,16 @@ public class Connector extends LifecycleMBeanBase  {
         return createObjectNameKeyProperties("Connector");
     }
 
+    public int getPortOffset() {
+        return this.portOffset;
+    }
+
+    public void setPortOffset(int portOffset) {
+        this.portOffset = portOffset;
+        setProperty("portOffset", String.valueOf(portOffset));
+    }
+
+    public int getPortWithOffset() {
+        return this.port + this.portOffset;
+    }
 }

--- a/java/org/apache/catalina/core/StandardServer.java
+++ b/java/org/apache/catalina/core/StandardServer.java
@@ -113,6 +113,8 @@ public final class StandardServer extends LifecycleMBeanBase implements Server {
      */
     private int port = 8005;
 
+    private int portOffset = 0;
+
     /**
      * The address on which we wait for shutdown commands.
      */
@@ -417,12 +419,14 @@ public final class StandardServer extends LifecycleMBeanBase implements Server {
         }
 
         // Set up a server socket to wait on
+        String addOffsetToDebugMessage = portOffset > 0 ? "-offset-"+portOffset : "";
         try {
-            awaitSocket = new ServerSocket(port, 1,
+            awaitSocket = new ServerSocket(getPortWithOffset(), 1,
                     InetAddress.getByName(address));
         } catch (IOException e) {
             log.error("StandardServer.await: create[" + address
                                + ":" + port
+                               + addOffsetToDebugMessage
                                + "]: ", e);
             return;
         }
@@ -928,4 +932,19 @@ public final class StandardServer extends LifecycleMBeanBase implements Server {
         return "type=Server";
     }
 
+
+    public int getPortOffset() {
+        return portOffset;
+    }
+
+    public void setPortOffset(int portOffset) {
+        // Values < 0 aren't valid
+        if(portOffset > 0) {
+            this.portOffset = portOffset;
+        }
+    }
+
+    public int getPortWithOffset() {
+        return this.port + this.portOffset;
+    }
 }

--- a/java/org/apache/catalina/mbeans/MBeanFactory.java
+++ b/java/org/apache/catalina/mbeans/MBeanFactory.java
@@ -699,8 +699,7 @@ public class MBeanFactory {
             if (objConnAddress != null) {
                 connAddress = ((InetAddress) objConnAddress).getHostAddress();
             }
-            String connPort = ""+conns[i].getPort();
-
+            String connPort = ""+conns[i].getPortWithOffset();
             if (address == null) {
                 // Don't combine this with outer if or we could get an NPE in
                 // 'else if' below
@@ -886,4 +885,3 @@ public class MBeanFactory {
     }
 
 }
-

--- a/java/org/apache/catalina/startup/AddPortOffsetRule.java
+++ b/java/org/apache/catalina/startup/AddPortOffsetRule.java
@@ -1,0 +1,19 @@
+package org.apache.catalina.startup;
+
+import org.apache.catalina.connector.Connector;
+import org.apache.catalina.core.StandardServer;
+import org.apache.tomcat.util.digester.Rule;
+import org.xml.sax.Attributes;
+
+public class AddPortOffsetRule extends Rule {
+  // Set portOffset on all the connectors based on portOffset in the Standard Server
+  @Override
+  public void begin(String namespace, String name, Attributes attributes) throws Exception {
+
+    Connector conn = (Connector) digester.peek();
+    StandardServer server = (StandardServer) digester.peek(2);
+
+    int portOffset = server.getPortOffset();
+    conn.setPortOffset(portOffset);
+  }
+}

--- a/java/org/apache/catalina/startup/Catalina.java
+++ b/java/org/apache/catalina/startup/Catalina.java
@@ -345,6 +345,8 @@ public class Catalina {
                             "addConnector",
                             "org.apache.catalina.connector.Connector");
 
+        digester.addRule("Server/Service/Connector", new AddPortOffsetRule());
+        
         digester.addObjectCreate("Server/Service/Connector/SSLHostConfig",
                                  "org.apache.tomcat.util.net.SSLHostConfig");
         digester.addSetProperties("Server/Service/Connector/SSLHostConfig");
@@ -494,8 +496,9 @@ public class Catalina {
 
         // Stop the existing server
         s = getServer();
+        String addPortOffset = s.getPortOffset() > 0 ? "-offset-"+s.getPortOffset() : "";
         if (s.getPort()>0) {
-            try (Socket socket = new Socket(s.getAddress(), s.getPort());
+            try (Socket socket = new Socket(s.getAddress(), s.getPortWithOffset());
                     OutputStream stream = socket.getOutputStream()) {
                 String shutdown = s.getShutdown();
                 for (int i = 0; i < shutdown.length(); i++) {
@@ -505,7 +508,7 @@ public class Catalina {
             } catch (ConnectException ce) {
                 log.error(sm.getString("catalina.stopServer.connectException",
                                        s.getAddress(),
-                                       String.valueOf(s.getPort())));
+                                       String.valueOf(s.getPort())+addPortOffset));
                 log.error("Catalina.stop: ", ce);
                 System.exit(1);
             } catch (IOException e) {

--- a/java/org/apache/catalina/valves/RemoteAddrValve.java
+++ b/java/org/apache/catalina/valves/RemoteAddrValve.java
@@ -45,7 +45,7 @@ public final class RemoteAddrValve extends RequestFilterValve {
     public void invoke(Request request, Response response) throws IOException, ServletException {
         String property;
         if (getAddConnectorPort()) {
-            property = request.getRequest().getRemoteAddr() + ";" + request.getConnector().getPort();
+            property = request.getRequest().getRemoteAddr() + ";" + request.getConnector().getPortWithOffset();
         } else {
             property = request.getRequest().getRemoteAddr();
         }

--- a/java/org/apache/catalina/valves/RemoteHostValve.java
+++ b/java/org/apache/catalina/valves/RemoteHostValve.java
@@ -43,7 +43,7 @@ public final class RemoteHostValve extends RequestFilterValve {
     public void invoke(Request request, Response response) throws IOException, ServletException {
         String property;
         if (getAddConnectorPort()) {
-            property = request.getRequest().getRemoteHost() + ";" + request.getConnector().getPort();
+            property = request.getRequest().getRemoteHost() + ";" + request.getConnector().getPortWithOffset();
         } else {
             property = request.getRequest().getRemoteHost();
         }

--- a/java/org/apache/coyote/AbstractProtocol.java
+++ b/java/org/apache/coyote/AbstractProtocol.java
@@ -352,6 +352,11 @@ public abstract class AbstractProtocol<S> implements ProtocolHandler,
         } else {
             name.append(port);
         }
+        int portOffset = getPortOffset();
+        if(portOffset > 0) {
+            name.append("-offset-");
+            name.append(portOffset);
+        }
         return name.toString();
     }
 
@@ -496,6 +501,11 @@ public abstract class AbstractProtocol<S> implements ProtocolHandler,
             name.append("auto-");
             name.append(getNameIndex());
         }
+        int offset = getPortOffset();
+        if(offset > 0) {
+            name.append(",port offset=");
+            name.append(offset);
+        }
         InetAddress address = getAddress();
         if (address != null) {
             name.append(",address=");
@@ -630,6 +640,17 @@ public abstract class AbstractProtocol<S> implements ProtocolHandler,
         }
     }
 
+    public int getPortOffset() {
+        return endpoint.getPortOffset();
+    }
+
+    public void setPortOffset(int portOffset) {
+        endpoint.setPortOffset(portOffset);
+    }
+
+    public int getPortWithOffset() {
+        return endpoint.getPortWithOffset();
+    }
 
     @Override
     public void closeServerSocketGraceful() {

--- a/java/org/apache/tomcat/util/net/AbstractEndpoint.java
+++ b/java/org/apache/tomcat/util/net/AbstractEndpoint.java
@@ -928,7 +928,7 @@ public abstract class AbstractEndpoint<S,U> {
             ExceptionUtils.handleThrowable(t);
             if (getLog().isDebugEnabled()) {
                 getLog().debug(sm.getString("endpoint.debug.unlock.fail", "" + getPort()+"-offset-" +
-                  getPortWithOffset()), t);
+                  getPortOffset()), t);
             }
         }
     }

--- a/java/org/apache/tomcat/util/net/AbstractEndpoint.java
+++ b/java/org/apache/tomcat/util/net/AbstractEndpoint.java
@@ -456,6 +456,11 @@ public abstract class AbstractEndpoint<S,U> {
     public void setPort(int port ) { this.port=port; }
 
 
+    private int portOffset = 0;
+    public int getPortOffset() { return portOffset; }
+    public void setPortOffset(int portOffset) { this.portOffset = portOffset; }
+    public int getPortWithOffset() { return port + portOffset; }
+
     public final int getLocalPort() {
         try {
             InetSocketAddress localAddress = getLocalAddress();
@@ -922,7 +927,8 @@ public abstract class AbstractEndpoint<S,U> {
         } catch(Throwable t) {
             ExceptionUtils.handleThrowable(t);
             if (getLog().isDebugEnabled()) {
-                getLog().debug(sm.getString("endpoint.debug.unlock.fail", "" + getPort()), t);
+                getLog().debug(sm.getString("endpoint.debug.unlock.fail", "" + getPort()+"-offset-" +
+                  getPortWithOffset()), t);
             }
         }
     }
@@ -1244,4 +1250,3 @@ public abstract class AbstractEndpoint<S,U> {
         closeSocket(socket);
     }
 }
-

--- a/java/org/apache/tomcat/util/net/AprEndpoint.java
+++ b/java/org/apache/tomcat/util/net/AprEndpoint.java
@@ -314,7 +314,7 @@ public class AprEndpoint extends AbstractEndpoint<Long,Long> implements SNICallB
          }
 
         long inetAddress = Address.info(addressStr, family,
-                getPort(), 0, rootPool);
+                getPortWithOffset(), 0, rootPool);
         // Create the APR server socket
         serverSock = Socket.create(Address.getInfo(inetAddress).family,
                 Socket.SOCK_STREAM,

--- a/java/org/apache/tomcat/util/net/Nio2Endpoint.java
+++ b/java/org/apache/tomcat/util/net/Nio2Endpoint.java
@@ -142,7 +142,8 @@ public class Nio2Endpoint extends AbstractJsseEndpoint<Nio2Channel,AsynchronousS
 
         serverSock = AsynchronousServerSocketChannel.open(threadGroup);
         socketProperties.setProperties(serverSock);
-        InetSocketAddress addr = (getAddress()!=null?new InetSocketAddress(getAddress(),getPort()):new InetSocketAddress(getPort()));
+        InetSocketAddress addr = (getAddress()!=null?new InetSocketAddress(getAddress(),getPortWithOffset()):new
+          InetSocketAddress(getPortWithOffset()));
         serverSock.bind(addr,getAcceptCount());
 
         // Initialize thread count defaults for acceptor, poller

--- a/java/org/apache/tomcat/util/net/NioEndpoint.java
+++ b/java/org/apache/tomcat/util/net/NioEndpoint.java
@@ -232,7 +232,7 @@ public class NioEndpoint extends AbstractJsseEndpoint<NioChannel,SocketChannel> 
         if (!getUseInheritedChannel()) {
             serverSock = ServerSocketChannel.open();
             socketProperties.setProperties(serverSock.socket());
-            InetSocketAddress addr = (getAddress()!=null?new InetSocketAddress(getAddress(),getPort()):new InetSocketAddress(getPort()));
+            InetSocketAddress addr = (getAddress()!=null?new InetSocketAddress(getAddress(),getPortWithOffset()):new InetSocketAddress(getPortWithOffset()));
             serverSock.socket().bind(addr,getAcceptCount());
         } else {
             // Retrieve the channel provided by the OS
@@ -322,8 +322,11 @@ public class NioEndpoint extends AbstractJsseEndpoint<NioChannel,SocketChannel> 
      */
     @Override
     public void unbind() throws Exception {
+        int offset = getPortOffset();
+        String addOffset = offset > 0 ? " offset by "+offset : "";
+
         if (log.isDebugEnabled()) {
-            log.debug("Destroy initiated for "+new InetSocketAddress(getAddress(),getPort()));
+            log.debug("Destroy initiated for "+new InetSocketAddress(getAddress(),getPort()) + addOffset);
         }
         if (running) {
             stop();
@@ -336,7 +339,7 @@ public class NioEndpoint extends AbstractJsseEndpoint<NioChannel,SocketChannel> 
         }
         selectorPool.close();
         if (log.isDebugEnabled()) {
-            log.debug("Destroy completed for "+new InetSocketAddress(getAddress(),getPort()));
+            log.debug("Destroy completed for "+new InetSocketAddress(getAddress(),getPort()) + addOffset);
         }
     }
 


### PR DESCRIPTION
This PR resolves [BZ61171](https://bz.apache.org/bugzilla/show_bug.cgi?id=61171) and adds the port offset functionality.

The implementation is deliberately done such that the current behavior is left unchanged, i.e. `getPort()` always returns the port without offset. However, if you set `portOffset` on the `StandardServer` element, all connectors get the offset, and are listening at port+portOffset port. To get port with offset, one specifically has to call `getPortWithOffset()`. This behavior is also signified in the logs, which now show, for example, `"http-nio-8080-offset-100"` rather than `"http-nio-8180"`.

User-facing documentation will follow when and if this PR gets merged.

Thoughts? As always, I'm keen on feedback and request for changes. Alternatively, feel free to change any part of the PR. 