### PR TITLE
Test Tomcat on ARM64 at TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,67 @@
+dist: bionic
+language: java
+jdk: oraclejdk8
+arch: arm64
+
+addons:
+    apt:
+      packages:
+        - ant
+        - build-essential
+        - automake
+        - autoconf
+        - tar
+        - libssl-dev
+        - subversion
+        - git
+        - libtool-bin
+
+install:
+    - ARCH=`uname -p`
+    - echo $ARCH
+    - JDK_X64="https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u242-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u242b08.tar.gz"
+    - JDK_ARM64="https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u232-b09/OpenJDK8U-jdk_aarch64_linux_hotspot_8u232b09.tar.gz"
+    - if test "X$ARCH" = "Xaarch64"; then JDK_URL=$JDK_ARM64; else JDK_URL=$JDK_X64; fi
+    - wget -q $JDK_URL && tar xzf OpenJDK*.tar.gz
+    - mv jdk8* jdk
+    - export JAVA_HOME=`pwd`/jdk
+    - wget -q http://mirrors.netix.net/apache/ant/binaries/apache-ant-1.10.7-bin.tar.gz && tar xzf apache-ant-*-bin.tar.gz
+    - export ANT_HOME=`pwd`/apache-ant-1.10.7
+    - export PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
+    - java -version
+    - ant -version
+    - rm -rf $HOME/tmp
+    - export CURR_PWD=`pwd`
+    - svn co -q https://svn.apache.org/repos/asf/apr/apr/branches/1.6.x/ $HOME/tmp/apr
+    - cd $HOME/tmp/apr
+    - ./buildconf
+    - ./configure --prefix=$HOME/tmp/apr-build
+    - make
+    - make install
+    - export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$HOME/tmp/apr-build/lib"
+    - git clone -q https://github.com/apache/tomcat-native.git $HOME/tmp/tomcat-native
+    - cd $HOME/tmp/tomcat-native/native
+    - sh buildconf --with-apr=$HOME/tmp/apr
+    - ./configure --with-apr=$HOME/tmp/apr --with-java-home=$JAVA_HOME --with-ssl=yes --prefix=$HOME/tmp/tomcat-native-build
+    - make
+    - make install
+    - cd $CURR_PWD
+    - yes | cp build.properties.default build.properties
+    - echo "test.threads=16" >> build.properties
+    - echo "test.relaxTiming=true" >> build.properties
+    - echo "test.excludePerformance=true" >> build.properties
+    - echo "test.openssl.path=/dev/null/openssl" >> build.properties
+    - echo "test.apr.loc=$HOME/tmp/tomcat-native-build/lib" >> build.properties
+
+
+script:
+    - ant -q clean
+    - travis_wait 60 "./.travis/antTest.sh"
+
+after_failure:
+    - tail -n 5000 ant-test.log
+    - ls -laR $HOME/tomcat-build-libs
+
+notifications:
+    email:
+      - dev@tomcat.apache.org

--- a/.travis/antTest.sh
+++ b/.travis/antTest.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# A helper script for TravisCI builds that saves the std
+# out and err streams in a log file. This is needed
+# because otherwise TravisCI complains that there is too
+# much logging on stdout
+
+ant -q test 2>&1 > ant-test.log


### PR DESCRIPTION
Discussion at Tomcat dev@ mailing list: https://markmail.org/message/cjgake2g2372457v

Right after the discussion at dev@ I've created https://issues.apache.org/jira/browse/INFRA-19665 but so far there was one unsuccessful attempt by Infra team to setup BuildBot on the ARM64 VM. The main problem was that the VM is running on Ubuntu 18.04 and for some reason the Puppet setup didn't work on ARM64.
@gmcdonald said that soon he will attempt again with venv.

This PR provides an alternative by using TravisCI ARM64 nodes. 
It tests **only** on ARM64. We could enable AMD64 too later if needed.
It builds APR from its `trunk`, Tomcat-Native from `master` and Tomcat itself from the current branch (`master` for now, but if accepted I'd like to backport this to `9.x` and probably to `8.5.x`). So, this setup does the same as Gump, I believe (I don't know the details of the Gump config).

If this PR is accepted then I will close https://issues.apache.org/jira/browse/INFRA-19665 .