### PR TITLE
tomcat-jdbc check if returned connection is closed

### DIFF
--- a/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/ConnectionPool.java
+++ b/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/ConnectionPool.java
@@ -911,6 +911,12 @@ public class ConnectionPool {
     protected boolean shouldClose(PooledConnection con, int action) {
         if (con.getConnectionVersion() < getPoolVersion()) return true;
         if (con.isDiscarded()) return true;
+        try {
+            if (con.isClosed()) return true;
+        } catch (SQLException e) {
+            log.warn("Unable to check if connection is closed", e);
+            return true;
+        }
         if (isClosed()) return true;
         if (!con.validate(action)) return true;
         if (!terminateTransaction(con)) return true;


### PR DESCRIPTION
I had a situation when driver closed connection because of I/O error, bur connection has been added to the avaialble ones and then returned to another caller.
The `testOn*` properties were not enabled in that case.

It looks like the pool can easily check if connection has been closed and don't accept it back.
WDYT?