### PR TITLE
Prevent NullPointerException in CrawlerSessionManagerValve

### DIFF
--- a/java/org/apache/catalina/valves/CrawlerSessionManagerValve.java
+++ b/java/org/apache/catalina/valves/CrawlerSessionManagerValve.java
@@ -265,7 +265,7 @@ public class CrawlerSessionManagerValve extends ValveBase {
         if (isHostAware) {
             result.append('-').append(host.getName());
         }
-        if (isContextAware) {
+        if (isContextAware && context != null) {
             result.append(context.getName());
         }
         return result.toString();


### PR DESCRIPTION
https://bz.apache.org/bugzilla/show_bug.cgi?id=62297 made the CrawlerSessionManagerValve context-aware but the new code does not handle the scenario where requests do not match _any_ application context.
This occurs when there is no application deployed on the ROOT context and the request is outside the context root of the deployed applications.

```
2019-08-09 13:55:49.125 SEVERE [http-nio-0.0.0.0-10099-exec-3] org.apache.coyote.http11.Http11Processor.service Error processing request
 java.lang.NullPointerException
        at org.apache.catalina.valves.CrawlerSessionManagerValve.getClientIdentifier(CrawlerSessionManagerValve.java:267)
        at org.apache.catalina.valves.CrawlerSessionManagerValve.invoke(CrawlerSessionManagerValve.java:181)
        at org.apache.catalina.valves.RemoteIpValve.invoke(RemoteIpValve.java:679)
        at org.apache.catalina.valves.RequestFilterValve.process(RequestFilterValve.java:348)
        at org.apache.catalina.valves.RemoteAddrValve.invoke(RemoteAddrValve.java:53)
        at org.apache.catalina.valves.StuckThreadDetectionValve.invoke(StuckThreadDetectionValve.java:206)
        at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:74)
        at org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:678)
        at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:343)
        at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:408)
        at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:66)
        at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:836)
        at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1747)
        at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
        at java.lang.Thread.run(Thread.java:748)
```

nb: this also applies to Tomcat 7/8/8.5