### PR TITLE
Improve Catalina class loader repositories regular expression

### DIFF
--- a/java/org/apache/catalina/startup/Bootstrap.java
+++ b/java/org/apache/catalina/startup/Bootstrap.java
@@ -59,7 +59,7 @@ public final class Bootstrap {
     private static final File catalinaBaseFile;
     private static final File catalinaHomeFile;
 
-    private static final Pattern PATH_PATTERN = Pattern.compile("(\".*?\")|(([^,])*)");
+    private static final Pattern PATH_PATTERN = Pattern.compile("(\"[^\"]*\")|(([^,])*)");
 
     static {
         // Will always be non-null


### PR DESCRIPTION
The goal of this enhancement is to improve the regular expression used
for searching class loader repositories when bootstrapping Catalina.

With the Java regular expression engine which is regex-directed, we
gain in performance by using the negated character class [^\"]* rather
than the lazy quantifier .*? in the regular expression used for
searching class loader repositories when bootstrapping Catalina.