### PR TITLE
Fix handling of query parameters with no value, like `?foo`

### DIFF
--- a/java/org/apache/tomcat/util/http/Parameters.java
+++ b/java/org/apache/tomcat/util/http/Parameters.java
@@ -263,6 +263,7 @@ public final class Parameters {
             do {
                 switch(bytes[pos]) {
                     case '=':
+                        valueStart = pos+1;
                         if (parsingName) {
                             // Name finished. Value starts from next character
                             nameEnd = pos;
@@ -393,7 +394,7 @@ public final class Parameters {
                     tmpValue.setCharset(charset);
                     value = tmpValue.toString();
                 } else {
-                    value = "";
+                    value = null;
                 }
 
                 try {

--- a/res/tomcat-maven/README.md
+++ b/res/tomcat-maven/README.md
@@ -39,7 +39,7 @@ mvn clean; mvn package
 ```
 docker build -t apache/tomcat-maven:1.0 -f ./Dockerfile .
 ```
-Docker build arguments include `namepsace` (default is `tomcat`) and `port` which should match the Tomcat port in `server.xml` (default is `8080`). Other ports that need to be exposed can be added in the `Dockerfile` as needed. Webapps should be added to the `webapps` folder where they will be auto deployed by the host if using the defaults. Otherwise, the `Dockerfile` command line can be edited like below to include the necesary resources and command line arguments to run a single or multiple hardcoded web applications.
+Docker build arguments include `namespace` (default is `tomcat`) and `port` which should match the Tomcat port in `server.xml` (default is `8080`). Other ports that need to be exposed can be added in the `Dockerfile` as needed. Webapps should be added to the `webapps` folder where they will be auto deployed by the host if using the defaults. Otherwise, the `Dockerfile` command line can be edited like below to include the necesary resources and command line arguments to run a single or multiple hardcoded web applications.
 
 ## Running
 

--- a/test/org/apache/catalina/core/TestApplicationHttpRequest.java
+++ b/test/org/apache/catalina/core/TestApplicationHttpRequest.java
@@ -366,9 +366,6 @@ public class TestApplicationHttpRequest extends TomcatBaseTest {
     }
 
     private static boolean objectsEqual(String object1, String object2) {
-        if (object1 == null && object2 == null) {
-            return true;
-        }
-        return object1.equals(object2);
+        return object1 != null ? object1.equals(object2) : object2 == null;
     }
 }

--- a/test/org/apache/catalina/core/TestApplicationHttpRequest.java
+++ b/test/org/apache/catalina/core/TestApplicationHttpRequest.java
@@ -80,7 +80,7 @@ public class TestApplicationHttpRequest extends TomcatBaseTest {
         // Parameters with no value are assigned a value of the empty string
         Map<String,String[]> expected = new HashMap<>();
         expected.put("a", new String[] { "b", "e" });
-        expected.put("c", new String[] { "" });
+        expected.put("c", new String[] { null });
         doQueryStringTest(null, "a=b&c&a=e", expected);
     }
 
@@ -124,7 +124,7 @@ public class TestApplicationHttpRequest extends TomcatBaseTest {
         // Parameters with no value are assigned a value of the empty string
         Map<String,String[]> expected = new HashMap<>();
         expected.put("a", new String[] { "b", "e" });
-        expected.put("c", new String[] { "" });
+        expected.put("c", new String[] { null });
         doQueryStringTest("a=b&c&a=e", null, expected);
     }
 
@@ -141,7 +141,7 @@ public class TestApplicationHttpRequest extends TomcatBaseTest {
     public void testMergeQueryString02() throws Exception {
         Map<String,String[]> expected = new HashMap<>();
         expected.put("a", new String[] { "z", "b", "e" });
-        expected.put("c", new String[] { "" });
+        expected.put("c", new String[] { null });
         doQueryStringTest("a=b&c&a=e", "a=z", expected);
     }
 
@@ -150,7 +150,7 @@ public class TestApplicationHttpRequest extends TomcatBaseTest {
     public void testMergeQueryString03() throws Exception {
         Map<String,String[]> expected = new HashMap<>();
         expected.put("a", new String[] { "b", "e" });
-        expected.put("c", new String[] { "z", "" });
+        expected.put("c", new String[] { "z", null });
         doQueryStringTest("a=b&c&a=e", "c=z", expected);
     }
 
@@ -158,13 +158,23 @@ public class TestApplicationHttpRequest extends TomcatBaseTest {
     @Test
     public void testMergeQueryString04() throws Exception {
         Map<String,String[]> expected = new HashMap<>();
-        expected.put("a", new String[] { "", "b", "e" });
-        expected.put("c", new String[] { "" });
+        expected.put("a", new String[] { null, "b", "e" });
+        expected.put("c", new String[] { null });
         doQueryStringTest("a=b&c&a=e", "a", expected);
     }
 
+
     @Test
     public void testMergeQueryString05() throws Exception {
+        Map<String,String[]> expected = new HashMap<>();
+        expected.put("a", new String[] { null, "b", "e" });
+        expected.put("c", new String[] { "" });
+        doQueryStringTest("a=b&c=&a=e", "a", expected);
+    }
+
+
+    @Test
+    public void testMergeQueryString06() throws Exception {
         // https://ru.wikipedia.org/wiki/%D0%A2%D0%B5%D1%81%D1%82
         // "Test" = "Test"
         String test = "\u0422\u0435\u0441\u0442";
@@ -284,7 +294,7 @@ public class TestApplicationHttpRequest extends TomcatBaseTest {
                     break;
                 }
                 for (int i = 0; i < expectedValue.length; i++) {
-                    if (!expectedValue[i].equals(entry.getValue()[i])) {
+                    if (!objectsEqual(expectedValue[i], entry.getValue()[i])) {
                         ok = false;
                         break;
                     }
@@ -353,5 +363,12 @@ public class TestApplicationHttpRequest extends TomcatBaseTest {
                 pw.print("OK");
             }
         }
+    }
+
+    private static boolean objectsEqual(String object1, String object2) {
+        if (object1 == null && object2 == null) {
+            return true;
+        }
+        return object1.equals(object2);
     }
 }

--- a/test/org/apache/tomcat/util/http/TestParameters.java
+++ b/test/org/apache/tomcat/util/http/TestParameters.java
@@ -118,7 +118,7 @@ public class TestParameters {
     }
 
     @Test
-    public void testNonExistantParameter() {
+    public void testNonExistentParameter() {
         Parameters p = new Parameters();
 
         String value = p.getParameter("foo");


### PR DESCRIPTION
Currently undefined values are returned as an empty string by `Parameters#getParameter(String)`, though `null` should be returned.

**Background:**
A query string can contain defined and undefined variable values.
A variable with a defined value is followed by a `=` (e.g. `?foo=abc` where `foo` is the string `abc`, or `bar=` where the string is empty).
A variable with an undefined value is not followed by `=`.
In Java such a value is coded with `null` and not an empty string because the latter is already the defined value of a string with zero length.

See also https://tools.ietf.org/html/rfc6570#section-2.3 and https://github.com/OpenFeign/feign/issues/872#issuecomment-452390655