### PR TITLE
Add missing word for readability

### DIFF
--- a/test/webapp/WEB-INF/test.tld
+++ b/test/webapp/WEB-INF/test.tld
@@ -44,7 +44,7 @@
     <name>toArray</name>
     <function-class>org.apache.el.TesterFunctions</function-class>
     <!-- Do not change whitespace in signature below.
-         It used to test for correctness in o.a.jasper.compiler.Validator. -->
+         It is used to test for correctness in o.a.jasper.compiler.Validator. -->
     <function-signature>
       java.lang.String toArray(java.lang.String,
                                java.lang.String)
@@ -55,7 +55,7 @@
     <name>toArrayB</name>
     <function-class>org.apache.el.TesterFunctions</function-class>
     <!-- Do not change whitespace in signature below.
-         It used to test for correctness in o.a.jasper.compiler.Validator. -->
+         It is used to test for correctness in o.a.jasper.compiler.Validator. -->
     <function-signature>
       java.lang.String toArray (java.lang.String,java.lang.String)
     </function-signature>


### PR DESCRIPTION
Not an important change, but seemed worth making now while it's topical rather than leaving as is.  The old version said that it tested in the past.  This version says that it currently tests.  "It's" would also be appropriate here if that's preferable for some reason.  

I'm not sure what's going on with the end-of-file.  I did not deliberately make a change there.  Just added a word in each of two lines.  