### PR TITLE
Use parameterized collection constructors where possible

### DIFF
--- a/java/jakarta/el/LambdaExpression.java
+++ b/java/jakarta/el/LambdaExpression.java
@@ -65,8 +65,7 @@ public class LambdaExpression {
         // Build the argument map
         // Start with the arguments from any outer expressions so if there is
         // any overlap the local arguments have priority
-        Map<String,Object> lambdaArguments = new HashMap<>();
-        lambdaArguments.putAll(nestedArguments);
+        Map<String, Object> lambdaArguments = new HashMap<>(nestedArguments);
         for (int i = 0; i < formalParamCount; i++) {
             lambdaArguments.put(formalParameters.get(i), args[i]);
         }

--- a/java/jakarta/servlet/ServletSecurityElement.java
+++ b/java/jakarta/servlet/ServletSecurityElement.java
@@ -107,14 +107,12 @@ public class ServletSecurityElement extends HttpConstraintElement {
     }
 
     public Collection<HttpMethodConstraintElement> getHttpMethodConstraints() {
-        Collection<HttpMethodConstraintElement> result = new HashSet<>();
-        result.addAll(methodConstraints.values());
+        Collection<HttpMethodConstraintElement> result = new HashSet<>(methodConstraints.values());
         return result;
     }
 
     public Collection<String> getMethodNames() {
-        Collection<String> result = new HashSet<>();
-        result.addAll(methodConstraints.keySet());
+        Collection<String> result = new HashSet<>(methodConstraints.keySet());
         return result;
     }
 

--- a/java/org/apache/catalina/connector/Request.java
+++ b/java/org/apache/catalina/connector/Request.java
@@ -930,8 +930,7 @@ public class Request implements HttpServletRequest {
         }
         // Take a copy to prevent ConcurrentModificationExceptions if used to
         // remove attributes
-        Set<String> names = new HashSet<>();
-        names.addAll(attributes.keySet());
+        Set<String> names = new HashSet<>(attributes.keySet());
         return Collections.enumeration(names);
     }
 
@@ -1978,8 +1977,7 @@ public class Request implements HttpServletRequest {
         if (!isTrailerFieldsReady()) {
             throw new IllegalStateException(sm.getString("coyoteRequest.trailersNotReady"));
         }
-        Map<String,String> result = new HashMap<>();
-        result.putAll(coyoteRequest.getTrailerFields());
+        Map<String, String> result = new HashMap<>(coyoteRequest.getTrailerFields());
         return result;
     }
 

--- a/java/org/apache/catalina/core/ApplicationContext.java
+++ b/java/org/apache/catalina/core/ApplicationContext.java
@@ -204,8 +204,7 @@ public class ApplicationContext implements ServletContext {
 
     @Override
     public Enumeration<String> getAttributeNames() {
-        Set<String> names = new HashSet<>();
-        names.addAll(attributes.keySet());
+        Set<String> names = new HashSet<>(attributes.keySet());
         return Collections.enumeration(names);
     }
 
@@ -297,8 +296,7 @@ public class ApplicationContext implements ServletContext {
 
     @Override
     public Enumeration<String> getInitParameterNames() {
-        Set<String> names = new HashSet<>();
-        names.addAll(parameters.keySet());
+        Set<String> names = new HashSet<>(parameters.keySet());
         // Special handling for XML settings as these attributes will always be
         // available if they have been set on the context
         if (context.getTldValidation()) {

--- a/java/org/apache/catalina/core/AsyncContextImpl.java
+++ b/java/org/apache/catalina/core/AsyncContextImpl.java
@@ -98,8 +98,7 @@ public class AsyncContextImpl implements AsyncContext, AsyncContextCallback {
         if (log.isDebugEnabled()) {
             log.debug(sm.getString("asyncContextImpl.fireOnComplete"));
         }
-        List<AsyncListenerWrapper> listenersCopy = new ArrayList<>();
-        listenersCopy.addAll(listeners);
+        List<AsyncListenerWrapper> listenersCopy = new ArrayList<>(listeners);
 
         ClassLoader oldCL = context.bind(Globals.IS_SECURITY_ENABLED, null);
         try {
@@ -133,8 +132,7 @@ public class AsyncContextImpl implements AsyncContext, AsyncContextCallback {
             }
             ClassLoader oldCL = context.bind(false, null);
             try {
-                List<AsyncListenerWrapper> listenersCopy = new ArrayList<>();
-                listenersCopy.addAll(listeners);
+                List<AsyncListenerWrapper> listenersCopy = new ArrayList<>(listeners);
                 for (AsyncListenerWrapper listener : listenersCopy) {
                     try {
                         listener.fireOnTimeout(event);
@@ -331,8 +329,7 @@ public class AsyncContextImpl implements AsyncContext, AsyncContextCallback {
             this.hasOriginalRequestAndResponse = originalRequestResponse;
             this.event = new AsyncEvent(this, request, response);
 
-            List<AsyncListenerWrapper> listenersCopy = new ArrayList<>();
-            listenersCopy.addAll(listeners);
+            List<AsyncListenerWrapper> listenersCopy = new ArrayList<>(listeners);
             listeners.clear();
             if (log.isDebugEnabled()) {
                 log.debug(sm.getString("asyncContextImpl.fireOnStartAsync"));
@@ -416,8 +413,7 @@ public class AsyncContextImpl implements AsyncContext, AsyncContextCallback {
             }
             AsyncEvent errorEvent = new AsyncEvent(event.getAsyncContext(),
                     event.getSuppliedRequest(), event.getSuppliedResponse(), t);
-            List<AsyncListenerWrapper> listenersCopy = new ArrayList<>();
-            listenersCopy.addAll(listeners);
+            List<AsyncListenerWrapper> listenersCopy = new ArrayList<>(listeners);
             for (AsyncListenerWrapper listener : listenersCopy) {
                 try {
                     listener.fireOnError(errorEvent);

--- a/java/org/apache/catalina/ha/context/ReplicatedContext.java
+++ b/java/org/apache/catalina/ha/context/ReplicatedContext.java
@@ -186,8 +186,7 @@ public class ReplicatedContext extends StandardContext implements MapOwner {
         @SuppressWarnings("unchecked")
         @Override
         public Enumeration<String> getAttributeNames() {
-            Set<String> names = new HashSet<>();
-            names.addAll(attributes.keySet());
+            Set<String> names = new HashSet<>(attributes.keySet());
 
             return new MultiEnumeration<>(new Enumeration[] {
                     super.getAttributeNames(),

--- a/java/org/apache/catalina/manager/HTMLManagerServlet.java
+++ b/java/org/apache/catalina/manager/HTMLManagerServlet.java
@@ -896,8 +896,7 @@ public final class HTMLManagerServlet extends ManagerServlet {
                     Escape.htmlElementContent(cn.getDisplayName())));
         }
         Manager manager = ctxt.getManager();
-        List<Session> sessions = new ArrayList<>();
-        sessions.addAll(Arrays.asList(manager.findSessions()));
+        List<Session> sessions = new ArrayList<>(Arrays.asList(manager.findSessions()));
         if (manager instanceof DistributedManager && showProxySessions) {
             // Add dummy proxy sessions
             Set<String> sessionIds =

--- a/java/org/apache/catalina/servlets/CGIServlet.java
+++ b/java/org/apache/catalina/servlets/CGIServlet.java
@@ -979,10 +979,8 @@ public final class CGIServlet extends HttpServlet {
              * (apologies to Marv Albert regarding MJ)
              */
 
-            Hashtable<String,String> envp = new Hashtable<>();
-
             // Add the shell environment variables (if any)
-            envp.putAll(shellEnv);
+            Hashtable<String, String> envp = new Hashtable<>(shellEnv);
 
             // Add the CGI environment variables
             String sPathInfoOrig = null;

--- a/java/org/apache/catalina/session/ManagerBase.java
+++ b/java/org/apache/catalina/session/ManagerBase.java
@@ -1063,9 +1063,9 @@ public abstract class ManagerBase extends LifecycleMBeanBase implements Manager 
     @Override
     public int getSessionAverageAliveTime() {
         // Copy current stats
-        List<SessionTiming> copy = new ArrayList<>();
+        List<SessionTiming> copy;
         synchronized (sessionExpirationTiming) {
-            copy.addAll(sessionExpirationTiming);
+            copy = new ArrayList<>(sessionExpirationTiming);
         }
 
         // Init
@@ -1094,9 +1094,9 @@ public abstract class ManagerBase extends LifecycleMBeanBase implements Manager 
     @Override
     public int getSessionCreateRate() {
         // Copy current stats
-        List<SessionTiming> copy = new ArrayList<>();
+        List<SessionTiming> copy;
         synchronized (sessionCreationTiming) {
-            copy.addAll(sessionCreationTiming);
+            copy = new ArrayList<>(sessionCreationTiming);
         }
 
         return calculateRate(copy);
@@ -1114,9 +1114,9 @@ public abstract class ManagerBase extends LifecycleMBeanBase implements Manager 
     @Override
     public int getSessionExpireRate() {
         // Copy current stats
-        List<SessionTiming> copy = new ArrayList<>();
+        List<SessionTiming> copy;
         synchronized (sessionExpirationTiming) {
-            copy.addAll(sessionExpirationTiming);
+            copy = new ArrayList<>(sessionExpirationTiming);
         }
 
         return calculateRate(copy);

--- a/java/org/apache/catalina/session/PersistentManagerBase.java
+++ b/java/org/apache/catalina/session/PersistentManagerBase.java
@@ -647,9 +647,8 @@ public abstract class PersistentManagerBase extends ManagerBase
 
     @Override
     public Set<String> getSessionIdsFull() {
-        Set<String> sessionIds = new HashSet<>();
         // In memory session ID list
-        sessionIds.addAll(sessions.keySet());
+        Set<String> sessionIds = new HashSet<>(sessions.keySet());
         // Store session ID list
         String[] storeKeys;
         try {

--- a/java/org/apache/catalina/session/StandardSession.java
+++ b/java/org/apache/catalina/session/StandardSession.java
@@ -1156,8 +1156,7 @@ public class StandardSession implements HttpSession, Session, Serializable {
             throw new IllegalStateException
                 (sm.getString("standardSession.getAttributeNames.ise"));
 
-        Set<String> names = new HashSet<>();
-        names.addAll(attributes.keySet());
+        Set<String> names = new HashSet<>(attributes.keySet());
         return Collections.enumeration(names);
     }
 

--- a/java/org/apache/catalina/startup/HostConfig.java
+++ b/java/org/apache/catalina/startup/HostConfig.java
@@ -1652,8 +1652,7 @@ public class HostConfig implements LifecycleListener {
         }
 
         // Need ordered set of names
-        SortedSet<String> sortedAppNames = new TreeSet<>();
-        sortedAppNames.addAll(deployed.keySet());
+        SortedSet<String> sortedAppNames = new TreeSet<>(deployed.keySet());
 
         Iterator<String> iter = sortedAppNames.iterator();
 

--- a/java/org/apache/coyote/http11/AbstractHttp11Protocol.java
+++ b/java/org/apache/coyote/http11/AbstractHttp11Protocol.java
@@ -396,8 +396,7 @@ public abstract class AbstractHttp11Protocol<S> extends AbstractProtocol<S> {
     public void setAllowedTrailerHeaders(String commaSeparatedHeaders) {
         // Jump through some hoops so we don't end up with an empty set while
         // doing updates.
-        Set<String> toRemove = new HashSet<>();
-        toRemove.addAll(allowedTrailerHeaders);
+        Set<String> toRemove = new HashSet<>(allowedTrailerHeaders);
         if (commaSeparatedHeaders != null) {
             String[] headers = commaSeparatedHeaders.split(",");
             for (String header : headers) {

--- a/java/org/apache/coyote/http2/HPackHuffman.java
+++ b/java/org/apache/coyote/http2/HPackHuffman.java
@@ -315,8 +315,7 @@ public class HPackHuffman {
         HuffmanCode[] currentCode = new HuffmanCode[256];
         currentCode[0] = new HuffmanCode(0, 0);
 
-        final Set<HuffmanCode> allCodes = new HashSet<>();
-        allCodes.addAll(Arrays.asList(HUFFMAN_CODES));
+        final Set<HuffmanCode> allCodes = new HashSet<>(Arrays.asList(HUFFMAN_CODES));
 
         while (!allCodes.isEmpty()) {
             int length = currentCode[pos].length;

--- a/java/org/apache/coyote/http2/Http2UpgradeHandler.java
+++ b/java/org/apache/coyote/http2/Http2UpgradeHandler.java
@@ -1020,8 +1020,7 @@ class Http2UpgradeHandler extends AbstractStream implements InternalHttpUpgradeH
 
         // Recipients are children of the current stream that are in the
         // backlog.
-        Set<AbstractStream> recipients = new HashSet<>();
-        recipients.addAll(stream.getChildStreams());
+        Set<AbstractStream> recipients = new HashSet<>(stream.getChildStreams());
         recipients.retainAll(backLogStreams.keySet());
 
         // Loop until we run out of allocation or recipients

--- a/java/org/apache/jasper/compiler/TagLibraryInfoImpl.java
+++ b/java/org/apache/jasper/compiler/TagLibraryInfoImpl.java
@@ -341,8 +341,7 @@ class TagLibraryInfoImpl extends TagLibraryInfo implements TagConstants {
             return null;
         }
 
-        Map<String,Object> initParams = new Hashtable<>();
-        initParams.putAll(validatorXml.getInitParams());
+        Map<String, Object> initParams = new Hashtable<>(validatorXml.getInitParams());
 
         try {
             Class<?> tlvClass = ctxt.getClassLoader().loadClass(validatorClass);

--- a/java/org/apache/tomcat/buildutil/MimeTypeMappings.java
+++ b/java/org/apache/tomcat/buildutil/MimeTypeMappings.java
@@ -49,8 +49,7 @@ public class MimeTypeMappings {
         digester.parse(globalWebXml);
 
         Map<String,String> webXmlMimeMappings = webXmlDefaultFragment.getMimeMappings();
-        SortedMap<String,String> sortedWebXmlMimeMappings = new TreeMap<>();
-        sortedWebXmlMimeMappings.putAll(webXmlMimeMappings);
+        SortedMap<String, String> sortedWebXmlMimeMappings = new TreeMap<>(webXmlMimeMappings);
 
         File f = new File("java/org/apache/catalina/startup/MimeTypeMappings.properties");
         FileOutputStream fos = new FileOutputStream(f);

--- a/java/org/apache/tomcat/util/net/AbstractJsseEndpoint.java
+++ b/java/org/apache/tomcat/util/net/AbstractJsseEndpoint.java
@@ -130,8 +130,7 @@ public abstract class AbstractJsseEndpoint<S,U> extends AbstractEndpoint<S,U> {
             // one protocol in common
             // Note: Tomcat does not explicitly negotiate http/1.1
             // TODO: Is this correct? Should it change?
-            List<String> commonProtocols = new ArrayList<>();
-            commonProtocols.addAll(negotiableProtocols);
+            List<String> commonProtocols = new ArrayList<>(negotiableProtocols);
             commonProtocols.retainAll(clientRequestedApplicationProtocols);
             if (commonProtocols.size() > 0) {
                 String[] commonProtocolsArray = commonProtocols.toArray(new String[commonProtocols.size()]);

--- a/java/org/apache/tomcat/util/net/SSLUtilBase.java
+++ b/java/org/apache/tomcat/util/net/SSLUtilBase.java
@@ -155,8 +155,7 @@ public abstract class SSLUtilBase implements SSLUtil {
             }
             if (log.isDebugEnabled() || warnOnSkip) {
                 if (enabled.size() != configured.size()) {
-                    List<T> skipped = new ArrayList<>();
-                    skipped.addAll(configured);
+                    List<T> skipped = new ArrayList<>(configured);
                     skipped.removeAll(enabled);
                     String msg = sm.getString("sslUtilBase.skipped", name, skipped);
                     if (warnOnSkip) {
@@ -307,8 +306,7 @@ public abstract class SSLUtilBase implements SSLUtil {
                     keyPass);
             PEMFile certificateFile = new PEMFile(certificate.getCertificateFile());
 
-            Collection<Certificate> chain = new ArrayList<>();
-            chain.addAll(certificateFile.getCertificates());
+            Collection<Certificate> chain = new ArrayList<>(certificateFile.getCertificates());
             if (certificate.getCertificateChainFile() != null) {
                 PEMFile certificateChainFile = new PEMFile(certificate.getCertificateChainFile());
                 chain.addAll(certificateChainFile.getCertificates());

--- a/java/org/apache/tomcat/util/net/openssl/OpenSSLContext.java
+++ b/java/org/apache/tomcat/util/net/openssl/OpenSSLContext.java
@@ -300,8 +300,7 @@ public class OpenSSLContext implements org.apache.tomcat.util.net.SSLContext {
             }
 
             if (negotiableProtocols != null && negotiableProtocols.size() > 0) {
-                List<String> protocols = new ArrayList<>();
-                protocols.addAll(negotiableProtocols);
+                List<String> protocols = new ArrayList<>(negotiableProtocols);
                 protocols.add("http/1.1");
                 String[] protocolsArray = protocols.toArray(new String[0]);
                 SSLContext.setAlpnProtos(ctx, protocolsArray, SSL.SSL_SELECTOR_FAILURE_NO_ADVERTISE);

--- a/java/org/apache/tomcat/util/net/openssl/ciphers/Cipher.java
+++ b/java/org/apache/tomcat/util/net/openssl/ciphers/Cipher.java
@@ -5019,8 +5019,7 @@ public enum Cipher {
         this.id = id;
         this.openSSLAlias = openSSLAlias;
         if (openSSlAltNames != null && openSSlAltNames.length != 0) {
-            Set<String> altNames = new HashSet<>();
-            altNames.addAll(Arrays.asList(openSSlAltNames));
+            Set<String> altNames = new HashSet<>(Arrays.asList(openSSlAltNames));
             this.openSSLAltNames = Collections.unmodifiableSet(altNames);
         } else {
             this.openSSLAltNames = Collections.emptySet();

--- a/java/org/apache/tomcat/websocket/BackgroundProcessManager.java
+++ b/java/org/apache/tomcat/websocket/BackgroundProcessManager.java
@@ -82,9 +82,9 @@ public class BackgroundProcessManager {
 
 
     private void process() {
-        Set<BackgroundProcess> currentProcesses = new HashSet<>();
+        Set<BackgroundProcess> currentProcesses;
         synchronized (processesLock) {
-            currentProcesses.addAll(processes);
+            currentProcesses = new HashSet<>(processes);
         }
         for (BackgroundProcess process : currentProcesses) {
             try {

--- a/test/org/apache/catalina/servlets/ServletOptionsBaseTest.java
+++ b/test/org/apache/catalina/servlets/ServletOptionsBaseTest.java
@@ -152,8 +152,7 @@ public abstract class ServletOptionsBaseTest extends TomcatBaseTest {
             for (int i = 0; i < values.length; i++) {
                 values[i] = values[i].trim();
             }
-            Set<String> allowed = new HashSet<>();
-            allowed.addAll(Arrays.asList(values));
+            Set<String> allowed = new HashSet<>(Arrays.asList(values));
 
             return allowed;
         }

--- a/test/org/apache/catalina/startup/TestTomcatNoServer.java
+++ b/test/org/apache/catalina/startup/TestTomcatNoServer.java
@@ -62,12 +62,10 @@ public class TestTomcatNoServer {
 
         Map<String,String> webXmlMimeMappings = webXmlDefaultFragment.getMimeMappings();
 
-        Set<String> embeddedExtensions = new HashSet<>();
-        embeddedExtensions.addAll(Arrays.asList(ctx.findMimeMappings()));
+        Set<String> embeddedExtensions = new HashSet<>(Arrays.asList(ctx.findMimeMappings()));
 
         // Find entries present in conf/web.xml that are missing in embedded
-        Set<String> missingInEmbedded = new HashSet<>();
-        missingInEmbedded.addAll(webXmlMimeMappings.keySet());
+        Set<String> missingInEmbedded = new HashSet<>(webXmlMimeMappings.keySet());
         missingInEmbedded.removeAll(embeddedExtensions);
         if (missingInEmbedded.size() > 0) {
             for (String missingExtension : missingInEmbedded) {
@@ -78,8 +76,7 @@ public class TestTomcatNoServer {
         }
 
         // Find entries present in embedded that are missing in conf/web.xml
-        Set<String> missingInWebXml = new HashSet<>();
-        missingInWebXml.addAll(embeddedExtensions);
+        Set<String> missingInWebXml = new HashSet<>(embeddedExtensions);
         missingInWebXml.removeAll(webXmlMimeMappings.keySet());
         if (missingInWebXml.size() > 0) {
             for (String missingExtension : missingInWebXml) {

--- a/test/org/apache/catalina/valves/TestRemoteIpValve.java
+++ b/test/org/apache/catalina/valves/TestRemoteIpValve.java
@@ -1140,10 +1140,8 @@ public class TestRemoteIpValve {
         }
         Assert.assertNotNull(actual);
         Assert.assertEquals(expected.length, actual.length);
-        List<String> e = new ArrayList<>();
-        e.addAll(Arrays.asList(expected));
-        List<String> a = new ArrayList<>();
-        a.addAll(Arrays.asList(actual));
+        List<String> e = new ArrayList<>(Arrays.asList(expected));
+        List<String> a = new ArrayList<>(Arrays.asList(actual));
 
         for (String entry : e) {
             Assert.assertTrue(a.remove(entry));

--- a/test/org/apache/tomcat/util/buf/TestCharsetCache.java
+++ b/test/org/apache/tomcat/util/buf/TestCharsetCache.java
@@ -33,10 +33,8 @@ public class TestCharsetCache {
     @Test
     public void testAllKnownCharsets() {
 
-        Set<String> known = new HashSet<>();
-        known.addAll(Arrays.asList(CharsetCache.LAZY_CHARSETS));
-        Set<String> initial = new HashSet<>();
-        initial.addAll(Arrays.asList(CharsetCache.INITIAL_CHARSETS));
+        Set<String> known = new HashSet<>(Arrays.asList(CharsetCache.LAZY_CHARSETS));
+        Set<String> initial = new HashSet<>(Arrays.asList(CharsetCache.INITIAL_CHARSETS));
 
         List<String> cacheMisses = new ArrayList<>();
 

--- a/test/org/apache/tomcat/util/descriptor/web/TestWebXmlOrdering.java
+++ b/test/org/apache/tomcat/util/descriptor/web/TestWebXmlOrdering.java
@@ -203,8 +203,7 @@ public class TestWebXmlOrdering {
                         for (int m = 0; m < 2; m++) {
                             setUp();
                             runner.init();
-                            ArrayList<WebXml> source = new ArrayList<>();
-                            source.addAll(fragments.values());
+                            ArrayList<WebXml> source = new ArrayList<>(fragments.values());
                             Map<String,WebXml> input =
                                     new LinkedHashMap<>();
 
@@ -255,8 +254,7 @@ public class TestWebXmlOrdering {
     }
 
     private void populatePositions(Set<WebXml> ordered) {
-        List<WebXml> indexed = new ArrayList<>();
-        indexed.addAll(ordered);
+        List<WebXml> indexed = new ArrayList<>(ordered);
 
         posA = indexed.indexOf(a);
         posB = indexed.indexOf(b);

--- a/test/org/apache/tomcat/util/net/openssl/ciphers/TestCipher.java
+++ b/test/org/apache/tomcat/util/net/openssl/ciphers/TestCipher.java
@@ -87,8 +87,7 @@ public class TestCipher {
                     cipher.getProtocol().getOpenSSLName());
         }
 
-        Set<String> unavailableCipherSuites = new HashSet<>();
-        unavailableCipherSuites.addAll(expectedCipherSuites);
+        Set<String> unavailableCipherSuites = new HashSet<>(expectedCipherSuites);
         unavailableCipherSuites.removeAll(availableCipherSuites);
         StringBuilder unavailableList = new StringBuilder("Unavailable cipher suites: ");
         for (String cipher : unavailableCipherSuites) {
@@ -97,8 +96,7 @@ public class TestCipher {
         }
         Assert.assertEquals(unavailableList.toString(), 0,  unavailableCipherSuites.size());
 
-        Set<String> unexpectedCipherSuites = new HashSet<>();
-        unexpectedCipherSuites.addAll(availableCipherSuites);
+        Set<String> unexpectedCipherSuites = new HashSet<>(availableCipherSuites);
         unexpectedCipherSuites.removeAll(expectedCipherSuites);
         StringBuilder unexpectedList = new StringBuilder("Unexpected cipher suites: ");
         for (String cipher : unexpectedCipherSuites) {
@@ -547,9 +545,7 @@ public class TestCipher {
                 "SSL_KRB5_EXPORT_WITH_DES_CBC_40_MD5",
                 "SSL_RSA_EXPORT_WITH_RC2_CBC_40_MD5"));
 
-        Set<String> allNames = new HashSet<>();
-
-        allNames.addAll(sslNames);
+        Set<String> allNames = new HashSet<>(sslNames);
 
         for (String sslName : sslNames) {
             allNames.add("TLS" + sslName.substring(3));


### PR DESCRIPTION
This allows collections like ArrayList and HashSet to initialize their backing arrays
with the correct size.