### PR TITLE
remove top '/' from parameter

### DIFF
--- a/java/org/apache/catalina/startup/WebappServiceLoader.java
+++ b/java/org/apache/catalina/startup/WebappServiceLoader.java
@@ -108,7 +108,7 @@ public class WebappServiceLoader<T> {
         if (orderedLibs == null) {
             // No ordered libs, so use every service definition we can find
             if (loader instanceof URLClassLoader) {
-                Enumeration<URL> resources = ((URLClassLoader) loader).findResources("/" + configFile);
+                Enumeration<URL> resources = ((URLClassLoader) loader).findResources(configFile);
                 while (resources.hasMoreElements()) {
                     URL resource = resources.nextElement();
                     parseConfigFile(applicationServicesFound, resource);


### PR DESCRIPTION
Remove top "/" from paramter of URLClassLoader#findResources().
I think that bad "/META-INF/services/...", good "META-INF/services/...".
