### PR TITLE
Fix '/opt already exists' build error

### DIFF
--- a/res/tomcat-maven/Dockerfile
+++ b/res/tomcat-maven/Dockerfile
@@ -38,7 +38,7 @@ ENV JAVA_OPTS="${JAVA_OPTS} -Djava.util.logging.manager=org.apache.juli.ClassLoa
 
 RUN sh -c 'touch app.jar'
 
-RUN mkdir /opt
+RUN mkdir -p /opt
 
 # Optional: Add Jolokia agent for JMX monitoring and management
 # RUN mkdir /opt/jolokia && wget https://repo.maven.apache.org/maven2/org/jolokia/jolokia-jvm/1.6.2/jolokia-jvm-1.6.2-agent.jar -O /opt/jolokia/jolokia.jar


### PR DESCRIPTION
The base image (openjdk:8-jre-alpine) already provides that folder.