### PR TITLE
Display generate date when showing every message in Html Manager

### DIFF
--- a/java/org/apache/catalina/manager/Constants.java
+++ b/java/org/apache/catalina/manager/Constants.java
@@ -146,7 +146,8 @@ public class Constants {
             " <tr>\n" +
             "  <td class=\"row-left\" width=\"10%\">" +
             "<small><strong>{0}</strong></small>&nbsp;</td>\n" +
-            "  <td class=\"row-left\"><pre>{1}</pre></td>\n" +
+            "  <td class=\"row-left\"><pre>{1}</pre><br/>" +
+            "   <i style=\"font-size: small;\">{2}</i></td>\n" +
             " </tr>\n" +
             "</table>\n" +
             "<br>\n" +

--- a/java/org/apache/catalina/manager/HTMLManagerServlet.java
+++ b/java/org/apache/catalina/manager/HTMLManagerServlet.java
@@ -26,6 +26,9 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -366,6 +369,11 @@ public final class HTMLManagerServlet extends ManagerServlet {
         } else {
             args[1] = Escape.htmlElementContent(message);
         }
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime nowUtc = LocalDateTime.now(ZoneId.of("UTC"));
+        args[2] = String.format("Generated at: %s UTC (%s VM time)",
+                formatter.format(nowUtc), formatter.format(now));
         writer.print(MessageFormat.format(Constants.MESSAGE_SECTION, args));
 
         // Manager Section


### PR DESCRIPTION
This additions _(only for Html Manager)_ show sample message in following format:
```
OK - Stopped application at context path [/app]

Generated at: 2018-11-18 14:44:08 UTC (2018-11-18 15:44:08 VM time)
```

**Why the addition:**
Often when I connect into our legacy servers with Windows RDP client,
I intercept existing session where the Tomcat Manager was open in the browser.

With current Tomcat Manager output I have no way of knowing **when** the Message shown was generated - was it 10 seconds ago or yesterday?

I welcome any feedback on this.