### PR TITLE
Use https for dependency download URL

### DIFF
--- a/build.properties.default
+++ b/build.properties.default
@@ -93,7 +93,7 @@ compile.debug=true
 # Do not pass -deprecation (-Xlint:deprecation) flag to javac
 compile.deprecation=false
 
-base-apache.loc.1=http://www.apache.org/dyn/closer.lua?action=download&filename=
+base-apache.loc.1=https://www.apache.org/dyn/closer.lua?action=download&filename=
 base-apache.loc.2=https://archive.apache.org/dist
 base-commons.loc.1=${base-apache.loc.1}/commons
 base-commons.loc.2=${base-apache.loc.2}/commons


### PR DESCRIPTION
I tried to build Tomcat 8.5.50 and ran into the following error:

```
~/repos/tomcat$ git checkout 8.5.50
~/repos/tomcat$ ant dist-static

(snip)

trydownload:
      [get] Getting: http://www.apache.org/dyn/closer.lua?action=download&filename=/tomcat/tomcat-connectors/native/1.2.23/binaries/tomcat-native-1.2.23-openssl-1.1.1c-win32-bin.zip
      [get] To: /home/sekikn/tomcat-build-libs/download-2064114466.zip
      [get] http://www.apache.org/dyn/closer.lua?action=download&filename=/tomcat/tomcat-connectors/native/1.2.23/binaries/tomcat-native-1.2.23-openssl-1.1.1c-win32-bin.zip moved to https://ftp.jaist.ac.jp/pub/apache//tomcat/tomcat-connectors/native/1.2.23/binaries/tomcat-native-1.2.23-openssl-1.1.1c-win32-bin.zip
      [get] https://ftp.jaist.ac.jp/pub/apache//tomcat/tomcat-connectors/native/1.2.23/binaries/tomcat-native-1.2.23-openssl-1.1.1c-win32-bin.zip moved to http://ftp.jaist.ac.jp/pub/apache/tomcat/tomcat-connectors/native/1.2.23/binaries/tomcat-native-1.2.23-openssl-1.1.1c-win32-bin.zip

BUILD FAILED
/home/sekikn/repos/tomcat/build.xml:2879: The following error occurred while executing this line:
/home/sekikn/repos/tomcat/build.xml:3113: The following error occurred while executing this line:
/home/sekikn/repos/tomcat/build.xml:3188: Redirection detected from https to http. Protocol switch unsafe, not allowed.

Total time: 1 second
```

Tomcat native connector 1.2.23 is not published on the Apache download site now, so ant tries to fall back to the Apache archive site, but that action is regarded as unsafe. Users can avoid this by overriding the "base-apache.loc.1" property, but it's a bit bothering so I'd like to fix the default value.