### PR TITLE
Correct header too large status to 414

### DIFF
--- a/java/org/apache/coyote/http11/Http11InputBuffer.java
+++ b/java/org/apache/coyote/http11/Http11InputBuffer.java
@@ -723,7 +723,7 @@ public class Http11InputBuffer implements InputBuffer, ApplicationBufferHandler 
                     // Avoid unknown protocol triggering an additional error
                     request.protocol().setString(Constants.HTTP_11);
                 }
-                throw new IllegalArgumentException(sm.getString("iib.requestheadertoolarge.error"));
+                throw new HeadersTooLargeException(sm.getString("iib.requestheadertoolarge.error"));
             }
         } else {
             byteBuffer.limit(end).position(end);

--- a/java/org/apache/coyote/http11/Http11Processor.java
+++ b/java/org/apache/coyote/http11/Http11Processor.java
@@ -550,6 +550,9 @@ public class Http11Processor extends AbstractProcessor {
                 }
                 // 400 - Bad Request
                 response.setStatus(400);
+                if (t instanceof HeadersTooLargeException) {
+                    response.setStatus(414);
+                }
                 setErrorState(ErrorState.CLOSE_CLEAN, t);
             }
 

--- a/java/org/apache/coyote/http11/Http11Processor.java
+++ b/java/org/apache/coyote/http11/Http11Processor.java
@@ -551,7 +551,7 @@ public class Http11Processor extends AbstractProcessor {
                 // 400 - Bad Request
                 response.setStatus(400);
                 if (t instanceof HeadersTooLargeException) {
-                    response.setStatus(414);
+                    response.setStatus(431);
                 }
                 setErrorState(ErrorState.CLOSE_CLEAN, t);
             }


### PR DESCRIPTION
When I exceeded the maximum length with the GET request, tomcat returned 400, but it should have returned 414