### PR TITLE
Early check end of input condition to avoid ArrayIndexOutOfBoundsExceptions

### DIFF
--- a/java/org/apache/tomcat/util/http/parser/HttpParser.java
+++ b/java/org/apache/tomcat/util/http/parser/HttpParser.java
@@ -890,7 +890,14 @@ public class HttpParser {
         }
 
         public DomainParseState next(int c) {
-            if (HttpParser.isAlpha(c)) {
+            if (c == -1) {
+                if (allowsEnd) {
+                    return END;
+                } else {
+                    throw new IllegalArgumentException(
+                            sm.getString("http.invalidSegmentEndState", this.name()));
+                }
+            } else if (HttpParser.isAlpha(c)) {
                 return ALPHA;
             } else if (HttpParser.isNumeric(c)) {
                 return NUMERIC;
@@ -907,13 +914,6 @@ public class HttpParser {
                 } else {
                     throw new IllegalArgumentException(sm.getString(errorMsg,
                             Character.toString((char) c)));
-                }
-            } else if (c == -1) {
-                if (allowsEnd) {
-                    return END;
-                } else {
-                    throw new IllegalArgumentException(
-                            sm.getString("http.invalidSegmentEndState", this.name()));
                 }
             } else if (c == '-') {
                 if (allowsHyphen) {


### PR DESCRIPTION
Exceptions are expensive and should only be thrown in an exceptional state. End of input is no exception but should be expected. With the previous code a perfectly valid hostname will produce and process two ArrayIndexOutOfBoundsExceptions at its end, one in HttpParser.isAlpha() and one in HttpParser.isNumeric(), before detecting the end of input.