### PR TITLE
Support for default values in property value expressions

### DIFF
--- a/java/org/apache/tomcat/util/IntrospectionUtils.java
+++ b/java/org/apache/tomcat/util/IntrospectionUtils.java
@@ -280,7 +280,8 @@ public final class IntrospectionUtils {
         return sb.toString();
     }
 
-    private static String getProperty(String name, Hashtable<Object, Object> staticProp, PropertySource[] dynamicProp, ClassLoader classLoader) {
+    private static String getProperty(String name, Hashtable<Object, Object> staticProp,
+            PropertySource[] dynamicProp, ClassLoader classLoader) {
         String v = null;
         if (staticProp != null) {
             v = (String) staticProp.get(name);

--- a/java/org/apache/tomcat/util/IntrospectionUtils.java
+++ b/java/org/apache/tomcat/util/IntrospectionUtils.java
@@ -219,7 +219,13 @@ public final class IntrospectionUtils {
     }
 
     /**
-     * Replace ${NAME} with the property value.
+     * Replaces ${NAME} in the value with the value of the property 'NAME'.
+     * Replaces ${NAME:DEFAULT} with the value of the property 'NAME:DEFAULT',
+     * if the property 'NAME:DEFAULT' is not set,
+     * the expresson is replaced with the value of the property 'NAME',
+     * if the property 'NAME' is not set,
+     * the expresson is replaced with 'DEFAULT'.
+     * If the property is not set and there is no default the value will be returned unmodified.
      * @param value The value
      * @param staticProp Replacement properties
      * @param dynamicProp Replacement properties

--- a/test/org/apache/tomcat/util/TestIntrospectionUtils.java
+++ b/test/org/apache/tomcat/util/TestIntrospectionUtils.java
@@ -16,6 +16,8 @@
  */
 package org.apache.tomcat.util;
 
+import java.util.Properties;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -108,5 +110,24 @@ public class TestIntrospectionUtils {
     public void testIsInstanceStandardContext12() {
         Assert.assertFalse(IntrospectionUtils.isInstance(
                 StandardContext.class, "com.example.Other"));
+    }
+
+    @Test
+    public void testReplaceProperties() {
+        Properties properties = new Properties();
+
+        Assert.assertEquals("no-expression", IntrospectionUtils.replaceProperties("no-expression", properties, null, null));
+
+        properties.setProperty("normal", "value1");
+        Assert.assertEquals("value1", IntrospectionUtils.replaceProperties("${normal}", properties, null, null));
+
+        properties.setProperty("property_with:colon", "value2");
+        Assert.assertEquals("value2", IntrospectionUtils.replaceProperties("${property_with:colon}", properties, null, null));
+        
+        Assert.assertEquals("value1", IntrospectionUtils.replaceProperties("${normal:default}", properties, null, null));
+
+        properties.remove("normal");
+        Assert.assertEquals("default", IntrospectionUtils.replaceProperties("${test1:default}", properties, null, null));
+
     }
 }

--- a/test/org/apache/tomcat/util/TestIntrospectionUtils.java
+++ b/test/org/apache/tomcat/util/TestIntrospectionUtils.java
@@ -119,9 +119,15 @@ public class TestIntrospectionUtils {
         Assert.assertEquals("no-expression", IntrospectionUtils.replaceProperties(
                 "no-expression", properties, null, null));
 
+        Assert.assertEquals("${normal}", IntrospectionUtils.replaceProperties(
+                "${normal}", properties, null, null));
+
         properties.setProperty("normal", "value1");
         Assert.assertEquals("value1", IntrospectionUtils.replaceProperties(
                 "${normal}", properties, null, null));
+
+        Assert.assertEquals("abcvalue1xyz", IntrospectionUtils.replaceProperties(
+                "abc${normal}xyz", properties, null, null));
 
         properties.setProperty("prop_with:colon", "value2");
         Assert.assertEquals("value2", IntrospectionUtils.replaceProperties(
@@ -132,7 +138,11 @@ public class TestIntrospectionUtils {
 
         properties.remove("normal");
         Assert.assertEquals("default", IntrospectionUtils.replaceProperties(
-                "${test1:default}", properties, null, null));
+                "${normal:default}", properties, null, null));
+
+        Assert.assertEquals("abc${normal}xyz", IntrospectionUtils.replaceProperties(
+                "abc${normal}xyz", properties, null, null));
+
 
     }
 }

--- a/test/org/apache/tomcat/util/TestIntrospectionUtils.java
+++ b/test/org/apache/tomcat/util/TestIntrospectionUtils.java
@@ -116,18 +116,23 @@ public class TestIntrospectionUtils {
     public void testReplaceProperties() {
         Properties properties = new Properties();
 
-        Assert.assertEquals("no-expression", IntrospectionUtils.replaceProperties("no-expression", properties, null, null));
+        Assert.assertEquals("no-expression", IntrospectionUtils.replaceProperties(
+                "no-expression", properties, null, null));
 
         properties.setProperty("normal", "value1");
-        Assert.assertEquals("value1", IntrospectionUtils.replaceProperties("${normal}", properties, null, null));
+        Assert.assertEquals("value1", IntrospectionUtils.replaceProperties(
+                "${normal}", properties, null, null));
 
-        properties.setProperty("property_with:colon", "value2");
-        Assert.assertEquals("value2", IntrospectionUtils.replaceProperties("${property_with:colon}", properties, null, null));
+        properties.setProperty("prop_with:colon", "value2");
+        Assert.assertEquals("value2", IntrospectionUtils.replaceProperties(
+                "${prop_with:colon}", properties, null, null));
         
-        Assert.assertEquals("value1", IntrospectionUtils.replaceProperties("${normal:default}", properties, null, null));
+        Assert.assertEquals("value1", IntrospectionUtils.replaceProperties(
+                "${normal:default}", properties, null, null));
 
         properties.remove("normal");
-        Assert.assertEquals("default", IntrospectionUtils.replaceProperties("${test1:default}", properties, null, null));
+        Assert.assertEquals("default", IntrospectionUtils.replaceProperties(
+                "${test1:default}", properties, null, null));
 
     }
 }


### PR DESCRIPTION
It would be nice to have support for default values in property value expressions.
You can use it with ${key:default}. 
Any interest in this feature?
Where is the best place for document this? 
Where to add a junit test for this? 
I used a modified version of 
org.apache.catalina.startup.TestTomcatStandalone on my local env.