### PR TITLE
fix regression: only skip jar-scanning completely if scanSet is empty

### DIFF
--- a/java/org/apache/tomcat/util/scan/StandardJarScanFilter.java
+++ b/java/org/apache/tomcat/util/scan/StandardJarScanFilter.java
@@ -260,7 +260,7 @@ public class StandardJarScanFilter implements JarScanFilter {
     }
 
     private static boolean determineSkipAll() {
-       return defaultScanSet.isEmpty() &&
+        return defaultScanSet.isEmpty() &&
                (defaultSkipSet.contains("*") || defaultSkipSet.contains("*.jar"));
     }
 }

--- a/java/org/apache/tomcat/util/scan/StandardJarScanFilter.java
+++ b/java/org/apache/tomcat/util/scan/StandardJarScanFilter.java
@@ -42,9 +42,9 @@ public class StandardJarScanFilter implements JarScanFilter {
         // Initialize defaults. There are no setter methods for them.
         defaultSkip = System.getProperty(Constants.SKIP_JARS_PROPERTY);
         populateSetFromAttribute(defaultSkip, defaultSkipSet);
-        defaultSkipAll = defaultSkipSet.contains("*") || defaultSkipSet.contains("*.jar");
         defaultScan = System.getProperty(Constants.SCAN_JARS_PROPERTY);
         populateSetFromAttribute(defaultScan, defaultScanSet);
+        defaultSkipAll = determineSkipAll();
     }
 
     private String tldSkip;
@@ -257,5 +257,10 @@ public class StandardJarScanFilter implements JarScanFilter {
                 }
             }
         }
+    }
+
+    private static boolean determineSkipAll() {
+       return defaultScanSet.isEmpty() &&
+               (defaultSkipSet.contains("*") || defaultSkipSet.contains("*.jar"));
     }
 }


### PR DESCRIPTION
The commit 21d08e1952d6612da9a712a173c81174958f4b8b introduced a regression to the behavior of jar-scanning. Since version 9.0.31 it skips all jars, if a wildcard is found in the skipSet - no matter the content of the scanSet!

The documentation for `jarsToScan` clearly states: 
> overrides the default jarsToSkip list above

This PR restores this behavior by also respecting the "jarsToScan".