### PR TITLE
preload driver in connection pool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ java/org/apache/catalina/startup/catalina.properties
 modules/jdbc-pool/bin
 modules/jdbc-pool/includes
 webapps/docs/jdbc-pool.xml
+target

--- a/modules/jdbc-pool/pom.xml
+++ b/modules/jdbc-pool/pom.xml
@@ -155,6 +155,34 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.1.1</version>
+        <executions>
+          <execution>
+            <id>copy</id>
+            <phase>process-test-resources</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.hsqldb</groupId>
+                  <artifactId>hsqldb</artifactId>
+                  <version>2.5.0</version>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>${project.build.directory}/test-libs</outputDirectory>
+                  <destFileName>hsqldb.jar</destFileName>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/DataSourceProxy.java
+++ b/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/DataSourceProxy.java
@@ -274,6 +274,11 @@ public class DataSourceProxy implements PoolConfiguration {
     @Override
     public void setDriverClassName(String driverClassName) {
         this.poolProperties.setDriverClassName(driverClassName);
+        try {
+            this.pool.reloadDriverIfNeeded();
+        } catch (SQLException e) {
+            throw new IllegalArgumentException(e);
+        }
     }
 
     /**

--- a/modules/jdbc-pool/src/test/java/org/apache/tomcat/jdbc/pool/PooledConnectionTest.java
+++ b/modules/jdbc-pool/src/test/java/org/apache/tomcat/jdbc/pool/PooledConnectionTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tomcat.jdbc.pool;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import org.junit.Test;
+
+/**
+ * Test related to pooled connection.
+ */
+public class PooledConnectionTest {
+    @Test
+    public void avoidNPEWhenTcclIsNull() throws SQLException, IOException {
+        final PoolProperties poolProperties = new PoolProperties();
+        poolProperties.setDriverClassName("org.hsqldb.jdbcDriver"); // not in test loader otherwise test is broken
+        poolProperties.setUsername("sa");
+        poolProperties.setPassword("");
+        poolProperties.setUrl("jdbc:hsqldb:mem:PooledConnectionTest_avoidNPEWhenTcclIsNull");
+        poolProperties.setMaxIdle(1);
+        poolProperties.setMinIdle(1);
+        poolProperties.setInitialSize(1);
+        poolProperties.setMaxActive(1);
+
+        final Thread thread = Thread.currentThread();
+        final ClassLoader testLoader = thread.getContextClassLoader();
+        final DataSource dataSource;
+        try (final URLClassLoader loader = new URLClassLoader(new URL[] {
+                Paths.get("target/test-libs/hsqldb.jar").toUri().toURL()
+        }, testLoader)) {
+            thread.setContextClassLoader(loader);
+            dataSource = new DataSource(poolProperties);
+            checkConnection(dataSource);
+        } finally {
+            thread.setContextClassLoader(testLoader);
+        }
+
+        thread.setContextClassLoader(null);
+        try {
+            checkConnection(dataSource);
+        } finally {
+            thread.setContextClassLoader(testLoader);
+        }
+
+        dataSource.close();
+    }
+
+    private void checkConnection(DataSource dataSource) throws SQLException {
+        try (final Connection connection = dataSource.getConnection()) {
+            assertTrue(connection.isValid(5));
+        }
+    }
+}


### PR DESCRIPTION
share it for all connections to not have mixed connections (multiple driver instances when fallbacking on TCCL)

Side note: the setters of DataSource(Proxy) should likely recreate the pool when called, not sure it is not already the case but looks fishy so a follow up issue can be needed