### PR TITLE
Use test -t command to check if STDOUT is opened on a terminal

### DIFF
--- a/bin/catalina.sh
+++ b/bin/catalina.sh
@@ -228,7 +228,7 @@ fi
 
 # Bugzilla 37848: When no TTY is available, don't output to console
 have_tty=0
-if [ "`tty`" != "not a tty" ]; then
+if [ -t 1 ]; then
     have_tty=1
 fi
 


### PR DESCRIPTION
Current check for TTY availability in catalina.sh doesn't work if non-English locales are installed and activated. This fix uses `test` command instead of `tty` command.