### PR TITLE
Fix missing implicit TLD map entries.

### DIFF
--- a/build.properties.default
+++ b/build.properties.default
@@ -306,4 +306,3 @@ bnd.loc=${base-maven.loc}/biz/aQute/bnd/biz.aQute.bnd/${bnd.version}/biz.aQute.b
 bndlib.home=${base.path}/bndlib-${bnd.version}
 bndlib.jar=${bndlib.home}/biz.aQute.bndlib-${bnd.version}.jar
 bndlib.loc=${base-maven.loc}/biz/aQute/bnd/biz.aQute.bndlib/${bnd.version}/biz.aQute.bndlib-${bnd.version}.jar
-test.entry=org.apache.jasper.TestJspC

--- a/build.properties.default
+++ b/build.properties.default
@@ -306,3 +306,4 @@ bnd.loc=${base-maven.loc}/biz/aQute/bnd/biz.aQute.bnd/${bnd.version}/biz.aQute.b
 bndlib.home=${base.path}/bndlib-${bnd.version}
 bndlib.jar=${bndlib.home}/biz.aQute.bndlib-${bnd.version}.jar
 bndlib.loc=${base-maven.loc}/biz/aQute/bnd/biz.aQute.bndlib/${bnd.version}/biz.aQute.bndlib-${bnd.version}.jar
+test.entry=org.apache.jasper.TestJspC

--- a/java/org/apache/jasper/servlet/TldScanner.java
+++ b/java/org/apache/jasper/servlet/TldScanner.java
@@ -272,10 +272,6 @@ public class TldScanner {
     }
 
     protected void parseTld(TldResourcePath path) throws IOException, SAXException {
-        if (tldResourcePathTaglibXmlMap.containsKey(path)) {
-            // TLD has already been parsed as a result of processing web.xml
-            return;
-        }
         TaglibXml tld = tldParser.parse(path);
         String uri = tld.getUri();
         if (uri != null) {
@@ -283,6 +279,12 @@ public class TldScanner {
                 uriTldResourcePathMap.put(uri, path);
             }
         }
+
+        if (tldResourcePathTaglibXmlMap.containsKey(path)) {
+            // TLD has already been parsed as a result of processing web.xml
+            return;
+        }
+
         tldResourcePathTaglibXmlMap.put(path, tld);
         if (tld.getListeners() != null) {
             listeners.addAll(tld.getListeners());


### PR DESCRIPTION
If TldResourcePath was already registred during parsing of jsp-config
section of web.xml, the implicit TLD map entries (derived from TLD files
URI) have not been added to uriTldResourcePathMap.

This was not in line with JSP2.2 specification section 7.3.4.