### PR TITLE
Update the ECJ dependency to 4.9 in ide-support files

### DIFF
--- a/res/ide-support/eclipse/eclipse.classpath
+++ b/res/ide-support/eclipse/eclipse.classpath
@@ -24,7 +24,7 @@
     <classpathentry kind="var" path="ANT_HOME/lib/ant.jar"/>
     <classpathentry kind="var" path="TOMCAT_LIBS_BASE/jaxrpc-1.1-rc4/geronimo-spec-jaxrpc-1.1-rc4.jar"/>
     <classpathentry kind="var" path="TOMCAT_LIBS_BASE/wsdl4j-1.6.3/wsdl4j-1.6.3.jar"/>
-    <classpathentry kind="var" path="TOMCAT_LIBS_BASE/ecj-4.7.3a/ecj-4.7.3a.jar"/>
+    <classpathentry kind="var" path="TOMCAT_LIBS_BASE/ecj-4.9/ecj-4.9.jar"/>
     <classpathentry kind="var" path="TOMCAT_LIBS_BASE/easymock-3.2/easymock-3.2.jar"/>
     <classpathentry kind="var" path="TOMCAT_LIBS_BASE/hamcrest-1.3/hamcrest-core-1.3.jar"/>
     <classpathentry kind="var" path="TOMCAT_LIBS_BASE/cglib-2.2.2/cglib-nodep-2.2.2.jar"/>

--- a/res/ide-support/idea/tomcat.iml
+++ b/res/ide-support/idea/tomcat.iml
@@ -70,7 +70,7 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$TOMCAT_BUILD_LIBS$/ecj-4.7.3a/ecj-4.7.3a.jar!/" />
+          <root url="jar://$TOMCAT_BUILD_LIBS$/ecj-4.9/ecj-4.9.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />

--- a/res/ide-support/netbeans/nb-tomcat-build.properties
+++ b/res/ide-support/netbeans/nb-tomcat-build.properties
@@ -37,7 +37,7 @@ nb-test.io-method=org.apache.coyote.http11.Http11NioProtocol
 # it is not possible to retrieve the classpaths from the build to
 # use in the NetBeans targets, so they must be explicitly declared
 
-nb-test.classpath=${test.classes}:${tomcat.build}/webapps/examples/WEB-INF/classes:${base.path}/junit-4.11/junit-4.11.jar:${base.path}/easymock-3.2/easymock-3.2.jar:${base.path}/hamcrest-1.3/hamcrest-core-1.3.jar:${base.path}/ecj-4.7.3a/ecj-4.7.3a.jar:${tomcat.classes}
+nb-test.classpath=${test.classes}:${tomcat.build}/webapps/examples/WEB-INF/classes:${base.path}/junit-4.11/junit-4.11.jar:${base.path}/easymock-3.2/easymock-3.2.jar:${base.path}/hamcrest-1.3/hamcrest-core-1.3.jar:${base.path}/ecj-4.9/ecj-4.9.jar:${tomcat.classes}
 
 # Extra properties used by the Tomcat project additional NetBeans targets.
 

--- a/res/ide-support/netbeans/project.xml
+++ b/res/ide-support/netbeans/project.xml
@@ -178,7 +178,7 @@
             -->
             <compilation-unit>
                 <package-root>java</package-root>
-                <classpath mode="compile">${base.path}/jaxrpc-1.1-rc4/geronimo-spec-jaxrpc-1.1-rc4.jar:${base.path}/wsdl4j-1.6.3/wsdl4j-1.6.3.jar:${base.path}/ecj-4.7.3a/ecj-4.7.3a.jar:${ant.includes}/</classpath>
+                <classpath mode="compile">${base.path}/jaxrpc-1.1-rc4/geronimo-spec-jaxrpc-1.1-rc4.jar:${base.path}/wsdl4j-1.6.3/wsdl4j-1.6.3.jar:${base.path}/ecj-4.9/ecj-4.9.jar:${ant.includes}/</classpath>
                 <source-level>1.7</source-level>
             </compilation-unit>
             <compilation-unit>


### PR DESCRIPTION
The ECJ dependency was bumped in revision a2c399c3 .