### PR TITLE
RewriteMap with quoted parameters and ServiceLoader support

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -826,6 +826,7 @@
     <jarIt jarfile="${catalina.jar}"
       filesDir="${tomcat.classes}"
       filesId="files.catalina"
+      meta-inf="${tomcat.manifests}/catalina.jar"
       addOSGi="true" />
 
     <!-- Catalina GroupCom/Tribes JAR File -->

--- a/java/org/apache/catalina/valves/rewrite/InternalRewriteMapsProvider.java
+++ b/java/org/apache/catalina/valves/rewrite/InternalRewriteMapsProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.catalina.valves.rewrite;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class InternalRewriteMapsProvider implements RewriteMapsProvider {
+
+    @Override
+    public String getNamespace() {
+        return "int";
+    }
+
+    @Override
+    public int getPriority() {
+        return 100;
+    }
+
+    @Override
+    public Map<String, RewriteMap> getMaps() {
+        Map<String, RewriteMap> maps = new HashMap<>();
+        maps.put("toupper", new UpperCaseRewriteMap());
+        maps.put("tolower", new LowerCaseRewriteMap());
+        return maps;
+    }
+
+}

--- a/java/org/apache/catalina/valves/rewrite/LowerCaseRewriteMap.java
+++ b/java/org/apache/catalina/valves/rewrite/LowerCaseRewriteMap.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.catalina.valves.rewrite;
+
+import java.util.Locale;
+
+public class LowerCaseRewriteMap implements RewriteMap {
+
+    private Locale locale;
+
+    @Override
+    public String setParameters(String params) {
+        this.locale = Locale.forLanguageTag(params);
+        return null;
+    }
+
+    @Override
+    public String lookup(String key) {
+        if (key != null) {
+            return key.toLowerCase(locale);
+        }
+        return null;
+    }
+
+}

--- a/java/org/apache/catalina/valves/rewrite/QuotedStringTokenizer.java
+++ b/java/org/apache/catalina/valves/rewrite/QuotedStringTokenizer.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.catalina.valves.rewrite;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+public class QuotedStringTokenizer {
+
+    private Iterator<String> tokenIterator;
+    private int tokenCount;
+    private int returnedTokens = 0;
+
+    enum WordMode {
+        SPACES, QUOTED, ESCAPED, SIMPLE, COMMENT
+    }
+
+    public QuotedStringTokenizer(String text) {
+        List<String> tokens;
+        if (text != null) {
+            tokens = tokenizeText(text);
+        } else {
+            tokens = Collections.emptyList();
+        }
+        this.tokenCount = tokens.size();
+        this.tokenIterator = tokens.iterator();
+    }
+
+    private List<String> tokenizeText(String inputText) {
+        List<String> tokens = new ArrayList<>();
+        int pos = 0;
+        int length = inputText.length();
+        WordMode currentMode = WordMode.SPACES;
+        StringBuilder currentToken = new StringBuilder();
+        while (pos < length) {
+            char currentChar = inputText.charAt(pos);
+            switch (currentMode) {
+            case SPACES:
+                currentMode = handleSpaces(currentToken, currentChar);
+                break;
+            case QUOTED:
+                currentMode = handleQuoted(tokens, currentToken, currentChar);
+                break;
+            case ESCAPED:
+                currentToken.append(currentChar);
+                currentMode = WordMode.QUOTED;
+                break;
+            case SIMPLE:
+                currentMode = handleSimple(tokens, currentToken, currentChar);
+                break;
+            case COMMENT:
+                if (currentChar == '\r' || currentChar == '\n') {
+                    currentMode = WordMode.SPACES;
+                }
+                break;
+            default:
+                throw new IllegalStateException(
+                        "Couldn't tokenize text " + inputText + " after position " + pos + "from mode " + currentMode);
+            }
+            pos++;
+        }
+        String possibleLastToken = currentToken.toString();
+        if (!possibleLastToken.isEmpty()) {
+            tokens.add(possibleLastToken);
+        }
+        return tokens;
+    }
+
+    private WordMode handleSimple(List<String> tokens, StringBuilder currentToken, char currentChar) {
+        if (Character.isWhitespace(currentChar)) {
+            tokens.add(currentToken.toString());
+            currentToken.setLength(0);
+            return WordMode.SPACES;
+        } else {
+            currentToken.append(currentChar);
+        }
+        return WordMode.SIMPLE;
+    }
+
+    private WordMode handleQuoted(List<String> tokens, StringBuilder currentToken, char currentChar) {
+        if (currentChar == '"') {
+            tokens.add(currentToken.toString());
+            currentToken.setLength(0);
+            return WordMode.SPACES;
+        } else if (currentChar == '\\') {
+            return WordMode.ESCAPED;
+        } else {
+            currentToken.append(currentChar);
+        }
+        return WordMode.QUOTED;
+    }
+
+    private WordMode handleSpaces(StringBuilder currentToken, char currentChar) {
+        if (!Character.isWhitespace(currentChar)) {
+            if (currentChar == '"') {
+                return WordMode.QUOTED;
+            } else if (currentChar == '#') {
+                return WordMode.COMMENT;
+            } else {
+                currentToken.append(currentChar);
+                return WordMode.SIMPLE;
+            }
+        }
+        return WordMode.SPACES;
+    }
+
+    public boolean hasMoreTokens() {
+        return tokenIterator.hasNext();
+    }
+
+    public String nextToken() {
+        returnedTokens++;
+        return tokenIterator.next();
+    }
+
+    public int countTokens() {
+        return tokenCount - returnedTokens;
+    }
+}

--- a/java/org/apache/catalina/valves/rewrite/RewriteMap.java
+++ b/java/org/apache/catalina/valves/rewrite/RewriteMap.java
@@ -46,6 +46,24 @@ public interface RewriteMap {
     public String setParameters(String params);
 
     /**
+     * Optional parameters that can be defined through the {@code RewriteMap}
+     * directive in the {@code rewrite.config} file.
+     * <p>
+     * This method will be called, if there are more than one parameters defined.
+     *
+     * @param params the optional parameters
+     */
+    default void setParameters(String... params) {
+        if (params == null) {
+            return;
+        }
+        if (params.length > 1) {
+            throw new IllegalArgumentException("Too many parameters for this map");
+        }
+        setParameters(params[0]);
+    }
+
+    /**
      * Maps a key to a replacement value.<br>
      * The method is free to return {@code null} to indicate, that the default
      * value from the {@code RewriteRule} directive should be used.

--- a/java/org/apache/catalina/valves/rewrite/RewriteMapsProvider.java
+++ b/java/org/apache/catalina/valves/rewrite/RewriteMapsProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.catalina.valves.rewrite;
+
+import java.util.Map;
+
+public interface RewriteMapsProvider {
+    String getNamespace();
+    int getPriority();
+    Map<String, RewriteMap> getMaps();
+}

--- a/java/org/apache/catalina/valves/rewrite/RewriteValve.java
+++ b/java/org/apache/catalina/valves/rewrite/RewriteValve.java
@@ -572,7 +572,7 @@ public class RewriteValve extends ValveBase {
      * @return The condition, rule or map resulting from parsing the line
      */
     public static Object parse(String line) {
-        StringTokenizer tokenizer = new StringTokenizer(line);
+        QuotedStringTokenizer tokenizer = new QuotedStringTokenizer(line);
         if (tokenizer.hasMoreTokens()) {
             String token = tokenizer.nextToken();
             if (token.equals("RewriteCond")) {

--- a/java/org/apache/catalina/valves/rewrite/UpperCaseRewriteMap.java
+++ b/java/org/apache/catalina/valves/rewrite/UpperCaseRewriteMap.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.catalina.valves.rewrite;
+
+import java.util.Locale;
+
+public class UpperCaseRewriteMap implements RewriteMap {
+
+    Locale locale = Locale.getDefault();
+
+    @Override
+    public String setParameters(String params) {
+        locale = Locale.forLanguageTag(params);
+        return null;
+    }
+
+    @Override
+    public String lookup(String key) {
+        if (key != null) {
+            return key.toUpperCase(locale);
+        }
+        return null;
+    }
+
+}

--- a/res/META-INF/catalina.jar/services/org.apache.catalina.valves.rewrite.RewriteMapsProvider
+++ b/res/META-INF/catalina.jar/services/org.apache.catalina.valves.rewrite.RewriteMapsProvider
@@ -1,0 +1,1 @@
+org.apache.catalina.valves.rewrite.InternalRewriteMapsProvider

--- a/test/org/apache/catalina/valves/rewrite/TestQuotedStringTokenizer.java
+++ b/test/org/apache/catalina/valves/rewrite/TestQuotedStringTokenizer.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.catalina.valves.rewrite;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class TestQuotedStringTokenizer {
+
+    private String inputText;
+    private List<String> tokens;
+
+    @Parameters(name = "{index}: tokenize({0}) = {1}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] { { null, Collections.emptyList() }, { "", Collections.emptyList() },
+                { " \t\r\n", Collections.emptyList() }, { "simple", Arrays.asList("simple") },
+                { "more than one word", Arrays.asList("more", "than", "one", "word") },
+                { "\"quoted text\"", Arrays.asList("quoted text") },
+                { "  mixed \t\"words with\\\"\" escapes", Arrays.asList("mixed", "words with\"", "escapes") },
+                { "# comment", Collections.emptyList() },
+                { "Something # and then a comment", Arrays.asList("Something") },
+                { "\"Quoted with a #\" which is not a comment",
+                        Arrays.asList("Quoted with a #", "which", "is", "not", "a", "comment") } });
+    }
+
+    public TestQuotedStringTokenizer(String inputText, List<String> tokens) {
+        this.inputText = inputText;
+        this.tokens = tokens;
+    }
+
+    @Test
+    public void testTokenize() {
+        QuotedStringTokenizer tokenizer = new QuotedStringTokenizer(inputText);
+        List<String> result = new ArrayList<>();
+        int count = tokens.size();
+        while (tokenizer.hasMoreTokens()) {
+            assertThat(tokenizer.countTokens(), is(count));
+            result.add(tokenizer.nextToken());
+            count--;
+        }
+        assertThat(tokenizer.countTokens(), is(0));
+        assertThat(tokens, is(result));
+    }
+
+}


### PR DESCRIPTION
This PR combines two things:
* Allows quoted parameters for `RewriteValve` config and adds a new default method to `RewriteMap` to allow for more than one parameter
* Uses a `ServiceLoader` to make implementations of `RewriteMap` available in the httpd rewrite module style a-la `int:toupper`.

It is missing a lot of documentation and a few test cases.