### PR TITLE
PropertySource: Add an environment variable based source

### DIFF
--- a/java/org/apache/tomcat/util/EnvironmentPropertySource.java
+++ b/java/org/apache/tomcat/util/EnvironmentPropertySource.java
@@ -1,0 +1,8 @@
+package org.apache.tomcat.util;
+
+public class EnvironmentPropertySource implements IntrospectionUtils.PropertySource {
+	@Override
+	public String getProperty(String key) {
+		return System.getenv(key);
+	}
+}

--- a/java/org/apache/tomcat/util/EnvironmentPropertySource.java
+++ b/java/org/apache/tomcat/util/EnvironmentPropertySource.java
@@ -1,8 +1,0 @@
-package org.apache.tomcat.util;
-
-public class EnvironmentPropertySource implements IntrospectionUtils.PropertySource {
-	@Override
-	public String getProperty(String key) {
-		return System.getenv(key);
-	}
-}

--- a/java/org/apache/tomcat/util/digester/Digester.java
+++ b/java/org/apache/tomcat/util/digester/Digester.java
@@ -138,6 +138,21 @@ public class Digester extends DefaultHandler2 {
     }
 
 
+    public class EnvironmentPropertySource implements IntrospectionUtils.PropertySource {
+        @Override
+        public String getProperty(String key) {
+            ClassLoader cl = getClassLoader();
+            if (cl instanceof PermissionCheck) {
+                Permission p = new RuntimePermission("getenv." + key, null);
+                if (!((PermissionCheck) cl).check(p)) {
+                    return null;
+                }
+            }
+            return System.getenv(key);
+        }
+    }
+
+
     protected IntrospectionUtils.PropertySource source[] = new IntrospectionUtils.PropertySource[] {
             new SystemPropertySource() };
 

--- a/webapps/docs/config/systemprops.xml
+++ b/webapps/docs/config/systemprops.xml
@@ -48,6 +48,9 @@
       <p>Property replacement from the specified property source on the JVM
          system properties can also be done using the
          <code>REPLACE_SYSTEM_PROPERTIES</code> system property.</p>
+      <p><code>org.apache.tomcat.util.digester.Digester.EnvironmentPropertySource</code>
+         can be used to replace parameters from the process' environment variables,
+         e.g. injected ConfigMaps or Secret objects in container based systems like OpenShift or Kubernetes.</p>
     </property>
     <property name="org.apache.tomcat.util.digester. REPLACE_SYSTEM_PROPERTIES">
       <p>Set this boolean system property to <code>true</code> to cause


### PR DESCRIPTION
When tomcat runs in an Openshift based container a Secret containing passwords
can be map as environment variables (with an additional prefix).
An webapp containing an embedded context.xml which defines JDBC datasources and
placeholder variables can be used with this new PropertySource to easily inject
configuration from a Secret or ConfigMap.