### PR TITLE
Avoid NPE in NamingContextListener.getGlobalNamingContext with Embedded containers

### DIFF
--- a/java/org/apache/catalina/core/NamingContextListener.java
+++ b/java/org/apache/catalina/core/NamingContextListener.java
@@ -1113,7 +1113,11 @@ public class NamingContextListener
     private javax.naming.Context getGlobalNamingContext() {
         if (container instanceof Context) {
             Engine e = (Engine) ((Context) container).getParent().getParent();
-            return e.getService().getServer().getGlobalNamingContext();
+            Server s = e.getService().getServer();
+            // When the Service is an Embedded service, it doesn't have a Server object
+            if (s != null) {
+                return s.getGlobalNamingContext();
+            }
         }
         return null;
     }


### PR DESCRIPTION
When the Service is an Embedded service, it doesn't have a Server object when stopping - Which in turn implies that when one uses a Tomcat Embedded server the getGlobalNamingContext also cannot rely on the Server object being present when shutting down. Add a !null check in order to avoid NPEs and hence a clean shutdown.