### PR TITLE
BZ 63792: The tomcat log contains garbled code because of i18n

### DIFF
--- a/java/org/apache/tomcat/util/compat/Jre9Compat.java
+++ b/java/org/apache/tomcat/util/compat/Jre9Compat.java
@@ -26,6 +26,7 @@ import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.Deque;
+import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.jar.JarFile;
 import java.util.zip.ZipFile;
@@ -227,5 +228,11 @@ class Jre9Compat extends JreCompat {
     @Override
     public int jarFileRuntimeMajorVersion() {
         return RUNTIME_MAJOR_VERSION;
+    }
+
+
+    @Override
+    public String getUTF8String(ResourceBundle bundle, String key) {
+        return bundle.getString(key);
     }
 }

--- a/java/org/apache/tomcat/util/compat/JreCompat.java
+++ b/java/org/apache/tomcat/util/compat/JreCompat.java
@@ -20,7 +20,9 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.Deque;
+import java.util.ResourceBundle;
 import java.util.jar.JarFile;
 
 import javax.net.ssl.SSLEngine;
@@ -193,5 +195,19 @@ public class JreCompat {
 
     public int jarFileRuntimeMajorVersion() {
         return RUNTIME_MAJOR_VERSION;
+    }
+
+
+    /**
+     * Get the utf-8 encoded string for the given key from the resource bundle or one of its parents.
+     *
+     * @param bundle The ResourceBundle for StringManager
+     * @param key The key for the desired string
+     * @return The string for the given key
+     */
+    public String getUTF8String(ResourceBundle bundle, String key) {
+        String str = bundle.getString(key);
+        str = new String(str.getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8);
+        return str;
     }
 }

--- a/java/org/apache/tomcat/util/res/StringManager.java
+++ b/java/org/apache/tomcat/util/res/StringManager.java
@@ -16,6 +16,8 @@
  */
 package org.apache.tomcat.util.res;
 
+import org.apache.tomcat.util.compat.JreCompat;
+
 import java.text.MessageFormat;
 import java.util.Enumeration;
 import java.util.Hashtable;
@@ -130,7 +132,7 @@ public class StringManager {
         try {
             // Avoid NPE if bundle is null and treat it like an MRE
             if (bundle != null) {
-                str = bundle.getString(key);
+                str = JreCompat.getInstance().getUTF8String(bundle, key);
             }
         } catch (MissingResourceException mre) {
             //bad: shouldn't mask an exception the following way:


### PR DESCRIPTION
Prevent garbled code when using ResourceBundle.