### PR TITLE
ByteBufferUtils.cleanDirectBuffer invocation failures are logged

### DIFF
--- a/java/org/apache/tomcat/util/buf/ByteBufferUtils.java
+++ b/java/org/apache/tomcat/util/buf/ByteBufferUtils.java
@@ -124,15 +124,18 @@ public class ByteBufferUtils {
                 cleanMethod.invoke(cleanerMethod.invoke(buf));
             } catch (IllegalAccessException | IllegalArgumentException
                     | InvocationTargetException | SecurityException e) {
-                // Ignore
+                if (log.isDebugEnabled()) {
+                    log.debug(sm.getString("byteBufferUtils.cleaner"), e);
+                }
             }
         } else if (invokeCleanerMethod != null) {
             try {
                 invokeCleanerMethod.invoke(unsafe, buf);
             } catch (IllegalAccessException | IllegalArgumentException
                     | InvocationTargetException | SecurityException e) {
-                // Ignore
-                e.printStackTrace();
+                if (log.isDebugEnabled()) {
+                    log.debug(sm.getString("byteBufferUtils.cleaner"), e);
+                }
             }
         }
     }


### PR DESCRIPTION
Previously cleanMethod failures were ignored entirely, and
invokeCleanerMethod failures were logged to stderr using
Throwable.printStackTrace().
Now debug logging may be enabled to capture this information
using the configured logging framework.