### PR TITLE
Use STDIN for terminal availability check

### DIFF
--- a/bin/catalina.sh
+++ b/bin/catalina.sh
@@ -228,7 +228,7 @@ fi
 
 # Bugzilla 37848: When no TTY is available, don't output to console
 have_tty=0
-if [ -t 1 ]; then
+if [ -t 0 ]; then
     have_tty=1
 fi
 


### PR DESCRIPTION
My previous patch for terminal availability check (using STDOUT), breaks when catalina.sh output is used in a pipe. This patch switches test to be based on STDIN. It better resembles behaviour of `tty` command previously used here and hopefully doesn't have any other side effects.