### PR TITLE
Improve IDE support for IntelliJ IDEA

### DIFF
--- a/res/ide-support/idea/ant.xml
+++ b/res/ide-support/idea/ant.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AntConfiguration">
+    <buildFile url="file://$PROJECT_DIR$/build.xml" />
+  </component>
+</project>

--- a/res/ide-support/idea/codeStyles/Project.xml
+++ b/res/ide-support/idea/codeStyles/Project.xml
@@ -1,0 +1,13 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <codeStyleSettings language="JAVA">
+      <option name="RIGHT_MARGIN" value="100" />
+      <option name="WRAP_ON_TYPING" value="0" />
+    </codeStyleSettings>
+    <codeStyleSettings language="XML">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/res/ide-support/idea/codeStyles/codeStyleConfig.xml
+++ b/res/ide-support/idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/res/ide-support/idea/copyright/Tomcat.xml
+++ b/res/ide-support/idea/copyright/Tomcat.xml
@@ -1,0 +1,6 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="notice" value="Licensed to the Apache Software Foundation (ASF) under one or more&#10;contributor license agreements.  See the NOTICE file distributed with&#10;this work for additional information regarding copyright ownership.&#10;The ASF licenses this file to You under the Apache License, Version 2.0&#10;(the &quot;License&quot;); you may not use this file except in compliance with&#10;the License.  You may obtain a copy of the License at&#10;&#10;     http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License." />
+    <option name="myName" value="Tomcat" />
+  </copyright>
+</component>

--- a/res/ide-support/idea/copyright/profiles_settings.xml
+++ b/res/ide-support/idea/copyright/profiles_settings.xml
@@ -1,0 +1,3 @@
+<component name="CopyrightManager">
+  <settings default="Tomcat" />
+</component>

--- a/res/ide-support/idea/externalDependencies.xml
+++ b/res/ide-support/idea/externalDependencies.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalDependencies">
+    <plugin id="AntSupport" />
+    <plugin id="Git4Idea" />
+    <plugin id="HtmlTools" />
+    <plugin id="Tomcat" />
+    <plugin id="com.intellij.java" />
+    <plugin id="com.intellij.javaee" />
+    <plugin id="com.intellij.jsp" />
+  </component>
+</project>

--- a/res/ide-support/idea/inspectionProfiles/Project_Default.xml
+++ b/res/ide-support/idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,11 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="AutoBoxing" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoreAddedToCollection" value="false" />
+    </inspection_tool>
+    <inspection_tool class="AutoUnboxing" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="UnnecessaryBoxing" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryUnboxing" enabled="false" level="WARNING" enabled_by_default="false" />
+  </profile>
+</component>


### PR DESCRIPTION
This change makes IntelliJ IDEA ~and other IDE's~ aware of some of the coding standards of the Tomcat project.

~The .editorconfig file (and the rules therein) will be automatically used by the Editors listed here: https://editorconfig.org/#download~

The files in the .idea folder are for IntellIJ IDEA only. I deliberately put them directly there (and not in `res/ide-support/idea`) so no manual setup is neccessary for them to take effect.