### PR TITLE
Don't place CrawlerSessionManagerValve into session, place data-holder only. For 8.5.x

### DIFF
--- a/java/org/apache/catalina/valves/CrawlerSessionManagerValve.java
+++ b/java/org/apache/catalina/valves/CrawlerSessionManagerValve.java
@@ -42,7 +42,7 @@ import org.apache.juli.logging.LogFactory;
  * users - regardless of whether or not they provide a session token with their
  * requests.
  */
-public class CrawlerSessionManagerValve extends ValveBase implements HttpSessionBindingListener {
+public class CrawlerSessionManagerValve extends ValveBase {
 
     private static final Log log = LogFactory.getLog(CrawlerSessionManagerValve.class);
 
@@ -241,7 +241,7 @@ public class CrawlerSessionManagerValve extends ValveBase implements HttpSession
                     clientIdSessionId.put(clientIdentifier, s.getId());
                     sessionIdClientId.put(s.getId(), clientIdentifier);
                     // #valueUnbound() will be called on session expiration
-                    s.setAttribute(this.getClass().getName(), this);
+                    s.setAttribute(this.getClass().getName(), new CrawlerHttpSessionBindingListener(clientIdSessionId, sessionIdClientId));
                     s.setMaxInactiveInterval(sessionInactiveInterval);
 
                     if (log.isDebugEnabled()) {
@@ -269,18 +269,26 @@ public class CrawlerSessionManagerValve extends ValveBase implements HttpSession
         return result.toString();
     }
 
+    private static class CrawlerHttpSessionBindingListener implements HttpSessionBindingListener {
+        private final Map<String, String> clientIdSessionId;
+        private final Map<String, String> sessionIdClientId;
 
-    @Override
-    public void valueBound(HttpSessionBindingEvent event) {
-        // NOOP
-    }
+        public CrawlerHttpSessionBindingListener(Map<String, String> clientIdSessionId, Map<String, String> sessionIdClientId) {
+            this.clientIdSessionId = clientIdSessionId;
+            this.sessionIdClientId = sessionIdClientId;
+        }
 
+        @Override
+        public void valueBound(HttpSessionBindingEvent event) {
+            // NOOP
+        }
 
-    @Override
-    public void valueUnbound(HttpSessionBindingEvent event) {
-        String clientIdentifier = sessionIdClientId.remove(event.getSession().getId());
-        if (clientIdentifier != null) {
-            clientIdSessionId.remove(clientIdentifier);
+        @Override
+        public void valueUnbound(HttpSessionBindingEvent event) {
+            String clientIdentifier = sessionIdClientId.remove(event.getSession().getId());
+            if (clientIdentifier != null) {
+                clientIdSessionId.remove(clientIdentifier);
+            }
         }
     }
 }

--- a/java/org/apache/catalina/valves/CrawlerSessionManagerValve.java
+++ b/java/org/apache/catalina/valves/CrawlerSessionManagerValve.java
@@ -88,8 +88,8 @@ public class CrawlerSessionManagerValve extends ValveBase {
     }
 
     /**
+     * @return The current regular expression being used to match user agents.
      * @see #setCrawlerUserAgents(String)
-     * @return  The current regular expression being used to match user agents.
      */
     public String getCrawlerUserAgents() {
         return crawlerUserAgents;
@@ -113,8 +113,8 @@ public class CrawlerSessionManagerValve extends ValveBase {
     }
 
     /**
-     * @see #setCrawlerIps(String)
      * @return The current regular expression being used to match IP addresses.
+     * @see #setCrawlerIps(String)
      */
     public String getCrawlerIps() {
         return crawlerIps;
@@ -125,15 +125,15 @@ public class CrawlerSessionManagerValve extends ValveBase {
      * Specify the session timeout (in seconds) for a crawler's session. This is
      * typically lower than that for a user session. The default is 60 seconds.
      *
-     * @param sessionInactiveInterval   The new timeout for crawler sessions
+     * @param sessionInactiveInterval The new timeout for crawler sessions
      */
     public void setSessionInactiveInterval(int sessionInactiveInterval) {
         this.sessionInactiveInterval = sessionInactiveInterval;
     }
 
     /**
+     * @return The current timeout in seconds
      * @see #setSessionInactiveInterval(int)
-     * @return  The current timeout in seconds
      */
     public int getSessionInactiveInterval() {
         return sessionInactiveInterval;
@@ -287,8 +287,9 @@ public class CrawlerSessionManagerValve extends ValveBase {
         @Override
         public void valueUnbound(HttpSessionBindingEvent event) {
             if (clientIdentifier != null && clientIdSessionId != null) {
-                if(clientIdSessionId.get(clientIdentifier).equals(event.getSession().getId()))
-                clientIdSessionId.remove(clientIdentifier);
+                if (clientIdSessionId.get(clientIdentifier).equals(event.getSession().getId())) {
+                    clientIdSessionId.remove(clientIdentifier);
+                }
             }
         }
     }

--- a/test/org/apache/catalina/valves/TestCrawlerSessionManagerValve.java
+++ b/test/org/apache/catalina/valves/TestCrawlerSessionManagerValve.java
@@ -28,7 +28,6 @@ import org.apache.catalina.Manager;
 import org.apache.catalina.core.StandardContext;
 import org.apache.catalina.session.StandardManager;
 import org.apache.catalina.session.StandardSession;
-import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 import org.apache.catalina.Context;


### PR DESCRIPTION
It helps to serialize this sessions with libraries like kryo.

Background:
we've found out, that our kryo library serializes the whole valve.
Our stack indicates, that jdk internals are getting serialized into the
sessions. It's unnecessary and can be solves more easily with this fix.