### PR TITLE
CoyoteAdapter: fix out-of-bounds read in checkNormalize

### DIFF
--- a/java/org/apache/catalina/connector/CoyoteAdapter.java
+++ b/java/org/apache/catalina/connector/CoyoteAdapter.java
@@ -1252,11 +1252,6 @@ public class CoyoteAdapter implements Adapter {
 
         int pos = 0;
 
-        // An empty URL is not acceptable
-        if (start == end) {
-            return false;
-        }
-
         // Check for '\' and 0
         for (pos = start; pos < end; pos++) {
             if (c[pos] == '\\') {

--- a/java/org/apache/catalina/connector/CoyoteAdapter.java
+++ b/java/org/apache/catalina/connector/CoyoteAdapter.java
@@ -1252,6 +1252,11 @@ public class CoyoteAdapter implements Adapter {
 
         int pos = 0;
 
+        // An empty URL is not acceptable
+        if (start == end) {
+            return false;
+        }
+
         // Check for '\' and 0
         for (pos = start; pos < end; pos++) {
             if (c[pos] == '\\') {
@@ -1269,6 +1274,11 @@ public class CoyoteAdapter implements Adapter {
                     return false;
                 }
             }
+        }
+
+        // The URL must start with '/'
+        if (c[start] != '/') {
+            return false;
         }
 
         // Check for ending with "/." or "/.."

--- a/test/org/apache/catalina/connector/TestCoyoteAdapter.java
+++ b/test/org/apache/catalina/connector/TestCoyoteAdapter.java
@@ -326,6 +326,7 @@ public class TestCoyoteAdapter extends TomcatBaseTest {
     @Test
     public void testNormalize01() {
         doTestNormalize("/foo/../bar", "/bar");
+        doTestNormalize("..", null);
     }
 
     private void doTestNormalize(String input, String expected) {
@@ -342,6 +343,29 @@ public class TestCoyoteAdapter extends TomcatBaseTest {
             Assert.assertTrue(result);
             Assert.assertEquals(expected, mb.toString());
         }
+    }
+
+    @Test
+    public void testCheckNormalize() {
+        doTestCheckNormalize("/url", true);
+
+        doTestCheckNormalize("", false);
+        doTestCheckNormalize("..", false);
+        doTestCheckNormalize("/.", false);
+        doTestCheckNormalize("/..", false);
+        doTestCheckNormalize("/./", false);
+        doTestCheckNormalize("//", false);
+        doTestCheckNormalize("/../", false);
+        doTestCheckNormalize("\\", false);
+        doTestCheckNormalize("\0", false);
+    }
+
+    private void doTestCheckNormalize(String input, boolean expected) {
+        MessageBytes mb = MessageBytes.newInstance();
+        mb.setChars(input.toCharArray(), 0, input.length());
+
+        boolean result = CoyoteAdapter.checkNormalize(mb);
+        Assert.assertEquals(expected, result);
     }
 
 

--- a/test/org/apache/catalina/connector/TestCoyoteAdapter.java
+++ b/test/org/apache/catalina/connector/TestCoyoteAdapter.java
@@ -349,7 +349,6 @@ public class TestCoyoteAdapter extends TomcatBaseTest {
     public void testCheckNormalize() {
         doTestCheckNormalize("/url", true);
 
-        doTestCheckNormalize("", false);
         doTestCheckNormalize("..", false);
         doTestCheckNormalize("/.", false);
         doTestCheckNormalize("/..", false);

--- a/test/org/apache/catalina/connector/TestCoyoteAdapter.java
+++ b/test/org/apache/catalina/connector/TestCoyoteAdapter.java
@@ -326,6 +326,10 @@ public class TestCoyoteAdapter extends TomcatBaseTest {
     @Test
     public void testNormalize01() {
         doTestNormalize("/foo/../bar", "/bar");
+    }
+
+    @Test
+    public void testNormalize02() {
         doTestNormalize("..", null);
     }
 
@@ -346,17 +350,13 @@ public class TestCoyoteAdapter extends TomcatBaseTest {
     }
 
     @Test
-    public void testCheckNormalize() {
+    public void testCheckNormalize01() {
         doTestCheckNormalize("/url", true);
+    }
 
+    @Test
+    public void testCheckNormalize02() {
         doTestCheckNormalize("..", false);
-        doTestCheckNormalize("/.", false);
-        doTestCheckNormalize("/..", false);
-        doTestCheckNormalize("/./", false);
-        doTestCheckNormalize("//", false);
-        doTestCheckNormalize("/../", false);
-        doTestCheckNormalize("\\", false);
-        doTestCheckNormalize("\0", false);
     }
 
     private void doTestCheckNormalize(String input, boolean expected) {


### PR DESCRIPTION
On malformed requests, checkNormalize would throw an ArrayIndexOutOfBoundsException leading to a 500 response. This change fixes checkNormalize to return false instead of throwing exception on those inputs, and adds a few tests to check the new functionality.

For the record, the exception is below:

```
java.lang.ArrayIndexOutOfBoundsException: -1
        at org.apache.catalina.connector.CoyoteAdapter.checkNormalize(CoyoteAdapter.java:1275) ~[tomcat-embed-core-9.0.19.jar!/:9.0.19]
        at org.apache.catalina.connector.CoyoteAdapter.postParseRequest(CoyoteAdapter.java:647) ~[tomcat-embed-core-9.0.19.jar!/:9.0.19]
        at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:337) ~[tomcat-embed-core-9.0.19.jar!/:9.0.19]
        at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:408) ~[tomcat-embed-core-9.0.19.jar!/:9.0.19]
        at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:66) [tomcat-embed-core-9.0.19.jar!/:9.0.19]
        at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:836) [tomcat-embed-core-9.0.19.jar!/:9.0.19]
        at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1747) [tomcat-embed-core-9.0.19.jar!/:9.0.19]
        at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49) [tomcat-embed-core-9.0.19.jar!/:9.0.19]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [na:1.8.0_212]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [na:1.8.0_212]
        at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61) [tomcat-embed-core-9.0.19.jar!/:9.0.19]
        at java.lang.Thread.run(Thread.java:748) [na:1.8.0_212]
```