### PR TITLE
fix JSSE_OPTS quoting

### DIFF
--- a/bin/catalina.bat
+++ b/bin/catalina.bat
@@ -206,7 +206,7 @@ set "CLASSPATH=%CLASSPATH%;%CATALINA_HOME%\bin\tomcat-juli.jar"
 :juliClasspathDone
 
 if not "%JSSE_OPTS%" == "" goto gotJsseOpts
-set JSSE_OPTS="-Djdk.tls.ephemeralDHKeySize=2048"
+set "JSSE_OPTS=-Djdk.tls.ephemeralDHKeySize=2048"
 :gotJsseOpts
 set "JAVA_OPTS=%JAVA_OPTS% %JSSE_OPTS%"
 


### PR DESCRIPTION
Otherwise if JSSE_OPTS is set with the same value, the quotation will cancel itself in the if condition.

```
if not ""-Djdk.tls.ephemeralDHKeySize=2048""
```

resulting in the following error

```
=2048"" was unexpected at this time.
```