### PR TITLE
Adding ReDoS warning/documentation to RewriteValve

### DIFF
--- a/java/org/apache/catalina/valves/rewrite/RewriteValve.java
+++ b/java/org/apache/catalina/valves/rewrite/RewriteValve.java
@@ -52,6 +52,18 @@ import org.apache.tomcat.util.file.ConfigFileLoader;
 import org.apache.tomcat.util.file.ConfigurationSource;
 import org.apache.tomcat.util.http.RequestUtil;
 
+/**
+* Note: Extra caution should be used when adding a Rewrite Rule. 
+* When specifying a regex to match for in a Rewrite Rule, certain regex
+* could allow an attacker to DoS your server, as Java's regex parsing is
+* vulnerable to "catastrophic backtracking" (also known as "Regular
+* expression Denial of Service", or ReDoS). There are some open source
+* tools to help detect vulnerable regex, though in general it is a hard
+* problem. A good defense is to use a regex debugger on your desired
+* regex, and read more on the subject of catastrophic backtracking.
+*
+* @see <a href="https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS">OWASP ReDoS</a>
+*/
 public class RewriteValve extends ValveBase {
 
     /**

--- a/webapps/docs/rewrite.xml
+++ b/webapps/docs/rewrite.xml
@@ -422,6 +422,17 @@ public interface RewriteMap {
       applied. This may not be the originally requested URL,
       which may already have matched a previous rule, and have been
       altered.</p>
+    
+      <p><strong>Security warning:</strong> Due to the way Java's
+      regex matching is done, poorly formed regex patterns are vulnerable
+      to "catastrophic backtracking", also known as "regular expression
+      denial of service" or ReDoS. Therefore, extra caution should be used
+      for RewriteRule patterns. In general it is difficult to automatically
+      detect such vulnerable regex, and so a good defense is to read a bit
+      on the subject of catastrophic backtracking. A good reference is the
+      <a href="https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS">
+      OWASP ReDoS guide</a>.</p>
+      
 
       <p>Some hints on the syntax of regular
       expressions:</p>


### PR DESCRIPTION
After reporting a potential DoS in "Rewrite Rules" to the Tomcat security team, it was decided that there was no bug in Tomcat itself, but rather in how a user sets up their Tomcat server. Thus, I was instructed by the security team to create a PR for updated documentation to better educate users on appropriate usage of Rewrite Rules. This commit added javadoc comments for the RewriteValve class, as instructed.

Furthermore, I'd like to update the documentation on this page as well, however I cannot find a mechanism to do so: https://tomcat.apache.org/tomcat-9.0-doc/rewrite.html