### PR TITLE
Add compiler source and target support for all Java versions over 10

### DIFF
--- a/java/org/apache/jasper/compiler/JDTCompiler.java
+++ b/java/org/apache/jasper/compiler/JDTCompiler.java
@@ -324,6 +324,9 @@ public class JDTCompiler extends org.apache.jasper.compiler.Compiler {
             } else if(opt.equals("11")) {
                 settings.put(CompilerOptions.OPTION_Source,
                              CompilerOptions.VERSION_11);
+            } else if(opt.equals("12")) {
+            // Constant not available in latest ECJ version
+                settings.put(CompilerOptions.OPTION_Source, "12");
             } else {
                 log.warn(Localizer.getMessage("jsp.warning.unknown.sourceVM", opt));
                 settings.put(CompilerOptions.OPTION_Source,
@@ -387,6 +390,10 @@ public class JDTCompiler extends org.apache.jasper.compiler.Compiler {
                         CompilerOptions.VERSION_11);
                 settings.put(CompilerOptions.OPTION_Compliance,
                         CompilerOptions.VERSION_11);
+            } else if(opt.equals("12")) {
+            // Constant not available in latest ECJ version
+                settings.put(CompilerOptions.OPTION_TargetPlatform, "12");
+                settings.put(CompilerOptions.OPTION_Compliance, "12");
             } else {
                 log.warn(Localizer.getMessage("jsp.warning.unknown.targetVM", opt));
                 settings.put(CompilerOptions.OPTION_TargetPlatform,


### PR DESCRIPTION
Hi,

I maintain the maven plugin to compile JSP : https://github.com/leonardehrenfried/jspc-maven-plugin

We have receive an issue when someone trying to compile JSP with Java 11 (to obtain target jsp class in Java 11 bytecode) see https://github.com/leonardehrenfried/jspc-maven-plugin/issues/39

I have look at the JDTCompiler source code and it appear that it handle only Java 10.

So I propose this modifications : 

- If compiler source or target is set, and value is not known by ECJ constant, we even set this directly and not fallback to Java 1.8.
Java move faster now, and probably ECJ will not move as faster.
- If compiler source or target is not set, we fallback to Java 1.8 as previous

WDYT ?

Thanks you all