### PR TITLE
Fix semantics of get and set EnableSessionCreation

### DIFF
--- a/java/org/apache/tomcat/util/net/openssl/LocalStrings.properties
+++ b/java/org/apache/tomcat/util/net/openssl/LocalStrings.properties
@@ -19,6 +19,7 @@ engine.engineClosed=Engine is closed
 engine.failedCipherSuite=Failed to enable cipher suite [{0}]
 engine.inboundClose=Inbound closed before receiving peer's close_notify
 engine.invalidBufferArray=offset: [{0}], length: [{1}] (expected: offset <= offset + length <= srcs.length [{2}])
+engine.noRestrictSessionCreation=OpenSslEngine does not permit restricting the engine to only resuming existing sessions
 engine.noSSLContext=No SSL context
 engine.noSession=SSL session ID not available
 engine.nullBuffer=Null buffer

--- a/java/org/apache/tomcat/util/net/openssl/OpenSSLEngine.java
+++ b/java/org/apache/tomcat/util/net/openssl/OpenSSLEngine.java
@@ -1117,14 +1117,15 @@ public final class OpenSSLEngine extends SSLEngine implements SSLUtil.ProtocolIn
 
     @Override
     public void setEnableSessionCreation(boolean b) {
-        if (b) {
-            throw new UnsupportedOperationException();
+        if (!b) {
+            String msg = sm.getString("engine.noRestrictSessionCreation");
+            throw new UnsupportedOperationException(msg);
         }
     }
 
     @Override
     public boolean getEnableSessionCreation() {
-        return false;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
Per the [javadocs for `SSLEngine`](https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLEngine.html#setEnableSessionCreation-boolean-), `setEnableSessionCreation` controls
whether or not new sessions are allowed to be created, or whether this
`SSLEngine` is restricted to resuming existing sessions. The default is
`true`, i.e., allow new sessions to be created. Because the OpenSSL
`SSLEngine` implementation does not limit the creation of new sessions,
`getEnableSessionCreation` should always return `true`, not `false`, and the
set operation should only yield an exception when the parameter is
false.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

---

I haven't looked for any existing BZs discussing this topic; the code also appears unused within Tomcat so this is mostly an implementation nit. This could potentially break existing code (if someone was calling `setEnableSessionCreation(false)`) -- but if they were truly expecting Tomcat's OpenSSL implementation to not create a new session, they'd be in for a surprise. This'd hopefully help them to fix their code (or better -- provide a PR adding this functionality if they truly need it). :-) 

I found this while working on JSS's SSLEngine and re-reading the semantics of both what Tomcat expects/does and what the javadocs say to do.

Note: I'm not sure how StringManager works -- do I have to provide translations for the exception for other languages now? Hopefully this exception is sufficiently clear in case anyone does stumble across it:

> OpenSslEngine does not permit restricting the engine to only resuming existing sessions