### PR TITLE
Apply deduplication to certain loaded and created Strings

### DIFF
--- a/java/org/apache/tomcat/util/digester/SetPropertiesRule.java
+++ b/java/org/apache/tomcat/util/digester/SetPropertiesRule.java
@@ -18,16 +18,13 @@
 
 package org.apache.tomcat.util.digester;
 
-
 import org.apache.tomcat.util.IntrospectionUtils;
 import org.xml.sax.Attributes;
-
 
 /**
  * <p>Rule implementation that sets properties on the object at the top of the
  * stack, based on attributes with corresponding names.</p>
  */
-
 public class SetPropertiesRule extends Rule {
 
     /**
@@ -62,7 +59,7 @@ public class SetPropertiesRule extends Rule {
             if ("".equals(name)) {
                 name = attributes.getQName(i);
             }
-            String value = attributes.getValue(i);
+            String value = attributes.getValue(i).intern();
 
             if (digester.log.isDebugEnabled()) {
                 digester.log.debug("[SetPropertiesRule]{" + digester.match +

--- a/java/org/apache/tomcat/util/modeler/modules/MbeansDescriptorsIntrospectionSource.java
+++ b/java/org/apache/tomcat/util/modeler/modules/MbeansDescriptorsIntrospectionSource.java
@@ -348,8 +348,8 @@ public class MbeansDescriptorsIntrospectionSource extends ModelerSource
                 for(int i=0; i<parms.length; i++ ) {
                     ParameterInfo pi=new ParameterInfo();
                     pi.setType(parms[i].getName());
-                    pi.setName( "param" + i);
-                    pi.setDescription("Introspected parameter param" + i);
+                    pi.setName(("param" + i).intern());
+                    pi.setDescription(("Introspected parameter param" + i).intern());
                     op.addParameter(pi);
                 }
                 mbean.addOperation(op);


### PR DESCRIPTION
Apply deduplication to certain loaded and created Strings by using
a static Map. This applies the same technique as described in
https://shipilev.net/jvm/anatomy-quarks/10-string-intern/ to
reduce the number of String instances that ultimately contain
the same contents.

See Fix https://bz.apache.org/bugzilla/show_bug.cgi?id=63236