### PR TITLE
Improved DNSMembershipProvider configuration code option 2

### DIFF
--- a/java/org/apache/catalina/tribes/membership/cloud/DNSMembershipProvider.java
+++ b/java/org/apache/catalina/tribes/membership/cloud/DNSMembershipProvider.java
@@ -55,6 +55,22 @@ public class DNSMembershipProvider extends CloudMembershipProvider {
         heartbeat();
     }
 
+    /**
+     * Get the DNS_MEMBERSHIP_SERVICE_NAME or KUBERNETES_NAMESPACE or OPENSHIFT_KUBE_PING_NAMESPACE
+     * or "tomcat" if the environment variable
+     * cannot be found (with a warning log about the missing namespace).
+     * @return the namespace
+     */
+    protected String getNamespace() {
+        String namespace = getEnv("DNS_MEMBERSHIP_SERVICE_NAME", "KUBERNETES_NAMESPACE", CUSTOM_ENV_PREFIX + "NAMESPACE");
+        if (namespace == null || namespace.length() == 0) {
+            log.warn(sm.getString("kubernetesMembershipProvider.noNamespace"));
+            namespace = "tomcat";
+        }
+        return namespace;
+    }
+
+
     @Override
     public boolean stop(int level) throws Exception {
         return super.stop(level);


### PR DESCRIPTION
DNSMembershipProvider configuration is little bit limited/broken with the KUBERNETES_NAMESPACE 
and OPENSHIFT_KUBE_PING_NAMESPACE environment variables. 
In Openshift the KUBERNETES_NAMESPACE is the Openshift project name. 
If you want override it with the OPENSHIFT_KUBE_PING_NAMESPACE variable this is not possible because the order of the resolution is KUBERNETES_NAMESPACE and then OPENSHIFT_KUBE_PING_NAMESPACE. 
Nobody will override the KUBERNETES_NAMESPACE with a different value because this is weired. 
Second KUBE_PING is a name for the kubernetes ping discovery for jgroups. 
I see two options to improve the configuration of the DNSMembershiftProvide. 
- Change the order of the resolution first look at OPENSHIFT_KUBE_PING_NAMESPACE and then KUBERNETES_NAMESPACE(this is not backwards compatible) 
- Add a new env variables like DNS_MEMBERSHIP_SERVICE_NAME 