### PR TITLE
Remove reflection from Connector.java

### DIFF
--- a/java/org/apache/catalina/mbeans/MBeanFactory.java
+++ b/java/org/apache/catalina/mbeans/MBeanFactory.java
@@ -49,6 +49,8 @@ import org.apache.juli.logging.Log;
 import org.apache.juli.logging.LogFactory;
 import org.apache.tomcat.util.res.StringManager;
 
+import static org.apache.catalina.util.ProtocolHandlerFactory.createProtocolHandler;
+
 
 /**
  * @author Amy Roh
@@ -285,7 +287,7 @@ public class MBeanFactory {
         throws Exception {
         // Set the protocol in the constructor
         String protocol = isAjp ? "AJP/1.3" : "HTTP/1.1";
-        Connector retobj = new Connector(protocol);
+        Connector retobj = new Connector(createProtocolHandler(protocol));
         if ((address!=null) && (address.length()>0)) {
             retobj.setProperty("address", address);
         }

--- a/java/org/apache/catalina/mbeans/ServiceMBean.java
+++ b/java/org/apache/catalina/mbeans/ServiceMBean.java
@@ -16,11 +16,13 @@
  */
 package org.apache.catalina.mbeans;
 
-import javax.management.MBeanException;
-
 import org.apache.catalina.Executor;
 import org.apache.catalina.Service;
 import org.apache.catalina.connector.Connector;
+
+import javax.management.MBeanException;
+
+import static org.apache.catalina.util.ProtocolHandlerFactory.createProtocolHandler;
 
 public class ServiceMBean extends BaseCatalinaMBean<Service> {
 
@@ -39,7 +41,12 @@ public class ServiceMBean extends BaseCatalinaMBean<Service> {
 
         Service service = doGetManagedResource();
         String protocol = isAjp ? "AJP/1.3" : "HTTP/1.1";
-        Connector connector = new Connector(protocol);
+        Connector connector = null;
+        try {
+            connector = new Connector(createProtocolHandler(protocol));
+        } catch (Exception e) {
+            throw new MBeanException(e);
+        }
         if ((address!=null) && (address.length()>0)) {
             connector.setProperty("address", address);
         }

--- a/java/org/apache/catalina/startup/ConnectorCreateRule.java
+++ b/java/org/apache/catalina/startup/ConnectorCreateRule.java
@@ -31,6 +31,8 @@ import org.apache.tomcat.util.digester.Rule;
 import org.apache.tomcat.util.res.StringManager;
 import org.xml.sax.Attributes;
 
+import static org.apache.catalina.util.ProtocolHandlerFactory.createProtocolHandler;
+
 
 /**
  * Rule implementation that creates a connector.
@@ -61,7 +63,7 @@ public class ConnectorCreateRule extends Rule {
         if ( attributes.getValue("executor")!=null ) {
             ex = svc.getExecutor(attributes.getValue("executor"));
         }
-        Connector con = new Connector(attributes.getValue("protocol"));
+        Connector con = new Connector(createProtocolHandler((attributes.getValue("protocol"))));
         if (ex != null) {
             setExecutor(con, ex);
         }

--- a/java/org/apache/catalina/startup/Tomcat.java
+++ b/java/org/apache/catalina/startup/Tomcat.java
@@ -70,6 +70,7 @@ import org.apache.catalina.realm.RealmBase;
 import org.apache.catalina.security.SecurityClassLoad;
 import org.apache.catalina.util.ContextName;
 import org.apache.catalina.util.IOTools;
+import org.apache.coyote.http11.Http11NioProtocol;
 import org.apache.tomcat.util.ExceptionUtils;
 import org.apache.tomcat.util.buf.UriUtil;
 import org.apache.tomcat.util.compat.JreCompat;
@@ -533,14 +534,16 @@ public class Tomcat {
         if (service.findConnectors().length > 0) {
             return service.findConnectors()[0];
         }
-        // The same as in standard Tomcat configuration.
-        // This creates an APR HTTP connector if AprLifecycleListener has been
-        // configured (created) and Tomcat Native library is available.
-        // Otherwise it creates a NIO HTTP connector.
-        Connector connector = new Connector("HTTP/1.1");
-        connector.setPort(port);
-        service.addConnector(connector);
-        return connector;
+        // If no connectors are available
+        // create a NIO connector
+        try {
+            Connector connector = new Connector(new Http11NioProtocol());
+            connector.setPort(port);
+            service.addConnector(connector);
+            return connector;
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     /**

--- a/java/org/apache/catalina/storeconfig/ConnectorStoreAppender.java
+++ b/java/org/apache/catalina/storeconfig/ConnectorStoreAppender.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.catalina.connector.Connector;
+import org.apache.catalina.util.ProtocolHandlerFactory;
 import org.apache.coyote.ProtocolHandler;
 import org.apache.tomcat.util.IntrospectionUtils;
 import org.apache.tomcat.util.net.SocketProperties;
@@ -69,7 +70,7 @@ public class ConnectorStoreAppender extends StoreAppender {
         String protocol = connector.getProtocol();
         List<String> propertyKeys = getPropertyKeys(connector);
         // Create blank instance
-        Object bean2 = new Connector(protocol);//defaultInstance(bean);
+        Object bean2 = new Connector(ProtocolHandlerFactory.createProtocolHandler(protocol));//defaultInstance(bean);
         for (String key : propertyKeys) {
             Object value = IntrospectionUtils.getProperty(bean, key);
             if (desc.isTransientAttribute(key)) {

--- a/java/org/apache/catalina/util/ProtocolHandlerFactory.java
+++ b/java/org/apache/catalina/util/ProtocolHandlerFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.catalina.util;
+
+import org.apache.catalina.core.AprLifecycleListener;
+import org.apache.coyote.ProtocolHandler;
+
+import java.lang.reflect.InvocationTargetException;
+
+public class ProtocolHandlerFactory {
+
+    public static ProtocolHandler createProtocolHandler(String protocol) throws
+        ClassNotFoundException, NoSuchMethodException, IllegalAccessException,
+        InvocationTargetException, InstantiationException {
+
+        boolean apr = AprLifecycleListener.isAprAvailable() && AprLifecycleListener.getUseAprConnector();
+
+        if ("HTTP/1.1".equals(protocol) || protocol == null) {
+            protocol = apr ?
+                "org.apache.coyote.http11.Http11AprProtocol" :
+                "org.apache.coyote.http11.Http11NioProtocol";
+        } else if ("AJP/1.3".equals(protocol)) {
+            protocol = apr ?
+                "org.apache.coyote.ajp.AjpAprProtocol" :
+                "org.apache.coyote.ajp.AjpNioProtocol";
+
+        }
+
+        // Instantiate protocol handler
+        Class<?> clazz = Class.forName(protocol);
+        return (ProtocolHandler) clazz.getConstructor().newInstance();
+    }
+}

--- a/java/org/apache/coyote/ProtocolHandler.java
+++ b/java/org/apache/coyote/ProtocolHandler.java
@@ -179,4 +179,21 @@ public interface ProtocolHandler {
      * @return the protocols
      */
     public UpgradeProtocol[] findUpgradeProtocols();
+
+    /**
+     * Returns {@code HTTP/1.1} unless implementation overrides it
+     * @return the protocol name for this implementation
+     */
+    default String getProtocolAbbreviation() {
+        return "HTTP/1.1";
+    }
+
+    /**
+     * For protocols that have a packet size, return a positive packet size.
+     * Used when creating response messages
+     * @return default is -1, no packet size available.
+     */
+    default int getPacketSize() {
+        return -1;
+    }
 }

--- a/java/org/apache/coyote/ajp/AbstractAjpProtocol.java
+++ b/java/org/apache/coyote/ajp/AbstractAjpProtocol.java
@@ -56,6 +56,10 @@ public abstract class AbstractAjpProtocol<S> extends AbstractProtocol<S> {
         getEndpoint().setHandler(cHandler);
     }
 
+    @Override
+    public String getProtocolAbbreviation() {
+        return "AJP/1.3";
+    }
 
     @Override
     protected String getProtocolName() {
@@ -205,6 +209,7 @@ public abstract class AbstractAjpProtocol<S> extends AbstractProtocol<S> {
      * AJP packet size.
      */
     private int packetSize = Constants.MAX_PACKET_SIZE;
+    @Override
     public int getPacketSize() { return packetSize; }
     public void setPacketSize(int packetSize) {
         if(packetSize < Constants.MAX_PACKET_SIZE) {

--- a/test/org/apache/catalina/connector/TestConnector.java
+++ b/test/org/apache/catalina/connector/TestConnector.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import jakarta.servlet.Servlet;
 
+import org.apache.coyote.http11.Http11NioProtocol;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -86,7 +87,7 @@ public class TestConnector extends TomcatBaseTest {
         Connector connector1 = tomcat.getConnector();
         connector1.setPort(0);
 
-        Connector connector2 = new Connector();
+        Connector connector2 = new Connector(new Http11NioProtocol());
         connector2.setPort(0);
 
         tomcat.getService().addConnector(connector2);
@@ -98,26 +99,6 @@ public class TestConnector extends TomcatBaseTest {
 
         Assert.assertTrue(localPort1 > 0);
         Assert.assertTrue(localPort2 > 0);
-    }
-
-
-    @Test(expected=LifecycleException.class)
-    public void testInvalidProtocolThrows() throws Exception {
-        doTestInvalidProtocol(true);
-    }
-
-
-    @Test
-    public void testInvalidProtocolNoThrows() throws Exception {
-        doTestInvalidProtocol(false);
-    }
-
-
-    private void doTestInvalidProtocol(boolean throwOnFailure) throws Exception {
-        Connector c = new Connector("foo.Bar");
-        c.setThrowOnFailure(throwOnFailure);
-
-        c.start();
     }
 
 
@@ -134,12 +115,12 @@ public class TestConnector extends TomcatBaseTest {
 
 
     private void doTestDuplicatePort(boolean throwOnFailure) throws Exception {
-        Connector c1 = new Connector();
+        Connector c1 = new Connector(new Http11NioProtocol());
         c1.setThrowOnFailure(throwOnFailure);
         c1.setPort(0);
         c1.start();
 
-        Connector c2 = new Connector();
+        Connector c2 = new Connector(new Http11NioProtocol());
         c2.setThrowOnFailure(throwOnFailure);
         c2.setPort(c1.getLocalPort());
 

--- a/test/org/apache/catalina/connector/TestResponse.java
+++ b/test/org/apache/catalina/connector/TestResponse.java
@@ -28,6 +28,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
+import org.apache.coyote.http11.Http11NioProtocol;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -595,7 +596,7 @@ public class TestResponse extends TomcatBaseTest {
     private void doTestSendRedirect(String input, String expectedLocation) throws Exception {
         // Set-up.
         // Note: Not sufficient for testing relative -> absolute
-        Connector connector = new Connector();
+        Connector connector = new Connector(new Http11NioProtocol());
         org.apache.coyote.Response cResponse = new org.apache.coyote.Response();
         Response response = new Response();
         response.setCoyoteResponse(cResponse);

--- a/test/org/apache/catalina/core/TestStandardService.java
+++ b/test/org/apache/catalina/core/TestStandardService.java
@@ -18,6 +18,7 @@ package org.apache.catalina.core;
 
 import java.net.InetAddress;
 
+import org.apache.coyote.http11.Http11NioProtocol;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -47,7 +48,7 @@ public class TestStandardService extends TomcatBaseTest {
 
         tomcat.start();
 
-        Connector c2 = new Connector("HTTP/1.1");
+        Connector c2 = new Connector(new Http11NioProtocol());
         c2.setThrowOnFailure(throwOnFailure);
 
         Assert.assertTrue(c2.setProperty("address", ((InetAddress) connector.getProperty("address")).getHostAddress()));

--- a/test/org/apache/catalina/filters/TestRemoteIpFilter.java
+++ b/test/org/apache/catalina/filters/TestRemoteIpFilter.java
@@ -37,6 +37,7 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import org.apache.coyote.http11.Http11NioProtocol;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -113,7 +114,7 @@ public class TestRemoteIpFilter extends TomcatBaseTest {
      */
     public static class MockHttpServletRequest extends Request {
         public MockHttpServletRequest() {
-            super(new Connector());
+            super(new Connector(new Http11NioProtocol()));
             setCoyoteRequest(new org.apache.coyote.Request());
         }
 

--- a/test/org/apache/catalina/startup/TomcatBaseTest.java
+++ b/test/org/apache/catalina/startup/TomcatBaseTest.java
@@ -42,6 +42,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
+import org.apache.catalina.util.ProtocolHandlerFactory;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -168,7 +169,7 @@ public abstract class TomcatBaseTest extends LoggingBaseTest {
         tomcat = new TomcatWithFastSessionIDs();
 
         String protocol = getProtocol();
-        Connector connector = new Connector(protocol);
+        Connector connector = new Connector(ProtocolHandlerFactory.createProtocolHandler(protocol));
         // Listen only on localhost
         Assert.assertTrue(connector.setProperty("address", InetAddress.getByName("localhost").getHostAddress()));
         // Use random free port

--- a/test/org/apache/catalina/valves/TestRequestFilterValve.java
+++ b/test/org/apache/catalina/valves/TestRequestFilterValve.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 
 import jakarta.servlet.ServletException;
 
+import org.apache.coyote.http11.Http11NioProtocol;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -82,7 +83,7 @@ public class TestRequestFilterValve {
                          String property, String type, boolean allowed) {
         // PREPARE
         RequestFilterValve valve = null;
-        Connector connector = new Connector();
+        Connector connector = new Connector(new Http11NioProtocol());
         Context context = new StandardContext();
         Request request = new Request(connector);
         Response response = new MockResponse();


### PR DESCRIPTION
I will start a discussion on dev@tomcat.apache.org

TL;DR; We are using Apache Tomcat embedded in native images (GraalVM). 
Reflection causes images to be unnecessarily large, and Apache Tomcat has many places where reflection can be avoided in an embedded scenario. 