### PR TITLE
Made some variable names more consistent with the other parts.

### DIFF
--- a/java/javax/servlet/GenericServlet.java
+++ b/java/javax/servlet/GenericServlet.java
@@ -180,12 +180,12 @@ public abstract class GenericServlet implements Servlet, ServletConfig,
      * Writes the specified message to a servlet log file, prepended by the
      * servlet's name. See {@link ServletContext#log(String)}.
      *
-     * @param msg
+     * @param message
      *            a <code>String</code> specifying the message to be written to
      *            the log file
      */
-    public void log(String msg) {
-        getServletContext().log(getServletName() + ": " + msg);
+    public void log(String message) {
+        getServletContext().log(getServletName() + ": " + message);
     }
 
     /**

--- a/java/org/apache/catalina/filters/AddDefaultCharsetFilter.java
+++ b/java/org/apache/catalina/filters/AddDefaultCharsetFilter.java
@@ -106,17 +106,17 @@ public class AddDefaultCharsetFilter extends FilterBase {
         }
 
         @Override
-        public void setContentType(String ct) {
+        public void setContentType(String contentType) {
 
-            if (ct != null && ct.startsWith("text/")) {
-                if (!ct.contains("charset=")) {
-                    super.setContentType(ct + ";charset=" + encoding);
+            if (contentType != null && contentType.startsWith("text/")) {
+                if (!contentType.contains("charset=")) {
+                    super.setContentType(contentType + ";charset=" + encoding);
                 } else {
-                    super.setContentType(ct);
+                    super.setContentType(contentType);
                     encoding = getCharacterEncoding();
                 }
             } else {
-                super.setContentType(ct);
+                super.setContentType(contentType);
             }
 
         }

--- a/java/org/apache/jasper/JspCompilationContext.java
+++ b/java/org/apache/jasper/JspCompilationContext.java
@@ -454,11 +454,11 @@ public class JspCompilationContext {
         if (isTagFile()) {
             String className = tagInfo.getTagClassName();
             int lastIndex = className.lastIndexOf('.');
-            String pkgName = "";
+            String packageName = "";
             if (lastIndex != -1) {
-                pkgName = className.substring(0, lastIndex);
+                packageName = className.substring(0, lastIndex);
             }
-            return pkgName;
+            return packageName;
         } else {
             String dPackageName = getDerivedPackageName();
             if (dPackageName.length() == 0) {
@@ -767,4 +767,3 @@ public class JspCompilationContext {
         return result.toString();
     }
 }
-

--- a/java/org/apache/jasper/compiler/Generator.java
+++ b/java/org/apache/jasper/compiler/Generator.java
@@ -3695,8 +3695,8 @@ class Generator {
         String className = tagInfo.getTagClassName();
         int lastIndex = className.lastIndexOf('.');
         if (lastIndex != -1) {
-            String pkgName = className.substring(0, lastIndex);
-            genPreamblePackage(pkgName);
+            String packageName = className.substring(0, lastIndex);
+            genPreamblePackage(packageName);
             className = className.substring(lastIndex + 1);
         }
 

--- a/java/org/apache/tomcat/util/buf/CharChunk.java
+++ b/java/org/apache/tomcat/util/buf/CharChunk.java
@@ -165,7 +165,7 @@ public final class CharChunk extends AbstractChunk implements CharSequence {
 
     // -------------------- Adding data to the buffer --------------------
 
-    public void append(char b) throws IOException {
+    public void append(char c) throws IOException {
         makeSpace(1);
         int limit = getLimitInternal();
 
@@ -173,7 +173,7 @@ public final class CharChunk extends AbstractChunk implements CharSequence {
         if (end >= limit) {
             flushBuffer();
         }
-        buff[end++] = b;
+        buff[end++] = c;
     }
 
 

--- a/java/org/apache/tomcat/util/security/ConcurrentMessageDigest.java
+++ b/java/org/apache/tomcat/util/security/ConcurrentMessageDigest.java
@@ -68,7 +68,7 @@ public class ConcurrentMessageDigest {
     }
 
 
-    public static byte[] digest(String algorithm, int rounds, byte[]... input) {
+    public static byte[] digest(String algorithm, int iterations, byte[]... input) {
 
         Queue<MessageDigest> queue = queues.get(algorithm);
         if (queue == null) {
@@ -93,8 +93,8 @@ public class ConcurrentMessageDigest {
         byte[] result = md.digest();
 
         // Subsequent rounds
-        if (rounds > 1) {
-            for (int i = 1; i < rounds; i++) {
+        if (iterations > 1) {
+            for (int i = 1; i < iterations; i++) {
                 md.update(result);
                 result = md.digest();
             }


### PR DESCRIPTION
Hello, we're developing an automated system that detects inconsistent variable names in a large software project. Our system checks if each variable name is consistent with other variables in the project in its usage pattern, and proposes correct candidates if inconsistency is detected. This is a part of academic research that we hope to publish soon, but as a part of the evaluation, we applied our systems to your projects and got a few interesting results. We carefully reviewed our system output and manually created a patch to correct a few variable names. We would be delighted if this patch is found to be useful. If you have a question or suggestion regarding this patch, we'd happily answer. Thank you.