### PR TITLE
Allow recursive substitution of properties.

### DIFF
--- a/java/org/apache/tomcat/util/IntrospectionUtils.java
+++ b/java/org/apache/tomcat/util/IntrospectionUtils.java
@@ -285,8 +285,17 @@ public final class IntrospectionUtils {
     public static String replaceProperties(String value,
             Hashtable<Object,Object> staticProp, PropertySource dynamicProp[],
             ClassLoader classLoader) {
+            return replaceProperties(value, staticProp, dynamicProp, classLoader, 0);
+    }
 
-        if (value.indexOf('$') < 0) {
+    private static String replaceProperties(String value,
+            Hashtable<Object,Object> staticProp, PropertySource dynamicProp[],
+            ClassLoader classLoader, int iterationCount) {
+        if (value.indexOf("${") < 0) {
+            return value;
+        }
+        if (iterationCount >=20) {
+            log.warn("System property failed to update and remains [" + value + "]");
             return value;
         }
         StringBuilder sb = new StringBuilder();
@@ -332,7 +341,15 @@ public final class IntrospectionUtils {
         }
         if (prev < value.length())
             sb.append(value.substring(prev));
-        return sb.toString();
+        String newval = sb.toString();
+        if (newval.indexOf("${") < 0) {
+            return newval;
+        }
+        if (newval.equals(value))
+            return value;
+        if (log.isDebugEnabled())
+            log.debug("IntrospectionUtils.replaceProperties iter on: " + newval);
+        return replaceProperties(newval, staticProp, dynamicProp, classLoader, iterationCount+1);
     }
 
     private static String getProperty(String name, Hashtable<Object, Object> staticProp,

--- a/test/org/apache/tomcat/util/TestIntrospectionUtils.java
+++ b/test/org/apache/tomcat/util/TestIntrospectionUtils.java
@@ -143,5 +143,17 @@ public class TestIntrospectionUtils {
 
         Assert.assertEquals("abc${normal}xyz", IntrospectionUtils.replaceProperties(
                 "abc${normal}xyz", properties, null, null));
+
+        properties.setProperty("my.ajp.port", "8009");
+        properties.setProperty("tomcat.ajp.port", "${my.ajp.port}");
+        Assert.assertEquals("8009", IntrospectionUtils.replaceProperties(
+                "${tomcat.ajp.port}", properties, null, null));
+
+    }
+    @Test
+    public void testReplacePropertiesRecursively() {
+        Properties properties = new Properties();
+        properties.setProperty("replaceMe", "something ${replaceMe}");
+        IntrospectionUtils.replaceProperties("${replaceMe}", properties, null, null);
     }
 }


### PR DESCRIPTION
Allow properties substitutions like:
my.http.port=8081
tomcat.http.port=${my.http.port}

It is related to https://issues.redhat.com/browse/JWS-973 and https://bz.apache.org/bugzilla/show_bug.cgi?id=62160