### PR TITLE
Don't place CrawlerSessionManagerValve into session, place data-holder only

### DIFF
--- a/java/org/apache/catalina/valves/CrawlerSessionManagerValve.java
+++ b/java/org/apache/catalina/valves/CrawlerSessionManagerValve.java
@@ -17,6 +17,7 @@
 package org.apache.catalina.valves;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Enumeration;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -241,7 +242,7 @@ public class CrawlerSessionManagerValve extends ValveBase {
                     clientIdSessionId.put(clientIdentifier, s.getId());
                     sessionIdClientId.put(s.getId(), clientIdentifier);
                     // #valueUnbound() will be called on session expiration
-                    s.setAttribute(this.getClass().getName(), new CrawlerHttpSessionBindingListener(clientIdSessionId, sessionIdClientId));
+                    s.setAttribute(this.getClass().getName(), new CrawlerHttpSessionBindingListener(clientIdSessionId, clientIdentifier));
                     s.setMaxInactiveInterval(sessionInactiveInterval);
 
                     if (log.isDebugEnabled()) {
@@ -269,20 +270,19 @@ public class CrawlerSessionManagerValve extends ValveBase {
         return result.toString();
     }
 
-    private static class CrawlerHttpSessionBindingListener implements HttpSessionBindingListener {
-        private final Map<String, String> clientIdSessionId;
-        private final Map<String, String> sessionIdClientId;
+    private static class CrawlerHttpSessionBindingListener implements HttpSessionBindingListener, Serializable {
+        private final transient Map<String, String> clientIdSessionId;
+        private final transient String clientIdentifier;
 
-        public CrawlerHttpSessionBindingListener(Map<String, String> clientIdSessionId, Map<String, String> sessionIdClientId) {
+        private CrawlerHttpSessionBindingListener(Map<String, String> clientIdSessionId, String clientIdentifier) {
             this.clientIdSessionId = clientIdSessionId;
-            this.sessionIdClientId = sessionIdClientId;
+            this.clientIdentifier = clientIdentifier;
         }
 
         @Override
         public void valueUnbound(HttpSessionBindingEvent event) {
-            String clientIdentifier = sessionIdClientId.remove(event.getSession().getId());
-            if (clientIdentifier != null) {
-                clientIdSessionId.remove(clientIdentifier);
+            if (clientIdentifier != null && clientIdSessionId != null) {
+                clientIdSessionId.remove(clientIdentifier, event.getSession().getId());
             }
         }
     }

--- a/test/org/apache/catalina/valves/TestCrawlerSessionManagerValve.java
+++ b/test/org/apache/catalina/valves/TestCrawlerSessionManagerValve.java
@@ -28,7 +28,6 @@ import org.apache.catalina.Manager;
 import org.apache.catalina.core.StandardContext;
 import org.apache.catalina.session.StandardManager;
 import org.apache.catalina.session.StandardSession;
-import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 import org.apache.catalina.Context;


### PR DESCRIPTION
It helps to serialize this sessions with libraries like kryo.

Background:
we've found out, that our kryo library serializes the whole valve.
Our stack indicates, that jdk internals are getting serialized into the
sessions. It's unnecessary and can be solves more easily with this fix.