### PR TITLE
Add two spaces (nbsp) in front of the Undeploy button

### DIFF
--- a/java/org/apache/catalina/manager/HTMLManagerServlet.java
+++ b/java/org/apache/catalina/manager/HTMLManagerServlet.java
@@ -1205,7 +1205,7 @@ public final class HTMLManagerServlet extends ManagerServlet {
         "  <small><input type=\"submit\" value=\"{5}\"></small>" +
         "  </form>\n" +
         "  <form class=\"inline\" method=\"POST\" action=\"{6}\">" +
-        "  <small><input type=\"submit\" value=\"{7}\"></small>" +
+        "  &nbsp;&nbsp;<small><input type=\"submit\" value=\"{7}\"></small>" +
         "  </form>\n" +
         " </td>\n" +
         " </tr><tr>\n" +


### PR DESCRIPTION
Since there is no JavaScript in the Manager HTML,
I decided to visually separate the Undeploy button from the rest of the buttons.

This is to "prevent" **missclicks** on the Reload button,
which ends with the Undeploy being clicked.

(there is no Bugzilla ticket for this - I've created this to get your opinion on this.)