### PR TITLE
if TRACE is not allowed skip error page for such requests

### DIFF
--- a/java/org/apache/catalina/core/StandardHostValve.java
+++ b/java/org/apache/catalina/core/StandardHostValve.java
@@ -222,6 +222,13 @@ final class StandardHostValve extends ValveBase {
             return;
         }
 
+        /* Do not look for error pages if TRACE request and it's not allowed */
+        if (statusCode == HttpServletResponse.SC_METHOD_NOT_ALLOWED
+                && "TRACE".equals(request.getMethod())
+                && !request.getConnector().getAllowTrace()) {
+            return;
+        }
+
         ErrorPage errorPage = context.findErrorPage(statusCode);
         if (errorPage == null) {
             // Look for a default error page


### PR DESCRIPTION
I have a Spring Boot application, and Spring Boot by default configures an erorr page.
The TTACE method is not alloed (default configuration).

When a TRACE request happens it tries to return 405, which is then sent to the error page which is not expecting to handle it and finally request is served by `HttpServlet.doTrace()`, response status is 405, but headers are returned back.

I think it should be fixed in Tomcat - if TRACE is not allowed, then application should never receive such requests.

Please see the suggested change and tests.