### PR TITLE
Don't place CrawlerSessionManagerValve into session, place data-holder only. For 7.0.x

### DIFF
--- a/java/org/apache/catalina/valves/CrawlerSessionManagerValve.java
+++ b/java/org/apache/catalina/valves/CrawlerSessionManagerValve.java
@@ -42,7 +42,7 @@ import org.apache.juli.logging.LogFactory;
  * users - regardless of whether or not they provide a session token with their
  * requests.
  */
-public class CrawlerSessionManagerValve extends ValveBase implements HttpSessionBindingListener {
+public class CrawlerSessionManagerValve extends ValveBase {
 
     private static final Log log = LogFactory.getLog(CrawlerSessionManagerValve.class);
 
@@ -241,7 +241,7 @@ public class CrawlerSessionManagerValve extends ValveBase implements HttpSession
                     clientIdSessionId.put(clientIdentifier, s.getId());
                     sessionIdClientId.put(s.getId(), clientIdentifier);
                     // #valueUnbound() will be called on session expiration
-                    s.setAttribute(this.getClass().getName(), this);
+                    s.setAttribute(this.getClass().getName(), new CrawlerHttpSessionBindingListener(clientIdSessionId, sessionIdClientId));
                     s.setMaxInactiveInterval(sessionInactiveInterval);
 
                     if (log.isDebugEnabled()) {
@@ -269,18 +269,26 @@ public class CrawlerSessionManagerValve extends ValveBase implements HttpSession
         return result.toString();
     }
 
+    private static class CrawlerHttpSessionBindingListener implements HttpSessionBindingListener {
+        private final Map<String, String> clientIdSessionId;
+        private final Map<String, String> sessionIdClientId;
 
-    @Override
-    public void valueBound(HttpSessionBindingEvent event) {
-        // NOOP
-    }
+        public CrawlerHttpSessionBindingListener(Map<String, String> clientIdSessionId, Map<String, String> sessionIdClientId) {
+            this.clientIdSessionId = clientIdSessionId;
+            this.sessionIdClientId = sessionIdClientId;
+        }
 
+        @Override
+        public void valueBound(HttpSessionBindingEvent event) {
+            // NOOP
+        }
 
-    @Override
-    public void valueUnbound(HttpSessionBindingEvent event) {
-        String clientIdentifier = sessionIdClientId.remove(event.getSession().getId());
-        if (clientIdentifier != null) {
-            clientIdSessionId.remove(clientIdentifier);
+        @Override
+        public void valueUnbound(HttpSessionBindingEvent event) {
+            String clientIdentifier = sessionIdClientId.remove(event.getSession().getId());
+            if (clientIdentifier != null) {
+                clientIdSessionId.remove(clientIdentifier);
+            }
         }
     }
 }

--- a/java/org/apache/catalina/valves/CrawlerSessionManagerValve.java
+++ b/java/org/apache/catalina/valves/CrawlerSessionManagerValve.java
@@ -17,6 +17,7 @@
 package org.apache.catalina.valves;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Enumeration;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -241,7 +242,7 @@ public class CrawlerSessionManagerValve extends ValveBase {
                     clientIdSessionId.put(clientIdentifier, s.getId());
                     sessionIdClientId.put(s.getId(), clientIdentifier);
                     // #valueUnbound() will be called on session expiration
-                    s.setAttribute(this.getClass().getName(), new CrawlerHttpSessionBindingListener(clientIdSessionId, sessionIdClientId));
+                    s.setAttribute(this.getClass().getName(), new CrawlerHttpSessionBindingListener(clientIdSessionId, clientIdentifier));
                     s.setMaxInactiveInterval(sessionInactiveInterval);
 
                     if (log.isDebugEnabled()) {
@@ -269,13 +270,13 @@ public class CrawlerSessionManagerValve extends ValveBase {
         return result.toString();
     }
 
-    private static class CrawlerHttpSessionBindingListener implements HttpSessionBindingListener {
-        private final Map<String, String> clientIdSessionId;
-        private final Map<String, String> sessionIdClientId;
+    private static class CrawlerHttpSessionBindingListener implements HttpSessionBindingListener, Serializable {
+        private final transient Map<String, String> clientIdSessionId;
+        private final transient String clientIdentifier;
 
-        public CrawlerHttpSessionBindingListener(Map<String, String> clientIdSessionId, Map<String, String> sessionIdClientId) {
+        private CrawlerHttpSessionBindingListener(Map<String, String> clientIdSessionId, String clientIdentifier) {
             this.clientIdSessionId = clientIdSessionId;
-            this.sessionIdClientId = sessionIdClientId;
+            this.clientIdentifier = clientIdentifier;
         }
 
         @Override
@@ -285,9 +286,8 @@ public class CrawlerSessionManagerValve extends ValveBase {
 
         @Override
         public void valueUnbound(HttpSessionBindingEvent event) {
-            String clientIdentifier = sessionIdClientId.remove(event.getSession().getId());
-            if (clientIdentifier != null) {
-                clientIdSessionId.remove(clientIdentifier);
+            if (clientIdentifier != null && clientIdSessionId != null) {
+                clientIdSessionId.remove(clientIdentifier, event.getSession().getId());
             }
         }
     }

--- a/test/org/apache/catalina/valves/TestCrawlerSessionManagerValve.java
+++ b/test/org/apache/catalina/valves/TestCrawlerSessionManagerValve.java
@@ -28,7 +28,6 @@ import org.apache.catalina.Manager;
 import org.apache.catalina.core.StandardContext;
 import org.apache.catalina.session.StandardManager;
 import org.apache.catalina.session.StandardSession;
-import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 import org.apache.catalina.Context;
@@ -48,7 +47,7 @@ public class TestCrawlerSessionManagerValve {
 
     static {
         TEST_MANAGER = new StandardManager();
-        TEST_MANAGER.setContext(new StandardContext());
+        TEST_MANAGER.setContainer(new StandardContext());
     }
 
 


### PR DESCRIPTION
It helps to serialize this sessions with libraries like kryo.

Background:
we've found out, that our kryo library serializes the whole valve.
Our stack indicates, that jdk internals are getting serialized into the
sessions. It's unnecessary and can be solves more easily with this fix.
(backporting, not an issue with 7.0.x for us)