### PR TITLE
Use empty arrays for Collections.toArray()

### DIFF
--- a/java/jakarta/servlet/jsp/el/ImplicitObjectELResolver.java
+++ b/java/jakarta/servlet/jsp/el/ImplicitObjectELResolver.java
@@ -323,7 +323,7 @@ public class ImplicitObjectELResolver extends ELResolver {
                             while (e.hasMoreElements()) {
                                 list.add(e.nextElement());
                             }
-                            return list.toArray(new String[list.size()]);
+                            return list.toArray(new String[0]);
                         }
                         return null;
                     }

--- a/java/org/apache/catalina/core/ContainerBase.java
+++ b/java/org/apache/catalina/core/ContainerBase.java
@@ -1256,7 +1256,7 @@ public abstract class ContainerBase extends LifecycleMBeanBase
                 names.add(next.getObjectName());
             }
         }
-        return names.toArray(new ObjectName[names.size()]);
+        return names.toArray(new ObjectName[0]);
     }
 
 

--- a/java/org/apache/catalina/core/DefaultInstanceManager.java
+++ b/java/org/apache/catalina/core/DefaultInstanceManager.java
@@ -445,7 +445,7 @@ public class DefaultInstanceManager implements InstanceManager {
                     annotationsArray = ANNOTATIONS_EMPTY;
                 } else {
                     annotationsArray = annotations.toArray(
-                            new AnnotationCacheEntry[annotations.size()]);
+							new AnnotationCacheEntry[0]);
                 }
                 synchronized (annotationCache) {
                     annotationCache.put(clazz, annotationsArray);

--- a/java/org/apache/catalina/core/StandardContext.java
+++ b/java/org/apache/catalina/core/StandardContext.java
@@ -3533,7 +3533,7 @@ public class StandardContext extends ContainerBase
     public String[] findParameters() {
         List<String> parameterNames = new ArrayList<>(parameters.size());
         parameterNames.addAll(parameters.keySet());
-        return parameterNames.toArray(new String[parameterNames.size()]);
+        return parameterNames.toArray(new String[0]);
     }
 
 

--- a/java/org/apache/catalina/core/StandardHost.java
+++ b/java/org/apache/catalina/core/StandardHost.java
@@ -749,7 +749,7 @@ public class StandardHost extends ContainerBase implements Host {
             }
         }
 
-        return result.toArray(new String[result.size()]);
+        return result.toArray(new String[0]);
     }
 
     /**

--- a/java/org/apache/catalina/core/StandardWrapper.java
+++ b/java/org/apache/catalina/core/StandardWrapper.java
@@ -905,7 +905,7 @@ public class StandardWrapper extends ContainerBase
 
         mappingsLock.readLock().lock();
         try {
-            return mappings.toArray(new String[mappings.size()]);
+            return mappings.toArray(new String[0]);
         } finally {
             mappingsLock.readLock().unlock();
         }

--- a/java/org/apache/catalina/ha/tcp/SimpleTcpCluster.java
+++ b/java/org/apache/catalina/ha/tcp/SimpleTcpCluster.java
@@ -262,7 +262,7 @@ public class SimpleTcpCluster extends LifecycleMBeanBase
      */
     @Override
     public Valve[] getValves() {
-        return valves.toArray(new Valve[valves.size()]);
+        return valves.toArray(new Valve[0]);
     }
 
     /**

--- a/java/org/apache/catalina/loader/WebappClassLoaderBase.java
+++ b/java/org/apache/catalina/loader/WebappClassLoaderBase.java
@@ -1445,7 +1445,7 @@ public abstract class WebappClassLoaderBase extends URLClassLoader
         ArrayList<URL> result = new ArrayList<>();
         result.addAll(localRepositories);
         result.addAll(Arrays.asList(super.getURLs()));
-        return result.toArray(new URL[result.size()]);
+        return result.toArray(new URL[0]);
     }
 
 

--- a/java/org/apache/catalina/mbeans/ContainerMBean.java
+++ b/java/org/apache/catalina/mbeans/ContainerMBean.java
@@ -195,7 +195,7 @@ public class ContainerMBean extends BaseCatalinaMBean<ContainerBase> {
             result.add(listener.getClass().getName());
         }
 
-        return result.toArray(new String[result.size()]);
+        return result.toArray(new String[0]);
     }
 
 
@@ -214,6 +214,6 @@ public class ContainerMBean extends BaseCatalinaMBean<ContainerBase> {
             result.add(listener.getClass().getName());
         }
 
-        return result.toArray(new String[result.size()]);
+        return result.toArray(new String[0]);
     }
 }

--- a/java/org/apache/catalina/mbeans/GroupMBean.java
+++ b/java/org/apache/catalina/mbeans/GroupMBean.java
@@ -73,7 +73,7 @@ public class GroupMBean extends BaseModelMBean {
                 throw iae;
             }
         }
-        return results.toArray(new String[results.size()]);
+        return results.toArray(new String[0]);
     }
 
 
@@ -97,7 +97,7 @@ public class GroupMBean extends BaseModelMBean {
                 throw iae;
             }
         }
-        return results.toArray(new String[results.size()]);
+        return results.toArray(new String[0]);
     }
 
 

--- a/java/org/apache/catalina/mbeans/MemoryUserDatabaseMBean.java
+++ b/java/org/apache/catalina/mbeans/MemoryUserDatabaseMBean.java
@@ -87,7 +87,7 @@ public class MemoryUserDatabaseMBean extends BaseModelMBean {
             Group group = groups.next();
             results.add(findGroup(group.getGroupname()));
         }
-        return results.toArray(new String[results.size()]);
+        return results.toArray(new String[0]);
     }
 
 
@@ -102,7 +102,7 @@ public class MemoryUserDatabaseMBean extends BaseModelMBean {
             Role role = roles.next();
             results.add(findRole(role.getRolename()));
         }
-        return results.toArray(new String[results.size()]);
+        return results.toArray(new String[0]);
     }
 
 
@@ -117,7 +117,7 @@ public class MemoryUserDatabaseMBean extends BaseModelMBean {
             User user = users.next();
             results.add(findUser(user.getUsername()));
         }
-        return results.toArray(new String[results.size()]);
+        return results.toArray(new String[0]);
     }
 
 

--- a/java/org/apache/catalina/mbeans/NamingResourcesMBean.java
+++ b/java/org/apache/catalina/mbeans/NamingResourcesMBean.java
@@ -76,7 +76,7 @@ public class NamingResourcesMBean extends BaseModelMBean {
                 throw iae;
             }
         }
-        return results.toArray(new String[results.size()]);
+        return results.toArray(new String[0]);
     }
 
 
@@ -99,7 +99,7 @@ public class NamingResourcesMBean extends BaseModelMBean {
                 throw iae;
             }
         }
-        return results.toArray(new String[results.size()]);
+        return results.toArray(new String[0]);
     }
 
 
@@ -124,7 +124,7 @@ public class NamingResourcesMBean extends BaseModelMBean {
                 throw iae;
             }
         }
-        return results.toArray(new String[results.size()]);
+        return results.toArray(new String[0]);
     }
 
 

--- a/java/org/apache/catalina/mbeans/UserMBean.java
+++ b/java/org/apache/catalina/mbeans/UserMBean.java
@@ -79,7 +79,7 @@ public class UserMBean extends BaseModelMBean {
                 throw iae;
             }
         }
-        return results.toArray(new String[results.size()]);
+        return results.toArray(new String[0]);
     }
 
 
@@ -104,7 +104,7 @@ public class UserMBean extends BaseModelMBean {
                 throw iae;
             }
         }
-        return results.toArray(new String[results.size()]);
+        return results.toArray(new String[0]);
     }
 
 

--- a/java/org/apache/catalina/realm/GenericPrincipal.java
+++ b/java/org/apache/catalina/realm/GenericPrincipal.java
@@ -164,7 +164,7 @@ public class GenericPrincipal implements TomcatPrincipal, Serializable {
         if (roles == null) {
             this.roles = new String[0];
         } else {
-            this.roles = roles.toArray(new String[roles.size()]);
+            this.roles = roles.toArray(new String[0]);
             if (this.roles.length > 1) {
                 Arrays.sort(this.roles);
             }

--- a/java/org/apache/catalina/servlets/CGIServlet.java
+++ b/java/org/apache/catalina/servlets/CGIServlet.java
@@ -1646,7 +1646,7 @@ public final class CGIServlet extends HttpServlet {
             try {
                 rt = Runtime.getRuntime();
                 proc = rt.exec(
-                        cmdAndArgs.toArray(new String[cmdAndArgs.size()]),
+                        cmdAndArgs.toArray(new String[0]),
                         hashToStringArray(env), wd);
 
                 String sContentLength = env.get("CONTENT_LENGTH");

--- a/java/org/apache/catalina/servlets/DefaultServlet.java
+++ b/java/org/apache/catalina/servlets/DefaultServlet.java
@@ -404,7 +404,7 @@ public class DefaultServlet extends HttpServlet {
             // gzip handling is for backwards compatibility with Tomcat 8.x
             ret.add(new CompressionFormat(".gz", "gzip"));
         }
-        return ret.toArray(new CompressionFormat[ret.size()]);
+        return ret.toArray(new CompressionFormat[0]);
     }
 
 

--- a/java/org/apache/catalina/session/FileStore.java
+++ b/java/org/apache/catalina/session/FileStore.java
@@ -191,7 +191,7 @@ public final class FileStore extends StoreBase {
                 list.add (file.substring(0, file.length() - n));
             }
         }
-        return list.toArray(new String[list.size()]);
+        return list.toArray(new String[0]);
     }
 
 

--- a/java/org/apache/catalina/session/JDBCStore.java
+++ b/java/org/apache/catalina/session/JDBCStore.java
@@ -531,7 +531,7 @@ public class JDBCStore extends StoreBase {
                                     tmpkeys.add(rst.getString(1));
                                 }
                             }
-                            keys = tmpkeys.toArray(new String[tmpkeys.size()]);
+                            keys = tmpkeys.toArray(new String[0]);
                             // Break out after the finally block
                             numberOfTries = 0;
                         }

--- a/java/org/apache/catalina/startup/Bootstrap.java
+++ b/java/org/apache/catalina/startup/Bootstrap.java
@@ -590,6 +590,6 @@ public final class Bootstrap {
             result.add(path);
         }
 
-        return result.toArray(new String[result.size()]);
+        return result.toArray(new String[0]);
     }
 }

--- a/java/org/apache/catalina/startup/ClassLoaderFactory.java
+++ b/java/org/apache/catalina/startup/ClassLoaderFactory.java
@@ -121,7 +121,7 @@ public final class ClassLoaderFactory {
         }
 
         // Construct the class loader itself
-        final URL[] array = set.toArray(new URL[set.size()]);
+        final URL[] array = set.toArray(new URL[0]);
         return AccessController.doPrivileged(
                 new PrivilegedAction<URLClassLoader>() {
                     @Override
@@ -218,7 +218,7 @@ public final class ClassLoaderFactory {
         }
 
         // Construct the class loader itself
-        final URL[] array = set.toArray(new URL[set.size()]);
+        final URL[] array = set.toArray(new URL[0]);
         if (log.isDebugEnabled())
             for (int i = 0; i < array.length; i++) {
                 log.debug("  location " + i + " is " + array[i]);

--- a/java/org/apache/catalina/startup/HostConfig.java
+++ b/java/org/apache/catalina/startup/HostConfig.java
@@ -461,7 +461,7 @@ public class HostConfig implements LifecycleListener {
                 filteredList.add(appPath);
             }
         }
-        return filteredList.toArray(new String[filteredList.size()]);
+        return filteredList.toArray(new String[0]);
     }
 
 

--- a/java/org/apache/catalina/storeconfig/StandardContextSF.java
+++ b/java/org/apache/catalina/storeconfig/StandardContextSF.java
@@ -353,7 +353,7 @@ public class StandardContextSF extends StoreFactoryBase {
                 continue;
             resource.add(wresources[i]);
         }
-        return resource.toArray(new String[resource.size()]);
+        return resource.toArray(new String[0]);
     }
 
 }

--- a/java/org/apache/catalina/tribes/ChannelException.java
+++ b/java/org/apache/catalina/tribes/ChannelException.java
@@ -135,7 +135,7 @@ public class ChannelException extends Exception {
      */
     public FaultyMember[] getFaultyMembers() {
         if ( this.faultyMembers==null ) return EMPTY_LIST;
-        return faultyMembers.toArray(new FaultyMember[faultyMembers.size()]);
+        return faultyMembers.toArray(new FaultyMember[0]);
     }
 
     /**

--- a/java/org/apache/catalina/tribes/group/RpcChannel.java
+++ b/java/org/apache/catalina/tribes/group/RpcChannel.java
@@ -274,7 +274,7 @@ public class RpcChannel implements ChannelListener {
         }
 
         public Response[] getResponses() {
-            return responses.toArray(new Response[responses.size()]);
+            return responses.toArray(new Response[0]);
         }
     }
 

--- a/java/org/apache/catalina/tribes/group/interceptors/TcpFailureDetector.java
+++ b/java/org/apache/catalina/tribes/group/interceptors/TcpFailureDetector.java
@@ -277,7 +277,7 @@ public class TcpFailureDetector extends ChannelInterceptorBase implements TcpFai
 
         //check suspect members if they are still alive,
         //if not, simply issue the memberDisappeared message
-        Member[] keys = removeSuspects.keySet().toArray(new Member[removeSuspects.size()]);
+        Member[] keys = removeSuspects.keySet().toArray(new Member[0]);
         for (int i = 0; i < keys.length; i++) {
             Member m = keys[i];
             if (membership.getMember(m) != null && (!memberAlive(m))) {
@@ -302,7 +302,7 @@ public class TcpFailureDetector extends ChannelInterceptorBase implements TcpFai
 
         //check add suspects members if they are alive now,
         //if they are, simply issue the memberAdded message
-        keys = addSuspects.keySet().toArray(new Member[addSuspects.size()]);
+        keys = addSuspects.keySet().toArray(new Member[0]);
         for (int i = 0; i < keys.length; i++) {
             Member m = keys[i];
             if ( membership.getMember(m) == null && (memberAlive(m))) {

--- a/java/org/apache/catalina/tribes/group/interceptors/TwoPhaseCommitInterceptor.java
+++ b/java/org/apache/catalina/tribes/group/interceptors/TwoPhaseCommitInterceptor.java
@@ -111,7 +111,7 @@ public class TwoPhaseCommitInterceptor extends ChannelInterceptorBase {
         try {
             long now = System.currentTimeMillis();
             @SuppressWarnings("unchecked")
-            Map.Entry<UniqueId,MapEntry>[] entries = messages.entrySet().toArray(new Map.Entry[messages.size()]);
+            Map.Entry<UniqueId,MapEntry>[] entries = messages.entrySet().toArray(new Map.Entry[0]);
             for (int i=0; i<entries.length; i++ ) {
                 MapEntry entry = entries[i].getValue();
                 if ( entry.expired(now,expire) ) {

--- a/java/org/apache/catalina/tribes/tipis/AbstractReplicatedMap.java
+++ b/java/org/apache/catalina/tribes/tipis/AbstractReplicatedMap.java
@@ -313,7 +313,7 @@ public abstract class AbstractReplicatedMap<K,V>
         }
         //update our map of members, expire some if we didn't receive a ping back
         synchronized (mapMembers) {
-            Member[] members = mapMembers.keySet().toArray(new Member[mapMembers.size()]);
+            Member[] members = mapMembers.keySet().toArray(new Member[0]);
             long now = System.currentTimeMillis();
             for (Member member : members) {
                 long access = mapMembers.get(member).longValue();
@@ -837,7 +837,7 @@ public abstract class AbstractReplicatedMap<K,V>
                 if ( mbrs[j].equals(set[i]) ) include = false;
             if ( include ) result.add(set[i]);
         }
-        return result.toArray(new Member[result.size()]);
+        return result.toArray(new Member[0]);
     }
 
     @Override

--- a/java/org/apache/catalina/tribes/tipis/ReplicatedMap.java
+++ b/java/org/apache/catalina/tribes/tipis/ReplicatedMap.java
@@ -159,7 +159,7 @@ public class ReplicatedMap<K,V> extends AbstractReplicatedMap<K,V> {
                     faulty.add(faultyMember.getMember());
                 }
             }
-            Member[] realFaultyMembers = faulty.toArray(new Member[faulty.size()]);
+            Member[] realFaultyMembers = faulty.toArray(new Member[0]);
             if (realFaultyMembers.length != 0) {
                 backup = excludeFromSet(realFaultyMembers, backup);
                 if (backup.length == 0) {

--- a/java/org/apache/catalina/tribes/transport/bio/MultipointBioSender.java
+++ b/java/org/apache/catalina/tribes/transport/bio/MultipointBioSender.java
@@ -143,7 +143,7 @@ public class MultipointBioSender extends AbstractSender implements MultiPointSen
     public boolean keepalive() {
         boolean result = false;
         @SuppressWarnings("unchecked")
-        Map.Entry<Member,BioSender>[] entries = bioSenders.entrySet().toArray(new Map.Entry[bioSenders.size()]);
+        Map.Entry<Member,BioSender>[] entries = bioSenders.entrySet().toArray(new Map.Entry[0]);
         for ( int i=0; i<entries.length; i++ ) {
             BioSender sender = entries[i].getValue();
             if ( sender.keepalive() ) {

--- a/java/org/apache/catalina/tribes/util/Arrays.java
+++ b/java/org/apache/catalina/tribes/util/Arrays.java
@@ -159,7 +159,7 @@ public class Arrays {
             if ( ignore!=null && ignore.equals(comp[i]) ) continue;
             if ( local.getMember(comp[i]) == null ) result.add(comp[i]);
         }
-        return result.toArray(new Member[result.size()]);
+        return result.toArray(new Member[0]);
     }
 
     public static Member[] remove(Member[] all, Member remove) {
@@ -170,7 +170,7 @@ public class Arrays {
         List<Member> alist = java.util.Arrays.asList(all);
         ArrayList<Member> list = new ArrayList<>(alist);
         for (int i=0; i<remove.length; i++ ) list.remove(remove[i]);
-        return list.toArray(new Member[list.size()]);
+        return list.toArray(new Member[0]);
     }
 
     public static int indexOf(Member member, Member[] members) {

--- a/java/org/apache/catalina/util/ErrorPageSupport.java
+++ b/java/org/apache/catalina/util/ErrorPageSupport.java
@@ -99,6 +99,6 @@ public class ErrorPageSupport {
         Set<ErrorPage> errorPages = new HashSet<>();
         errorPages.addAll(exceptionPages.values());
         errorPages.addAll(statusPages.values());
-        return errorPages.toArray(new ErrorPage[errorPages.size()]);
+        return errorPages.toArray(new ErrorPage[0]);
     }
 }

--- a/java/org/apache/catalina/valves/StuckThreadDetectionValve.java
+++ b/java/org/apache/catalina/valves/StuckThreadDetectionValve.java
@@ -271,7 +271,7 @@ public class StuckThreadDetectionValve extends ValveBase {
                 nameList.add(monitoredThread.getThread().getName());
             }
         }
-        return nameList.toArray(new String[nameList.size()]);
+        return nameList.toArray(new String[0]);
     }
 
     public long getInterruptedThreadsCount() {

--- a/java/org/apache/catalina/webresources/AbstractArchiveResourceSet.java
+++ b/java/org/apache/catalina/webresources/AbstractArchiveResourceSet.java
@@ -109,7 +109,7 @@ public abstract class AbstractArchiveResourceSet extends AbstractResourceSet {
                 }
             }
         }
-        return result.toArray(new String[result.size()]);
+        return result.toArray(new String[0]);
     }
 
     @Override

--- a/java/org/apache/catalina/webresources/StandardRoot.java
+++ b/java/org/apache/catalina/webresources/StandardRoot.java
@@ -134,7 +134,7 @@ public class StandardRoot extends LifecycleMBeanBase implements WebResourceRoot 
                 }
             }
         }
-        return result.toArray(new String[result.size()]);
+        return result.toArray(new String[0]);
     }
 
 
@@ -337,7 +337,7 @@ public class StandardRoot extends LifecycleMBeanBase implements WebResourceRoot 
             result.add(main.getResource(path));
         }
 
-        return result.toArray(new WebResource[result.size()]);
+        return result.toArray(new WebResource[0]);
     }
 
     @Override
@@ -438,7 +438,7 @@ public class StandardRoot extends LifecycleMBeanBase implements WebResourceRoot 
 
     @Override
     public WebResourceSet[] getPreResources() {
-        return preResources.toArray(new WebResourceSet[preResources.size()]);
+        return preResources.toArray(new WebResourceSet[0]);
     }
 
     @Override
@@ -449,7 +449,7 @@ public class StandardRoot extends LifecycleMBeanBase implements WebResourceRoot 
 
     @Override
     public WebResourceSet[] getJarResources() {
-        return jarResources.toArray(new WebResourceSet[jarResources.size()]);
+        return jarResources.toArray(new WebResourceSet[0]);
     }
 
     @Override
@@ -460,11 +460,11 @@ public class StandardRoot extends LifecycleMBeanBase implements WebResourceRoot 
 
     @Override
     public WebResourceSet[] getPostResources() {
-        return postResources.toArray(new WebResourceSet[postResources.size()]);
+        return postResources.toArray(new WebResourceSet[0]);
     }
 
     protected WebResourceSet[] getClassResources() {
-        return classResources.toArray(new WebResourceSet[classResources.size()]);
+        return classResources.toArray(new WebResourceSet[0]);
     }
 
     protected void addClassResources(WebResourceSet webResourceSet) {

--- a/java/org/apache/coyote/CompressionConfig.java
+++ b/java/org/apache/coyote/CompressionConfig.java
@@ -160,7 +160,7 @@ public class CompressionConfig {
                 values.add(token);
             }
         }
-        result = values.toArray(new String[values.size()]);
+        result = values.toArray(new String[0]);
         compressibleMimeTypes = result;
         return result;
     }

--- a/java/org/apache/el/parser/AstMethodParameters.java
+++ b/java/org/apache/el/parser/AstMethodParameters.java
@@ -33,7 +33,7 @@ public final class AstMethodParameters extends SimpleNode {
         for (int i = 0; i < this.jjtGetNumChildren(); i++) {
             params.add(this.jjtGetChild(i).getValue(ctx));
         }
-        return params.toArray(new Object[params.size()]);
+        return params.toArray(new Object[0]);
     }
 
     @Override

--- a/java/org/apache/el/stream/Stream.java
+++ b/java/org/apache/el/stream/Stream.java
@@ -260,7 +260,7 @@ public class Stream {
         while (iterator.hasNext()) {
             result.add(iterator.next());
         }
-        return result.toArray(new Object[result.size()]);
+        return result.toArray(new Object[0]);
     }
 
 

--- a/java/org/apache/jasper/compiler/JavacErrorDetail.java
+++ b/java/org/apache/jasper/compiler/JavacErrorDetail.java
@@ -226,6 +226,6 @@ public class JavacErrorDetail {
             lines.add(line);
         }
 
-        return lines.toArray( new String[lines.size()] );
+        return lines.toArray(new String[0]);
     }
 }

--- a/java/org/apache/jasper/compiler/TagLibraryInfoImpl.java
+++ b/java/org/apache/jasper/compiler/TagLibraryInfoImpl.java
@@ -221,9 +221,9 @@ class TagLibraryInfoImpl extends TagLibraryInfo implements TagConstants {
                 err.jspError("jsp.error.tld.mandatory.element.missing", "jsp-version", uri);
             }
 
-            this.tags = tagInfos.toArray(new TagInfo[tagInfos.size()]);
-            this.tagFiles = tagFileInfos.toArray(new TagFileInfo[tagFileInfos.size()]);
-            this.functions = functionInfos.toArray(new FunctionInfo[functionInfos.size()]);
+            this.tags = tagInfos.toArray(new TagInfo[0]);
+            this.tagFiles = tagFileInfos.toArray(new TagFileInfo[0]);
+            this.functions = functionInfos.toArray(new FunctionInfo[0]);
         } catch (IOException ioe) {
             throw new JasperException(ioe);
         }
@@ -232,7 +232,7 @@ class TagLibraryInfoImpl extends TagLibraryInfo implements TagConstants {
     @Override
     public TagLibraryInfo[] getTagLibraryInfos() {
         Collection<TagLibraryInfo> coll = pi.getTaglibs();
-        return coll.toArray(new TagLibraryInfo[coll.size()]);
+        return coll.toArray(new TagLibraryInfo[0]);
     }
 
     /*
@@ -305,11 +305,11 @@ class TagLibraryInfoImpl extends TagLibraryInfo implements TagConstants {
                 tagXml.getInfo(),
                 this,
                 tei,
-                attributeInfos.toArray(new TagAttributeInfo[attributeInfos.size()]),
+                attributeInfos.toArray(new TagAttributeInfo[0]),
                 tagXml.getDisplayName(),
                 tagXml.getSmallIcon(),
                 tagXml.getLargeIcon(),
-                variableInfos.toArray(new TagVariableInfo[variableInfos.size()]),
+                variableInfos.toArray(new TagVariableInfo[0]),
                 tagXml.hasDynamicAttributes());
     }
 

--- a/java/org/apache/jasper/compiler/Validator.java
+++ b/java/org/apache/jasper/compiler/Validator.java
@@ -1689,7 +1689,7 @@ class Validator {
                 }
                 start = p + 1;
             }
-            return params.toArray(new String[params.size()]);
+            return params.toArray(new String[0]);
         }
 
         private FunctionMapper getFunctionMapper(ELNode.Nodes el)

--- a/java/org/apache/naming/factory/webservices/ServiceRefFactory.java
+++ b/java/org/apache/naming/factory/webservices/ServiceRefFactory.java
@@ -290,7 +290,7 @@ public class ServiceRefFactory implements ObjectFactory {
 
                     // Set the handlers informations
                     handlerInfo.setHandlerClass(handlerClass);
-                    handlerInfo.setHeaders(headers.toArray(new QName[headers.size()]));
+                    handlerInfo.setHeaders(headers.toArray(new QName[0]));
                     handlerInfo.setHandlerConfig(config);
 
                     if (!portNames.isEmpty()) {

--- a/java/org/apache/tomcat/dbcp/dbcp2/BasicDataSource.java
+++ b/java/org/apache/tomcat/dbcp/dbcp2/BasicDataSource.java
@@ -803,7 +803,7 @@ public class BasicDataSource implements DataSource, BasicDataSourceMXBean, MBean
     @Override
     public String[] getConnectionInitSqlsAsArray() {
         final Collection<String> result = getConnectionInitSqls();
-        return result.toArray(new String[result.size()]);
+        return result.toArray(new String[0]);
     }
 
     protected GenericObjectPool<PoolableConnection> getConnectionPool() {
@@ -899,7 +899,7 @@ public class BasicDataSource implements DataSource, BasicDataSourceMXBean, MBean
     @Override
     public String[] getDisconnectionSqlCodesAsArray() {
         final Collection<String> result = getDisconnectionSqlCodes();
-        return result.toArray(new String[result.size()]);
+        return result.toArray(new String[0]);
     }
 
     /**

--- a/java/org/apache/tomcat/dbcp/dbcp2/PoolableCallableStatement.java
+++ b/java/org/apache/tomcat/dbcp/dbcp2/PoolableCallableStatement.java
@@ -123,7 +123,7 @@ public class PoolableCallableStatement extends DelegatingCallableStatement {
         final List<AbandonedTrace> resultSetList = getTrace();
         if (resultSetList != null) {
             final List<Exception> thrownList = new ArrayList<>();
-            final ResultSet[] resultSets = resultSetList.toArray(new ResultSet[resultSetList.size()]);
+            final ResultSet[] resultSets = resultSetList.toArray(new ResultSet[0]);
             for (final ResultSet resultSet : resultSets) {
                 if (resultSet != null) {
                     try {

--- a/java/org/apache/tomcat/dbcp/dbcp2/PoolablePreparedStatement.java
+++ b/java/org/apache/tomcat/dbcp/dbcp2/PoolablePreparedStatement.java
@@ -138,7 +138,7 @@ public class PoolablePreparedStatement<K> extends DelegatingPreparedStatement {
         final List<AbandonedTrace> resultSetList = getTrace();
         if (resultSetList != null) {
             final List<Exception> thrownList = new ArrayList<>();
-            final ResultSet[] resultSets = resultSetList.toArray(new ResultSet[resultSetList.size()]);
+            final ResultSet[] resultSets = resultSetList.toArray(new ResultSet[0]);
             for (final ResultSet resultSet : resultSets) {
                 if (resultSet != null) {
                     try {

--- a/java/org/apache/tomcat/dbcp/dbcp2/PoolingDriver.java
+++ b/java/org/apache/tomcat/dbcp/dbcp2/PoolingDriver.java
@@ -135,7 +135,7 @@ public class PoolingDriver implements Driver {
      */
     public synchronized String[] getPoolNames() {
         final Set<String> names = pools.keySet();
-        return names.toArray(new String[names.size()]);
+        return names.toArray(new String[0]);
     }
 
     @Override

--- a/java/org/apache/tomcat/util/descriptor/web/FilterMap.java
+++ b/java/org/apache/tomcat/util/descriptor/web/FilterMap.java
@@ -193,7 +193,7 @@ public class FilterMap extends XmlEncodingBase implements Serializable {
         if ((dispatcherMapping & ASYNC) != 0) {
             result.add(DispatcherType.ASYNC.name());
         }
-        return result.toArray(new String[result.size()]);
+        return result.toArray(new String[0]);
     }
 
     // --------------------------------------------------------- Public Methods

--- a/java/org/apache/tomcat/util/descriptor/web/SecurityConstraint.java
+++ b/java/org/apache/tomcat/util/descriptor/web/SecurityConstraint.java
@@ -574,7 +574,7 @@ public class SecurityConstraint extends XmlEncodingBase implements Serializable 
 
         }
 
-        return result.toArray(new SecurityConstraint[result.size()]);
+        return result.toArray(new SecurityConstraint[0]);
     }
 
     private static SecurityConstraint createConstraint(
@@ -733,7 +733,7 @@ public class SecurityConstraint extends XmlEncodingBase implements Serializable 
                     newConstraints, log);
         }
 
-        return newConstraints.toArray(new SecurityConstraint[newConstraints.size()]);
+        return newConstraints.toArray(new SecurityConstraint[0]);
     }
 
 

--- a/java/org/apache/tomcat/util/http/Parameters.java
+++ b/java/org/apache/tomcat/util/http/Parameters.java
@@ -146,7 +146,7 @@ public final class Parameters {
         if (values == null) {
             return null;
         }
-        return values.toArray(new String[values.size()]);
+        return values.toArray(new String[0]);
     }
 
     public Enumeration<String> getParameterNames() {

--- a/java/org/apache/tomcat/util/modeler/BaseAttributeFilter.java
+++ b/java/org/apache/tomcat/util/modeler/BaseAttributeFilter.java
@@ -106,7 +106,7 @@ public class BaseAttributeFilter implements NotificationFilter {
     public String[] getNames() {
 
         synchronized (names) {
-            return names.toArray(new String[names.size()]);
+            return names.toArray(new String[0]);
         }
 
     }

--- a/java/org/apache/tomcat/util/net/AbstractJsseEndpoint.java
+++ b/java/org/apache/tomcat/util/net/AbstractJsseEndpoint.java
@@ -134,7 +134,7 @@ public abstract class AbstractJsseEndpoint<S,U> extends AbstractEndpoint<S,U> {
             commonProtocols.addAll(negotiableProtocols);
             commonProtocols.retainAll(clientRequestedApplicationProtocols);
             if (commonProtocols.size() > 0) {
-                String[] commonProtocolsArray = commonProtocols.toArray(new String[commonProtocols.size()]);
+                String[] commonProtocolsArray = commonProtocols.toArray(new String[0]);
                 JreCompat.getInstance().setApplicationProtocols(sslParameters, commonProtocolsArray);
             }
         }

--- a/java/org/apache/tomcat/util/net/SSLUtilBase.java
+++ b/java/org/apache/tomcat/util/net/SSLUtilBase.java
@@ -110,7 +110,7 @@ public abstract class SSLUtilBase implements SSLUtil {
         if (enabledProtocols.contains("SSLv3")) {
             log.warn(sm.getString("jsse.ssl3"));
         }
-        this.enabledProtocols = enabledProtocols.toArray(new String[enabledProtocols.size()]);
+        this.enabledProtocols = enabledProtocols.toArray(new String[0]);
 
         if (enabledProtocols.contains(Constants.SSL_PROTO_TLSv1_3) &&
                 sslHostConfig.getCertificateVerification() == CertificateVerification.OPTIONAL &&
@@ -123,7 +123,7 @@ public abstract class SSLUtilBase implements SSLUtil {
         Set<String> implementedCiphers = getImplementedCiphers();
         List<String> enabledCiphers =
                 getEnabled("ciphers", getLog(), false, configuredCiphers, implementedCiphers);
-        this.enabledCiphers = enabledCiphers.toArray(new String[enabledCiphers.size()]);
+        this.enabledCiphers = enabledCiphers.toArray(new String[0]);
     }
 
 
@@ -322,7 +322,7 @@ public abstract class SSLUtilBase implements SSLUtil {
             ksUsed = KeyStore.getInstance("JKS");
             ksUsed.load(null,  null);
             ksUsed.setKeyEntry(keyAlias, privateKeyFile.getPrivateKey(), keyPass.toCharArray(),
-                    chain.toArray(new Certificate[chain.size()]));
+                    chain.toArray(new Certificate[0]));
         } else {
             if (keyAlias != null && !ks.isKeyEntry(keyAlias)) {
                 throw new IOException(sm.getString("jsse.alias_no_key_entry", keyAlias));

--- a/java/org/apache/tomcat/util/net/WriteBuffer.java
+++ b/java/org/apache/tomcat/util/net/WriteBuffer.java
@@ -97,7 +97,7 @@ public class WriteBuffer {
             result.add(buffer.getBuf());
         }
         buffers.clear();
-        return result.toArray(new ByteBuffer[result.size()]);
+        return result.toArray(new ByteBuffer[0]);
     }
 
 

--- a/java/org/apache/tomcat/util/net/jsse/JSSESSLContext.java
+++ b/java/org/apache/tomcat/util/net/jsse/JSSESSLContext.java
@@ -105,6 +105,6 @@ class JSSESSLContext implements SSLContext {
                 }
             }
         }
-        return certs.toArray(new X509Certificate[certs.size()]);
+        return certs.toArray(new X509Certificate[0]);
     }
 }

--- a/java/org/apache/tomcat/util/net/openssl/OpenSSLContext.java
+++ b/java/org/apache/tomcat/util/net/openssl/OpenSSLContext.java
@@ -354,7 +354,7 @@ public class OpenSSLContext implements org.apache.tomcat.util.net.SSLContext {
                     enabled.add(Constants.SSL_PROTO_SSLv3);
                 }
                 sslHostConfig.setEnabledProtocols(
-                        enabled.toArray(new String[enabled.size()]));
+                        enabled.toArray(new String[0]));
                 // Reconfigure the enabled ciphers
                 sslHostConfig.setEnabledCiphers(SSLContext.getCiphers(ctx));
             }

--- a/java/org/apache/tomcat/util/net/openssl/OpenSSLEngine.java
+++ b/java/org/apache/tomcat/util/net/openssl/OpenSSLEngine.java
@@ -703,7 +703,7 @@ public final class OpenSSLEngine extends SSLEngine implements SSLUtil.ProtocolIn
     @Override
     public String[] getSupportedCipherSuites() {
         Set<String> availableCipherSuites = AVAILABLE_CIPHER_SUITES;
-        return availableCipherSuites.toArray(new String[availableCipherSuites.size()]);
+        return availableCipherSuites.toArray(new String[0]);
     }
 
     @Override
@@ -768,7 +768,7 @@ public final class OpenSSLEngine extends SSLEngine implements SSLUtil.ProtocolIn
 
     @Override
     public String[] getSupportedProtocols() {
-        return IMPLEMENTED_PROTOCOLS_SET.toArray(new String[IMPLEMENTED_PROTOCOLS_SET.size()]);
+        return IMPLEMENTED_PROTOCOLS_SET.toArray(new String[0]);
     }
 
     @Override
@@ -1237,7 +1237,7 @@ public final class OpenSSLEngine extends SSLEngine implements SSLUtil.ProtocolIn
             if (values == null || values.isEmpty()) {
                 return new String[0];
             }
-            return values.keySet().toArray(new String[values.size()]);
+            return values.keySet().toArray(new String[0]);
         }
 
         private void notifyUnbound(Object value, String name) {

--- a/test/org/apache/catalina/valves/TestLoadBalancerDrainingValve.java
+++ b/test/org/apache/catalina/valves/TestLoadBalancerDrainingValve.java
@@ -223,7 +223,7 @@ public class TestLoadBalancerDrainingValve {
 
             EasyMock.expect(request.getRequestedSessionId()).andStubReturn(sessionId);
             EasyMock.expect(request.getRequestURI()).andStubReturn(requestURI);
-            EasyMock.expect(request.getCookies()).andStubReturn(cookies.toArray(new Cookie[cookies.size()]));
+            EasyMock.expect(request.getCookies()).andStubReturn(cookies.toArray(new Cookie[0]));
             EasyMock.expect(request.getContext()).andStubReturn(ctx);
             EasyMock.expect(ctx.getSessionCookieName()).andStubReturn(sessionCookieName);
             EasyMock.expect(servletContext.getSessionCookieConfig()).andStubReturn(cookieConfig);

--- a/test/org/apache/tomcat/unittest/TesterContext.java
+++ b/test/org/apache/tomcat/unittest/TesterContext.java
@@ -85,7 +85,7 @@ public class TesterContext implements Context {
 
     @Override
     public String[] findSecurityRoles() {
-        return securityRoles.toArray(new String[securityRoles.size()]);
+        return securityRoles.toArray(new String[0]);
     }
 
     @Override
@@ -102,7 +102,7 @@ public class TesterContext implements Context {
     @Override
     public SecurityConstraint[] findConstraints() {
         return securityConstraints.toArray(
-                new SecurityConstraint[securityConstraints.size()]);
+				new SecurityConstraint[0]);
     }
 
     @Override

--- a/test/org/apache/tomcat/util/net/openssl/ciphers/TesterOpenSSL.java
+++ b/test/org/apache/tomcat/util/net/openssl/ciphers/TesterOpenSSL.java
@@ -385,7 +385,7 @@ public class TesterOpenSSL {
             args.add(specification);
         }
 
-        String stdout = executeOpenSSLCommand(args.toArray(new String[args.size()]));
+        String stdout = executeOpenSSLCommand(args.toArray(new String[0]));
 
         if (stdout.length() == 0) {
             return stdout;
@@ -461,7 +461,7 @@ public class TesterOpenSSL {
             cmd.add(arg);
         }
 
-        ProcessBuilder pb = new ProcessBuilder(cmd.toArray(new String[cmd.size()]));
+        ProcessBuilder pb = new ProcessBuilder(cmd.toArray(new String[0]));
 
         if (openSSLLibPath != null) {
             Map<String,String> env = pb.environment();

--- a/webapps/examples/WEB-INF/classes/compressionFilters/CompressionFilter.java
+++ b/webapps/examples/WEB-INF/classes/compressionFilters/CompressionFilter.java
@@ -118,7 +118,7 @@ public class CompressionFilter extends GenericFilter {
 
             if (values.size() > 0) {
                 compressionMimeTypes = values.toArray(
-                        new String[values.size()]);
+                        new String[0]);
             } else {
                 compressionMimeTypes = null;
             }


### PR DESCRIPTION
There are two styles to convert a collection to an array:
either using a pre-sized array (like `c.toArray(new String[c.size()])`)
or using an empty array (like `c.toArray(new String[0])`).

In older Java versions using pre-sized array was recommended,
as the reflection call which is necessary to create an array of proper size was quite slow.
However since late updates of OpenJDK 6 this call was intrinsified,
making the performance of the empty array version the same and sometimes even better,
compared to the pre-sized version.

See also: https://shipilev.net/blog/2016/arrays-wisdom-ancients/