### PR TITLE
BZ 63556: Mark request as forwarded in RemoteIpValve/RemoteIpFilter

### DIFF
--- a/java/org/apache/catalina/Globals.java
+++ b/java/org/apache/catalina/Globals.java
@@ -199,6 +199,15 @@ public final class Globals {
             org.apache.coyote.Constants.REMOTE_ADDR_ATTRIBUTE;
 
 
+    /**
+     * The request attribute that is set to the value of {@code Boolean.TRUE}
+     * by the RemoteIpFilter, RemoteIpValve (and other similar components) that identifies
+     * a request which been forwarded via one or more proxies.
+     */
+    public static final String REQUEST_FORWARDED_ATTRIBUTE =
+        "org.apache.tomcat.request.forwarded";
+
+
     public static final String ASYNC_SUPPORTED_ATTR =
         "org.apache.catalina.ASYNC_SUPPORTED";
 

--- a/java/org/apache/catalina/filters/RemoteIpFilter.java
+++ b/java/org/apache/catalina/filters/RemoteIpFilter.java
@@ -82,6 +82,8 @@ import org.apache.tomcat.util.res.StringManager;
  * <code>protocolHeaderHttpsValue</code> configuration parameter (default <code>https</code>) then <code>request.isSecure = true</code>,
  * <code>request.scheme = https</code> and <code>request.serverPort = 443</code>. Note that 443 can be overwritten with the
  * <code>$httpsServerPort</code> configuration parameter.</li>
+ * <li>Mark the request with the attribute {@link Globals#REQUEST_FORWARDED_ATTRIBUTE} and value {@code Boolean.TRUE} to indicate
+ * that this request has been forwarded by one or more proxies.</li>
  * </ul>
  * <table border="1">
  * <caption>Configuration parameters</caption>
@@ -819,6 +821,8 @@ public class RemoteIpFilter extends GenericFilter {
                     setPorts(xRequest, httpServerPort);
                 }
             }
+
+            request.setAttribute(Globals.REQUEST_FORWARDED_ATTRIBUTE, Boolean.TRUE);
 
             if (log.isDebugEnabled()) {
                 log.debug("Incoming request " + request.getRequestURI() + " with originalRemoteAddr '" + request.getRemoteAddr()

--- a/java/org/apache/catalina/valves/RemoteIpValve.java
+++ b/java/org/apache/catalina/valves/RemoteIpValve.java
@@ -64,6 +64,8 @@ import org.apache.tomcat.util.http.MimeHeaders;
  * <code>protocolHeaderHttpsValue</code> configuration parameter (default <code>https</code>) then <code>request.isSecure = true</code>,
  * <code>request.scheme = https</code> and <code>request.serverPort = 443</code>. Note that 443 can be overwritten with the
  * <code>$httpsServerPort</code> configuration parameter.</li>
+ * <li>Mark the request with the attribute {@link Globals#REQUEST_FORWARDED_ATTRIBUTE} and value {@code Boolean.TRUE} to indicate
+ * that this request has been forwarded by one or more proxies.</li>
  * </ul>
  * <table border="1">
  * <caption>Configuration parameters</caption>
@@ -650,6 +652,8 @@ public class RemoteIpValve extends ValveBase {
                     setPorts(request, httpServerPort);
                 }
             }
+
+            request.setAttribute(Globals.REQUEST_FORWARDED_ATTRIBUTE, Boolean.TRUE);
 
             if (log.isDebugEnabled()) {
                 log.debug("Incoming request " + request.getRequestURI() + " with originalRemoteAddr '" + originalRemoteAddr

--- a/test/org/apache/catalina/filters/TestRemoteIpFilter.java
+++ b/test/org/apache/catalina/filters/TestRemoteIpFilter.java
@@ -42,6 +42,7 @@ import org.junit.Test;
 
 import org.apache.catalina.AccessLog;
 import org.apache.catalina.Context;
+import org.apache.catalina.Globals;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.connector.Request;
@@ -622,6 +623,28 @@ public class TestRemoteIpFilter extends TomcatBaseTest {
         Assert.assertEquals("org.apache.catalina.AccessLog.RemoteHost",
                 "140.211.11.130",
                 actualRequest.getAttribute(AccessLog.REMOTE_HOST_ATTRIBUTE));
+    }
+
+    @Test
+    public void testRequestForwarded() throws Exception {
+        // PREPARE
+        FilterDef filterDef = new FilterDef();
+        filterDef.addInitParameter("protocolHeader", "x-forwarded-proto");
+        filterDef.addInitParameter("remoteIpHeader", "x-my-forwarded-for");
+        filterDef.addInitParameter("httpServerPort", "8080");
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("192.168.0.10");
+        request.setHeader("x-my-forwarded-for", "140.211.11.130");
+        request.setHeader("x-forwarded-proto", "http");
+
+        // TEST
+        HttpServletRequest actualRequest = testRemoteIpFilter(filterDef, request).getRequest();
+
+        // VERIFY
+        Assert.assertEquals("org.apache.tomcat.request.forwarded",
+                Boolean.TRUE,
+                actualRequest.getAttribute(Globals.REQUEST_FORWARDED_ATTRIBUTE));
     }
 
     /*

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -45,6 +45,14 @@
   issues do not "pop up" wrt. others).
 -->
 <section name="Tomcat 9.0.23 (markt)" rtext="in development">
+  <subsection name="Catalina">
+    <changelog>
+      <add>
+        <bug>63556</bug>: Mark request as forwarded in RemoteIpValve and
+        RemoteIpFilter (michaelo)
+      </add>
+     </changelog>
+  </subsection>
   <subsection name="Coyote">
     <changelog>
       <scode>


### PR DESCRIPTION
This is WIP, please review. I will squash, backport to 8.5.x (mark-forwarded-request/8.5.x) and merge into both branches. Should this land in 7.0.x too?