### PR TITLE
Filter invalid HTTP 2.0 headers from response

### DIFF
--- a/java/org/apache/coyote/LocalStrings.properties
+++ b/java/org/apache/coyote/LocalStrings.properties
@@ -58,6 +58,7 @@ request.nullReadListener=The listener passed to setReadListener() may not be nul
 request.readListenerSet=The non-blocking read listener has already been set
 
 response.encoding.invalid=The encoding [{0}] is not recognised by the JRE
+response.ignoringInvalidHeader=Ignoring invalid header [{0}: {1}]
 response.noTrailers.notSupported=A trailer fields supplier may not be set for this response. Either the underlying protocol does not support trailer fields or the protocol requires that the supplier is set before the response is committed
 response.notAsync=It is only valid to switch to non-blocking IO within async processing or HTTP upgrade processing
 response.notNonBlocking=It is invalid to call isReady() when the response has not been put into non-blocking mode

--- a/java/org/apache/coyote/LocalStrings_fr.properties
+++ b/java/org/apache/coyote/LocalStrings_fr.properties
@@ -57,6 +57,7 @@ request.nullReadListener=L'écouteur passé à setReadListener() ne peut pas êt
 request.readListenerSet=L'écouteur des lectures non bloquantes a déjà été défini
 
 response.encoding.invalid=L''encodage [{0}] n''est pas reconnu par le JRE
+response.ignoringInvalidHeader=En-tête invalide ignoré [{0}: {1}]
 response.noTrailers.notSupported=Un fournisseur d'en-tête de fin ne peut pas être mis sur cette réponse, soit le protocole ne supporte pas ces en-têtes, soit le protocole requiert que le fournisseur soit fourni avant le début de l'envoi de la réponse
 response.notAsync=Il n'est possible de passer en mode d'entrée-sorties non bloquantes que lors de traitements asynchrones ou après mise à niveau depuis HTTP
 response.notNonBlocking=Il n'est pas permis d'appeler isReady() quand la réponse n'a pas été mise en mode non-bloquant

--- a/test/org/apache/coyote/http2/TestInvalidHeader.java
+++ b/test/org/apache/coyote/http2/TestInvalidHeader.java
@@ -1,0 +1,117 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.coyote.http2;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.apache.catalina.Context;
+import org.apache.catalina.startup.Tomcat;
+
+public class TestInvalidHeader extends Http2TestBase {
+
+    /*
+     * @see org.apache.coyote.Response#checkSpecialHeaders()
+     */
+//    @Test
+//    public void testInvalidHeader() throws Exception {
+//
+//        enableHttp2();
+//        configureAndStartWebApplication();
+//
+//        openClientConnection();
+//        doHttpUpgrade();
+//        sendClientPreface();
+//        validateHttp2InitialResponse();
+//
+//        byte[] frameHeader = new byte[9];
+//        ByteBuffer headersPayload = ByteBuffer.allocate(128);
+//        List<Header> headers = new ArrayList<>(3);
+//        headers.add(new Header(":method", "GET"));
+//        headers.add(new Header(":scheme", "http"));
+//        headers.add(new Header(":path", "/simple"));
+//        headers.add(new Header(":authority", "localhost:" + getPort()));
+//        headers.add(new Header("Connection", "keep-alive"));
+//
+//        buildGetRequest(frameHeader, headersPayload, null, headers, 3);
+//
+//        writeFrame(frameHeader, headersPayload);
+//
+//        readSimpleGetResponse();
+//
+//        Assert.assertEquals(getSimpleResponseTrace(3), output.getTrace());
+//    }
+
+    protected static class FaultyServlet extends SimpleServlet
+    {
+
+        private static final long serialVersionUID = 1L;
+
+        public static final int CONTENT_LENGTH = 8192;
+
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+            throws ServletException, IOException
+        {
+            // Add faulty header
+            resp.addHeader("Connection", "keep-alive");
+            super.doGet(req, resp);
+        }
+    }
+
+
+    @Test
+    public void testInvalidHeader() throws Exception {
+
+        enableHttp2();
+
+        Tomcat tomcat = getTomcatInstance();
+
+        Context ctxt = tomcat.addContext("", null);
+        Tomcat.addServlet(ctxt, "simple", new FaultyServlet());
+        ctxt.addServletMappingDecoded("/simple", "simple");
+
+        tomcat.start();
+
+        openClientConnection();
+        doHttpUpgrade();
+        sendClientPreface();
+        validateHttp2InitialResponse();
+
+        byte[] frameHeader = new byte[9];
+        ByteBuffer headersPayload = ByteBuffer.allocate(128);
+        buildGetRequest(frameHeader, headersPayload, null, 3, "/simple");
+
+        writeFrame(frameHeader, headersPayload);
+
+        readSimpleGetResponse();
+
+        Assert.assertEquals(getSimpleResponseTrace(3), output.getTrace());
+    }
+
+}

--- a/test/org/apache/coyote/http2/TestInvalidHeader.java
+++ b/test/org/apache/coyote/http2/TestInvalidHeader.java
@@ -38,35 +38,6 @@ public class TestInvalidHeader extends Http2TestBase {
     /*
      * @see org.apache.coyote.Response#checkSpecialHeaders()
      */
-//    @Test
-//    public void testInvalidHeader() throws Exception {
-//
-//        enableHttp2();
-//        configureAndStartWebApplication();
-//
-//        openClientConnection();
-//        doHttpUpgrade();
-//        sendClientPreface();
-//        validateHttp2InitialResponse();
-//
-//        byte[] frameHeader = new byte[9];
-//        ByteBuffer headersPayload = ByteBuffer.allocate(128);
-//        List<Header> headers = new ArrayList<>(3);
-//        headers.add(new Header(":method", "GET"));
-//        headers.add(new Header(":scheme", "http"));
-//        headers.add(new Header(":path", "/simple"));
-//        headers.add(new Header(":authority", "localhost:" + getPort()));
-//        headers.add(new Header("Connection", "keep-alive"));
-//
-//        buildGetRequest(frameHeader, headersPayload, null, headers, 3);
-//
-//        writeFrame(frameHeader, headersPayload);
-//
-//        readSimpleGetResponse();
-//
-//        Assert.assertEquals(getSimpleResponseTrace(3), output.getTrace());
-//    }
-
     protected static class FaultyServlet extends SimpleServlet
     {
 


### PR DESCRIPTION
Connection headers like `Connection: keep-alive` are invalid in HTTP/2.0, and some clients (like Safari or curl) are very touchy about it.

When an application component adds the typical HTTP/1.x "Connection: keep-alive" header to the response, despite the component's good intention, the header is faulty in HTTP/2.0 and SHOULD always be filtered.

The current implementation emits a warning in the logs only once per instance.

