### PR TITLE
Fix cygpath error by adding cond check with JAVA_ENDORSED_DIRS

### DIFF
--- a/bin/tool-wrapper.sh
+++ b/bin/tool-wrapper.sh
@@ -127,7 +127,7 @@ if $cygwin; then
   JRE_HOME=`cygpath --absolute --windows "$JRE_HOME"`
   CATALINA_HOME=`cygpath --absolute --windows "$CATALINA_HOME"`
   CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
-  JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+  [ -n "$JAVA_ENDORSED_DIRS" ] && JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
 fi
 
 # Java 9 no longer supports the java.endorsed.dirs


### PR DESCRIPTION
The new `bin/tool-wrapper.sh` script gives the error `cygpath: can't convert empty path` when used in Cygwin shell. This is due to `JAVA_ENDORSED_DIRS` was converted even when it's empty.

This PR fixes the error by checking if `JAVA_ENDORSED_DIRS` is not empty first.