### PR TITLE
The feature of the transfer rate control are added to the sendfile.

### DIFF
--- a/conf/web.xml
+++ b/conf/web.xml
@@ -77,6 +77,9 @@
   <!--                       which sendfile will be used. Use a negative    -->
   <!--                       value to always disable sendfile.  [48]        -->
   <!--                                                                      -->
+  <!--   sendfileRate        For transfer rate control,                     -->
+  <!--                       using double value in MB per second.           -->
+  <!--                                                                      -->
   <!--   useAcceptRanges     Should the Accept-Ranges header be included    -->
   <!--                       in responses where appropriate? [true]         -->
   <!--                                                                      -->

--- a/java/org/apache/catalina/Globals.java
+++ b/java/org/apache/catalina/Globals.java
@@ -187,6 +187,16 @@ public final class Globals {
 
 
     /**
+     * The request attribute for transfer rate control,
+     * using double values in megabytes per second.
+     *
+     * Duplicated here for neater code in the catalina packages.
+     */
+    public static final String SENDFILE_RATE_ATTR =
+            org.apache.coyote.Constants.SENDFILE_RATE_ATTR;
+
+
+    /**
      * The request attribute set by the RemoteIpFilter, RemoteIpValve (and may
      * be set by other similar components) that identifies for the connector the
      * remote IP address claimed to be associated with this request when a

--- a/java/org/apache/catalina/servlets/DefaultServlet.java
+++ b/java/org/apache/catalina/servlets/DefaultServlet.java
@@ -246,6 +246,11 @@ public class DefaultServlet extends HttpServlet {
     protected int sendfileSize = 48 * 1024;
 
     /**
+     * Rate limit for sendfile usage in MB per second.
+     */
+    protected double sendfileRate = 0D;
+
+    /**
      * Should the Accept-Ranges: bytes header be send with static resources?
      */
     protected boolean useAcceptRanges = true;
@@ -294,6 +299,9 @@ public class DefaultServlet extends HttpServlet {
         if (getServletConfig().getInitParameter("sendfileSize") != null)
             sendfileSize =
                 Integer.parseInt(getServletConfig().getInitParameter("sendfileSize")) * 1024;
+
+        if (getServletConfig().getInitParameter("sendfileRate") != null)
+            sendfileRate = Double.parseDouble(getServletConfig().getInitParameter("sendfileRate"));
 
         fileEncoding = getServletConfig().getInitParameter("fileEncoding");
         if (fileEncoding == null) {
@@ -2056,6 +2064,9 @@ public class DefaultServlet extends HttpServlet {
             } else {
                 request.setAttribute(Globals.SENDFILE_FILE_START_ATTR, Long.valueOf(range.start));
                 request.setAttribute(Globals.SENDFILE_FILE_END_ATTR, Long.valueOf(range.end + 1));
+            }
+            if (sendfileRate > 0) {
+                request.setAttribute(Globals.SENDFILE_RATE_ATTR, sendfileRate);
             }
             return true;
         }

--- a/java/org/apache/coyote/Constants.java
+++ b/java/org/apache/coyote/Constants.java
@@ -89,6 +89,12 @@ public final class Constants {
 
 
     /**
+     * The request attribute for transfer rate control,
+     * using double values in megabytes per second.
+     */
+    public static final String SENDFILE_RATE_ATTR = "org.apache.tomcat.sendfile.rate";
+
+    /**
      * The request attribute set by the RemoteIpFilter, RemoteIpValve (and may
      * be set by other similar components) that identifies for the connector the
      * remote IP address claimed to be associated with this request when a

--- a/java/org/apache/coyote/http11/Http11Processor.java
+++ b/java/org/apache/coyote/http11/Http11Processor.java
@@ -1006,7 +1006,10 @@ public class Http11Processor extends AbstractProcessor {
                     org.apache.coyote.Constants.SENDFILE_FILE_START_ATTR)).longValue();
             long end = ((Long) request.getAttribute(
                     org.apache.coyote.Constants.SENDFILE_FILE_END_ATTR)).longValue();
-            sendfileData = socketWrapper.createSendfileData(fileName, pos, end - pos);
+            Double rate = (Double)request.getAttribute(
+                    org.apache.coyote.Constants.SENDFILE_RATE_ATTR);
+            sendfileData = socketWrapper.createSendfileData(fileName, pos, end - pos,
+                    null == rate ? 0D : rate.doubleValue());
         }
     }
 

--- a/java/org/apache/tomcat/util/net/RateLimiter.java
+++ b/java/org/apache/tomcat/util/net/RateLimiter.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tomcat.util.net;
+
+import java.io.IOException;
+
+/** Abstract base class to rate limit IO.  Typically implementations are
+ *  shared across multiple IndexInputs or IndexOutputs (for example
+ *  those involved all merging).  Those IndexInputs and
+ *  IndexOutputs would call {@link #pause} whenever the have read
+ *  or written more than {@link #getMinPauseCheckBytes} bytes. */
+public abstract class RateLimiter {
+
+  /**
+   * Sets an updated MB per second rate limit.
+   */
+  public abstract void setMBPerSec(double mbPerSec);
+
+  /**
+   * The current MB per second rate limit.
+   */
+  public abstract double getMBPerSec();
+  
+  /** Pauses, if necessary, to keep the instantaneous IO
+   *  rate at or below the target. 
+   *  <p>
+   *  Note: the implementation is thread-safe
+   *  </p>
+   *  @return the pause time in nano seconds 
+   * */
+  public abstract long pause(long bytes);
+  
+  /** How many bytes caller should add up itself before invoking {@link #pause}. */
+  public abstract long getMinPauseCheckBytes();
+
+  /**
+   * Simple class to rate limit IO.
+   */
+  public static class SimpleRateLimiter extends RateLimiter {
+
+    private final static int MIN_PAUSE_CHECK_MSEC = 5;
+
+    private volatile double mbPerSec;
+    private volatile long minPauseCheckBytes;
+    private long lastNS;
+
+    // TODO: we could also allow eg a sub class to dynamically
+    // determine the allowed rate, eg if an app wants to
+    // change the allowed rate over time or something
+
+    /** mbPerSec is the MB/sec max IO rate */
+    public SimpleRateLimiter(double mbPerSec) {
+      setMBPerSec(mbPerSec);
+      lastNS = System.nanoTime();
+    }
+
+    /**
+     * Sets an updated mb per second rate limit.
+     */
+    @Override
+    public void setMBPerSec(double mbPerSec) {
+      this.mbPerSec = mbPerSec;
+      minPauseCheckBytes = (long) ((MIN_PAUSE_CHECK_MSEC / 1000.0) * mbPerSec * 1024 * 1024);
+    }
+
+    @Override
+    public long getMinPauseCheckBytes() {
+      return minPauseCheckBytes;
+    }
+
+    /**
+     * The current mb per second rate limit.
+     */
+    @Override
+    public double getMBPerSec() {
+      return this.mbPerSec;
+    }
+    
+    /** Pauses, if necessary, to keep the instantaneous IO
+     *  rate at or below the target.  Be sure to only call
+     *  this method when bytes &gt; {@link #getMinPauseCheckBytes},
+     *  otherwise it will pause way too long!
+     *
+     *  @return the pause time in nano seconds */  
+    @Override
+    public long pause(long bytes) {
+
+      long startNS = System.nanoTime();
+
+      double secondsToPause = (bytes/1024./1024.) / mbPerSec;
+
+      long targetNS;
+
+      // Sync'd to read + write lastNS:
+      synchronized (this) {
+
+        // Time we should sleep until; this is purely instantaneous
+        // rate (just adds seconds onto the last time we had paused to);
+        // maybe we should also offer decayed recent history one?
+        targetNS = lastNS + (long) (1000000000 * secondsToPause);
+
+        if (startNS >= targetNS) {
+          // OK, current time is already beyond the target sleep time,
+          // no pausing to do.
+
+          // Set to startNS, not targetNS, to enforce the instant rate, not
+          // the "averaaged over all history" rate:
+          lastNS = startNS;
+          return 0;
+        }
+
+        lastNS = targetNS;
+      }
+
+      long curNS = startNS;
+
+      // While loop because Thread.sleep doesn't always sleep
+      // enough:
+      while (true) {
+        final long pauseNS = targetNS - curNS;
+        if (pauseNS > 0) {
+          try {
+            // NOTE: except maybe on real-time JVMs, minimum realistic sleep time
+            // is 1 msec; if you pass just 1 nsec the default impl rounds
+            // this up to 1 msec:
+            int sleepNS;
+            int sleepMS;
+            if (pauseNS > 100000L * Integer.MAX_VALUE) {
+              // Not really practical (sleeping for 25 days) but we shouldn't overflow int:
+              sleepMS = Integer.MAX_VALUE;
+              sleepNS = 0;
+            } else {
+              sleepMS = (int) (pauseNS/1000000);
+              sleepNS = (int) (pauseNS % 1000000);
+            }
+            Thread.sleep(sleepMS, sleepNS);
+          } catch (InterruptedException ie) {
+            throw new RuntimeException(ie);
+          }
+          curNS = System.nanoTime();
+          continue;
+        }
+        break;
+      }
+
+      return curNS - startNS;
+    }
+  }
+}

--- a/java/org/apache/tomcat/util/net/SendfileDataBase.java
+++ b/java/org/apache/tomcat/util/net/SendfileDataBase.java
@@ -46,9 +46,15 @@ public abstract class SendfileDataBase {
      */
     public long length;
 
-    public SendfileDataBase(String filename, long pos, long length) {
+    /**
+     * For transfer rate control.
+     */
+    public RateLimiter rateLimiter;
+
+    public SendfileDataBase(String filename, long pos, long length, double rate) {
         this.fileName = filename;
         this.pos = pos;
         this.length = length;
+        this.rateLimiter = rate > 0 ? new RateLimiter.SimpleRateLimiter(rate) : null;
     }
 }

--- a/java/org/apache/tomcat/util/net/SocketWrapperBase.java
+++ b/java/org/apache/tomcat/util/net/SocketWrapperBase.java
@@ -767,7 +767,7 @@ public abstract class SocketWrapperBase<E> {
 
     public abstract void registerWriteInterest();
 
-    public abstract SendfileDataBase createSendfileData(String filename, long pos, long length);
+    public abstract SendfileDataBase createSendfileData(String filename, long pos, long length, double rate);
 
     /**
      * Starts the sendfile process. It is expected that if the sendfile process


### PR DESCRIPTION
The Sendfile feature has been added with the characteristics of the transfer rate control, which can be individually limited for each sendfile process.
Use a double value in megabytes per second.
has been tested by: APR, NIO, NIO2 these three kinds of connector modes.
And the initial parameter "sendfilerate" configuration support for global Defaultservlet.

BTW：The org.apache.tomcat.util.net.RateLimiter is copied from lucene-core-7.5.0.jar.

