### PR TITLE
Increment ReleaseIdle Counter when testAllIdle releases them

### DIFF
--- a/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/ConnectionPool.java
+++ b/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/ConnectionPool.java
@@ -1138,6 +1138,7 @@ public class ConnectionPool {
                         release = !reconnectIfExpired(con) || !con.validate(PooledConnection.VALIDATE_IDLE);
                     }
                     if (release) {
+                        releasedIdleCount.incrementAndGet();
                         idle.remove(con);
                         release(con);
                     }


### PR DESCRIPTION
In Tomcat JDBC module, I reckon PoolCleaner cleans the idle connections in two ways

- checkIdle
- testAllIdle

`releasedIdleCount` is incremented when released from `checkIdle` but not from `testAllIdle`. Is it part of the design? If so, why is it not counted?

IMO, the counter should be incremented in `testAllIdle` too. This PR includes this change.