### PR TITLE
Add a fake attribute for source

### DIFF
--- a/java/org/apache/catalina/startup/Catalina.java
+++ b/java/org/apache/catalina/startup/Catalina.java
@@ -282,6 +282,7 @@ public class Catalina {
         Map<Class<?>, List<String>> fakeAttributes = new HashMap<>();
         List<String> attrs = new ArrayList<>();
         attrs.add("className");
+        attrs.add("source");
         fakeAttributes.put(Object.class, attrs);
         digester.setFakeAttributes(fakeAttributes);
         digester.setUseContextClassLoader(true);


### PR DESCRIPTION
Eclipse adds a source attribute to Tomcat's Context element.  Presumably this helps it keep track of what context element relates to what project.  Tomcat however warns on unrecognized attributes.  This sets source as a fake attribute, which tells Tomcat not to report it.  

You can see more of a description of this on Stack Overflow, e.g. at https://stackoverflow.com/a/3566358/6660678

As you can see, several people ascribed unrelated behavior to this warning.  Meanwhile, all the warning is saying is that Tomcat doesn't know what a source attribute is in server.xml.  Removing the warning thus makes it easier to find the real warning.  

Due to the way that fakeAttributes work (see java/org/apache/tomcat/util/digester/SetPropertiesRule.java lines 72-78), they are not checked until just before the system would issue the warning.  So this would make no difference if someone actually added a source attribute.  

All this does is suppress the warning for a correctly spelled source attribute.  The warning would still appear for incorrectly spelled attributes like sorce or peth.  I can't really see any circumstance where one could misspell a legitimate (not fake) attribute as source.  

You can also view java/org/apache/tomcat/util/digester/Digester.java at lines 734-773 (particularly 748-761) for more context.  Convenience links:  

https://github.com/apache/tomcat/blob/18e106480a59f3b7b5b1d2f3bda3b2d7e065361e/java/org/apache/tomcat/util/digester/Digester.java#L734-L773
https://github.com/apache/tomcat/blob/18e106480a59f3b7b5b1d2f3bda3b2d7e065361e/java/org/apache/tomcat/util/digester/SetPropertiesRule.java#L72-L78

In case you were wondering, `top` is declared here as type `Object`, so there isn't a more specific class that we could use for indexing in this case.  

You can view the issue yourself, outside of Eclipse, by adding something like `source="org.eclipse.jst.jee.server"` to your Context entry in servers.xml (assuming that's where you have your context defined).  

This issue annoys me because inevitably, just as I've forgotten the whole thing, I find myself scanning logs trying to diagnose something.  I see this warning, remember that it's not really important, but wonder about getting rid of it.  Then I go through the whole process again of finding out what causes it.  And of course, short of dropping Eclipse or modifying code, there is no way to get rid of the warning.  

I don't want to drop Eclipse.  Can we make this small code modification, please?  