### PR TITLE
fixed-chinese-encoding

### DIFF
--- a/java/org/apache/tomcat/util/res/StringManager.java
+++ b/java/org/apache/tomcat/util/res/StringManager.java
@@ -146,7 +146,13 @@ public class StringManager {
             //      a null check.
             str = null;
         }
-
+        // change the encoing from "ISO-8859-1" to "UTF-8"
+        // Therefore, there will be no garbled characters when using Chinese
+        try {
+            str = new String(str.getBytes("ISO-8859-1"),"UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
         return str;
     }
 


### PR DESCRIPTION
When I use Chinese, I find that the log printed by the console is garbled，like this :
26-May-2020 09:42:32.374 严重 [main] org.apache.catalina.startup.Catalina.initDirs å¨[catalina-home1/temp]æ¾ä¸å°æå®çä¸´æ¶æä»¶å¤¹
26-May-2020 09:42:33.259 信息 [main] org.apache.catalina.startup.VersionLoggerListener.log Server.æå¡å¨çæ¬: Apache Tomcat/@VERSION@
26-May-2020 09:42:33.259 信息 [main] org.apache.catalina.startup.VersionLoggerListener.log æå¡å¨æå»º:        @VERSION_BUILT@
26-May-2020 09:42:33.259 信息 [main] org.apache.catalina.startup.VersionLoggerListener.log æå¡å¨çæ¬å·(:     @VERSION_NUMBER@
26-May-2020 09:42:33.260 信息 [main] org.apache.catalina.startup.VersionLoggerListener.log æä½ç³»ç»åç§°:      Mac OS X

So I changed the encoding so that there is no problem.
