### PR TITLE
support schemes "wss" and "ws" in WsHandshakeRequest.buildRequestUri()

### DIFF
--- a/java/org/apache/tomcat/websocket/server/WsHandshakeRequest.java
+++ b/java/org/apache/tomcat/websocket/server/WsHandshakeRequest.java
@@ -156,6 +156,8 @@ public class WsHandshakeRequest implements HandshakeRequest {
             uri.append("ws");
         } else if ("https".equals(scheme)) {
             uri.append("wss");
+        } else if ("wss".equals(scheme) || "ws".equals(scheme)) {
+            uri.append(scheme);
         } else {
             // Should never happen
             throw new IllegalArgumentException(
@@ -166,6 +168,8 @@ public class WsHandshakeRequest implements HandshakeRequest {
         uri.append(req.getServerName());
 
         if ((scheme.equals("http") && (port != 80))
+            || (scheme.equals("ws") && (port != 80))
+            || (scheme.equals("wss") && (port != 443))
             || (scheme.equals("https") && (port != 443))) {
             uri.append(':');
             uri.append(port);


### PR DESCRIPTION
requests with scheme "wss" or "ws", as outlined in [RFC 6455 section 11.1](https://tools.ietf.org/html/rfc6455#section-11.1), will cause an `IllegalArgumentException` with message "wsHandshakeRequest.unknownScheme" without this change.

this fixes a regression from e09e6b04e41d3dae27fcfe060e6f8f89f1c0d6b5 / BZ 62731