### PR TITLE
Set 'release' parameter for main compile target

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -713,6 +713,7 @@
            deprecation="${compile.deprecation}"
            source="${compile.source}"
            target="${compile.target}"
+           release="${compile.release}"
            encoding="ISO-8859-1"
            includeAntRuntime="true" >
       <!-- Uncomment this to show unchecked warnings:


### PR DESCRIPTION
As is, compiling with JDK9+ produces bytecode that can't run on older JVMs.