### PR TITLE
Adding volatile keywords to member variables

### DIFF
--- a/java/org/apache/catalina/core/StandardContext.java
+++ b/java/org/apache/catalina/core/StandardContext.java
@@ -206,7 +206,7 @@ public class StandardContext extends ContainerBase
      * application, in the order they were encountered in the resulting merged
      * web.xml file.
      */
-    private String applicationListeners[] = new String[0];
+    private volatile String applicationListeners[] = new String[0];
 
     private final Object applicationListenersLock = new Object();
 
@@ -243,7 +243,7 @@ public class StandardContext extends ContainerBase
     /**
      * The set of application parameters defined for this application.
      */
-    private ApplicationParameter applicationParameters[] =
+    private volatile ApplicationParameter applicationParameters[] =
         new ApplicationParameter[0];
 
     private final Object applicationParametersLock = new Object();
@@ -517,7 +517,7 @@ public class StandardContext extends ContainerBase
     /**
      * The security roles for this application, keyed by role name.
      */
-    private String securityRoles[] = new String[0];
+    private volatile String securityRoles[] = new String[0];
 
     private final Object securityRolesLock = new Object();
 
@@ -558,7 +558,7 @@ public class StandardContext extends ContainerBase
     /**
      * The watched resources for this application.
      */
-    private String watchedResources[] = new String[0];
+    private volatile String watchedResources[] = new String[0];
 
     private final Object watchedResourcesLock = new Object();
 
@@ -566,7 +566,7 @@ public class StandardContext extends ContainerBase
     /**
      * The welcome files for this application.
      */
-    private String welcomeFiles[] = new String[0];
+    private volatile String welcomeFiles[] = new String[0];
 
     private final Object welcomeFilesLock = new Object();
 
@@ -575,7 +575,7 @@ public class StandardContext extends ContainerBase
      * The set of classnames of LifecycleListeners that will be added
      * to each newly created Wrapper by <code>createWrapper()</code>.
      */
-    private String wrapperLifecycles[] = new String[0];
+    private volatile String wrapperLifecycles[] = new String[0];
 
     private final Object wrapperLifecyclesLock = new Object();
 
@@ -583,7 +583,7 @@ public class StandardContext extends ContainerBase
      * The set of classnames of ContainerListeners that will be added
      * to each newly created Wrapper by <code>createWrapper()</code>.
      */
-    private String wrapperListeners[] = new String[0];
+    private volatile String wrapperListeners[] = new String[0];
 
     private final Object wrapperListenersLock = new Object();
 


### PR DESCRIPTION
The semantics of the Java programming language allow compilers and microprocessors to
perform optimizations that can interact with incorrectly synchronized code in ways that can
produce behaviors that seem paradoxical.[https://edelivery.oracle.com/otn-pub/jcp/memory_model-1.0-pfd-spec-oth-JSpec/memory_model-1_0-pfd-spec.pdf](url) page6

For example 
```
org.apache.catalina.core.StandardContext.java

private String applicationListeners[] = new String[0];
.........
 @Override

  public void addApplicationListener(String listener) {
```

        synchronized (applicationListenersLock) {
            String results[] = new String[applicationListeners.length + 1];
            for (int i = 0; i < applicationListeners.length; i++) {
                if (listener.equals(applicationListeners[i])) {
                    log.info(sm.getString("standardContext.duplicateListener",listener));
                    return;
                }
                results[i] = applicationListeners[i];
            }
            results[applicationListeners.length] = listener;
            applicationListeners = results;
        }
        fireContainerEvent("addApplicationListener", listener);
    }

We expect this line of code(`applicationListeners = results;`) to be executed eventually
But because of instruction reordering,The following operating procedures are also allowed to exis
```
@Override
    public void addApplicationListener(String listener) {
```

        synchronized (applicationListenersLock) {
            String results[] = new String[applicationListeners.length + 1];
            applicationListeners = results;
            for (int i = 0; i < applicationListeners.length; i++) {
                if (listener.equals(applicationListeners[i])) {
                    log.info(sm.getString("standardContext.duplicateListener",listener));
                    return;
                }
                results[i] = applicationListeners[i];
            }
            results[applicationListeners.length] = listener;
            
        }
        fireContainerEvent("addApplicationListener", listener);

    }
If this happens, it will be different from our expectations.

If volatile modifiers are added to variables, instruction reordering is prohibited
`private String applicationListeners[] = new String[0]; `-->
` private volatile String applicationListeners[] = new String[0];`
Satisfy the purpose of the last execution of this line of code(`applicationListeners = results;`).