### PR TITLE
Adding Support for JDK "only" and JAVA_HOME environment variable to Windows Installer

### DIFF
--- a/res/tomcat.nsi
+++ b/res/tomcat.nsi
@@ -1032,8 +1032,9 @@ Function findJVMPath
   ;Step three: Read defaults from registry
   ReadRegStr $1 HKLM "SOFTWARE\JavaSoft\Java Runtime Environment" "CurrentVersion"
   ReadRegStr $2 HKLM "SOFTWARE\JavaSoft\Java Runtime Environment\$1" "RuntimeLib"
-
-  IfErrors 0 FoundJvmDll  
+  IfErrors 0 FoundJvmDll
+  
+  ;not found
   StrCpy $2 ""
 
   FoundJvmDll:

--- a/res/tomcat.nsi
+++ b/res/tomcat.nsi
@@ -1032,8 +1032,8 @@ Function findJVMPath
   ;Step three: Read defaults from registry
   ReadRegStr $1 HKLM "SOFTWARE\JavaSoft\Java Runtime Environment" "CurrentVersion"
   ReadRegStr $2 HKLM "SOFTWARE\JavaSoft\Java Runtime Environment\$1" "RuntimeLib"
-  IfErrors 0 FoundJvmDll
-  
+
+  IfErrors 0 FoundJvmDll  
   StrCpy $2 ""
 
   FoundJvmDll:

--- a/res/tomcat.nsi
+++ b/res/tomcat.nsi
@@ -979,7 +979,9 @@ Function findJavaHome
   ; If nothing found, try environment variable JAVA_HOME
   ${If} $1 == ""
     ExpandEnvStrings $1 "%JAVA_HOME%"
-
+  	${If} $1 == "%JAVA_HOME%"
+      StrCpy $1 ""
+    ${EndIf}
     ClearErrors
   ${EndIf}
 

--- a/res/tomcat.nsi
+++ b/res/tomcat.nsi
@@ -963,17 +963,23 @@ Function findJavaHome
       SetRegView 64
     ${EndIf}
   ${EndIf}
-    
+
   ; If no 32-bit Java (JRE) found, look for 64-bit Java JDK
   ${If} $1 == ""
   ${AndIf} $0 != "%PROGRAMW6432%"
-    SetRegView 64
     ReadRegStr $2 HKLM "SOFTWARE\JavaSoft\JDK" "CurrentVersion"
     ReadRegStr $1 HKLM "SOFTWARE\JavaSoft\JDK\$2" "JavaHome"
     ; "RuntimeLib" is not available here
 
     IfErrors 0 +2
     StrCpy $1 ""
+    ClearErrors
+  ${EndIf}
+
+  ; If nothing found, try environment variable JAVA_HOME
+  ${If} $1 == ""
+    ExpandEnvStrings $1 "%JAVA_HOME%"
+
     ClearErrors
   ${EndIf}
 

--- a/res/tomcat.nsi
+++ b/res/tomcat.nsi
@@ -965,7 +965,8 @@ Function findJavaHome
   ${EndIf}
     
   ; If no 32-bit Java (JRE) found, look for 64-bit Java JDK
-  ${If} $0 != "%PROGRAMW6432%"
+  ${If} $1 == ""
+  ${AndIf} $0 != "%PROGRAMW6432%"
     SetRegView 64
     ReadRegStr $2 HKLM "SOFTWARE\JavaSoft\JDK" "CurrentVersion"
     ReadRegStr $1 HKLM "SOFTWARE\JavaSoft\JDK\$2" "JavaHome"
@@ -974,7 +975,7 @@ Function findJavaHome
     IfErrors 0 +2
     StrCpy $1 ""
     ClearErrors
-  ${EndIf}    
+  ${EndIf}
 
   ; Put the result in the stack
   Push $1

--- a/res/tomcat.nsi
+++ b/res/tomcat.nsi
@@ -963,6 +963,18 @@ Function findJavaHome
       SetRegView 64
     ${EndIf}
   ${EndIf}
+    
+  ; If no 32-bit Java (JRE) found, look for 64-bit Java JDK
+  ${If} $0 != "%PROGRAMW6432%"
+    SetRegView 64
+    ReadRegStr $2 HKLM "SOFTWARE\JavaSoft\JDK" "CurrentVersion"
+    ReadRegStr $1 HKLM "SOFTWARE\JavaSoft\JDK\$2" "JavaHome"
+    ; "RuntimeLib" is not available here
+
+    IfErrors 0 +2
+    StrCpy $1 ""
+    ClearErrors
+  ${EndIf}    
 
   ; Put the result in the stack
   Push $1
@@ -1007,12 +1019,12 @@ Function findJVMPath
   IfFileExists "$2" FoundJvmDll
 
   ClearErrors
-  ;Step three: Read defaults from registry
 
+  ;Step three: Read defaults from registry
   ReadRegStr $1 HKLM "SOFTWARE\JavaSoft\Java Runtime Environment" "CurrentVersion"
   ReadRegStr $2 HKLM "SOFTWARE\JavaSoft\Java Runtime Environment\$1" "RuntimeLib"
-
   IfErrors 0 FoundJvmDll
+  
   StrCpy $2 ""
 
   FoundJvmDll:

--- a/webapps/docs/setup.xml
+++ b/webapps/docs/setup.xml
@@ -64,8 +64,9 @@
             determine the base path of a Java <min-java-version/> or later JRE, including the JRE
             installed as part of the full JDK. When running on a 64-bit
             operating system, the installer will first look for a 64-bit JRE and
-            only look for a 32-bit JRE if a 64-bit JRE is not found. It is not
-            mandatory to use the default JRE detected by the installer. Any
+            only look for a 32-bit JRE if a 64-bit JRE is not found. At last the 
+            installer considers a JDK or the <code>JAVA_HOME</code> environment variable.
+            It is not mandatory to use the default JRE detected by the installer. Any
             installed Java <min-java-version/> or later JRE (32-bit or 64-bit) may be used.</li>
         <li><strong>Tray icon</strong>: When Tomcat is run as a service, there
             will not be any tray icon present when Tomcat is running. Note that

--- a/webapps/docs/setup.xml
+++ b/webapps/docs/setup.xml
@@ -66,8 +66,8 @@
             operating system, the installer will first look for a 64-bit JRE and
             only look for a 32-bit JRE if a 64-bit JRE is not found. At last the 
             installer considers a JDK or the <code>JAVA_HOME</code> environment variable.
-            It is not mandatory to use the default JRE detected by the installer. Any
-            installed Java <min-java-version/> or later JRE (32-bit or 64-bit) may be used.</li>
+            It is not mandatory to use the default JRE detected by the installer.
+            Any installed Java <min-java-version/> or later JRE (32-bit or 64-bit) may be used.</li>
         <li><strong>Tray icon</strong>: When Tomcat is run as a service, there
             will not be any tray icon present when Tomcat is running. Note that
             when choosing to run Tomcat at the end of installation, the tray


### PR DESCRIPTION
Since Java 11 Oracle distributes no separate JRE and renamed the windows registry key for the JDK. This patch will find the JDK with registry key HKLM “SOFTWARE\JavaSoft\JDK". As a last failback this patch looks for Java in the environment variable JAVA_HOME.