### PR TITLE
Fix wrong protocol version usage

### DIFF
--- a/java/org/apache/coyote/http2/Stream.java
+++ b/java/org/apache/coyote/http2/Stream.java
@@ -126,7 +126,7 @@ class Stream extends AbstractStream implements HeaderEmitter {
         this.coyoteRequest.setSendfile(handler.hasAsyncIO() && handler.getProtocol().getUseSendfile());
         this.coyoteResponse.setOutputBuffer(http2OutputBuffer);
         this.coyoteRequest.setResponse(coyoteResponse);
-        this.coyoteRequest.protocol().setString("HTTP/2.0");
+        this.coyoteRequest.protocol().setString("HTTP/2");
         if (this.coyoteRequest.getStartTime() < 0) {
             this.coyoteRequest.setStartTime(System.currentTimeMillis());
         }


### PR DESCRIPTION
When serving a HTTP/2 request the protocol version was set as "HTTP/2.0"
which does not exist.

This needs also to be backported to 8.5