### PR TITLE
Simplify some #toString() methods

### DIFF
--- a/java/org/apache/catalina/connector/CoyotePrincipal.java
+++ b/java/org/apache/catalina/connector/CoyotePrincipal.java
@@ -62,10 +62,7 @@ public class CoyotePrincipal implements Principal, Serializable {
      */
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder("CoyotePrincipal[");
-        sb.append(this.name);
-        sb.append(']');
-        return sb.toString();
+        return "CoyotePrincipal[" + this.name + "]";
     }
 
 

--- a/java/org/apache/catalina/core/StandardThreadExecutor.java
+++ b/java/org/apache/catalina/core/StandardThreadExecutor.java
@@ -338,8 +338,6 @@ public class StandardThreadExecutor extends LifecycleMBeanBase
 
     @Override
     protected String getObjectNameKeyProperties() {
-        StringBuilder name = new StringBuilder("type=Executor,name=");
-        name.append(getName());
-        return name.toString();
+        return "type=Executor,name=" + getName();
     }
 }

--- a/java/org/apache/catalina/tribes/UniqueId.java
+++ b/java/org/apache/catalina/tribes/UniqueId.java
@@ -70,9 +70,7 @@ public final class UniqueId implements Serializable{
 
     @Override
     public String toString() {
-        StringBuilder buf = new StringBuilder("UniqueId");
-        buf.append(Arrays.toString(id));
-        return buf.toString();
+        return "UniqueId" + Arrays.toString(id);
     }
 
 }

--- a/java/org/apache/juli/VerbatimFormatter.java
+++ b/java/org/apache/juli/VerbatimFormatter.java
@@ -31,13 +31,8 @@ public class VerbatimFormatter extends Formatter {
 
     @Override
     public String format(LogRecord record) {
-        // Timestamp
-        StringBuilder sb = new StringBuilder(record.getMessage());
-
-        // New line for next record
-        sb.append(System.lineSeparator());
-
-        return sb.toString();
+        // Timestamp + New line for next record
+        return record.getMessage() + System.lineSeparator();
     }
 
 }

--- a/java/org/apache/tomcat/dbcp/dbcp2/datasources/CPDSConnectionFactory.java
+++ b/java/org/apache/tomcat/dbcp/dbcp2/datasources/CPDSConnectionFactory.java
@@ -420,7 +420,7 @@ class CPDSConnectionFactory
         builder.append(validatingSet);
         builder.append(", pcMap=");
         builder.append(pcMap);
-        builder.append("]");
+        builder.append(']');
         return builder.toString();
     }
 }

--- a/java/org/apache/tomcat/dbcp/dbcp2/datasources/InstanceKeyDataSource.java
+++ b/java/org/apache/tomcat/dbcp/dbcp2/datasources/InstanceKeyDataSource.java
@@ -1062,9 +1062,9 @@ public abstract class InstanceKeyDataSource implements DataSource, Referenceable
     @Override
     public synchronized String toString() {
         final StringBuilder builder = new StringBuilder(super.toString());
-        builder.append("[");
+        builder.append('[');
         toStringFields(builder);
-        builder.append("]");
+        builder.append(']');
         return builder.toString();
     }
 

--- a/java/org/apache/tomcat/util/descriptor/web/ContextTransaction.java
+++ b/java/org/apache/tomcat/util/descriptor/web/ContextTransaction.java
@@ -84,8 +84,6 @@ public class ContextTransaction implements Serializable {
      */
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder("Transaction[");
-        sb.append(']');
-        return sb.toString();
+        return "Transaction[]";
     }
 }

--- a/java/org/apache/tomcat/util/digester/SetPropertiesRule.java
+++ b/java/org/apache/tomcat/util/digester/SetPropertiesRule.java
@@ -131,8 +131,6 @@ public class SetPropertiesRule extends Rule {
      */
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder("SetPropertiesRule[");
-        sb.append(']');
-        return sb.toString();
+        return "SetPropertiesRule[]";
     }
 }

--- a/java/org/apache/tomcat/util/http/fileupload/FileUploadBase.java
+++ b/java/org/apache/tomcat/util/http/fileupload/FileUploadBase.java
@@ -491,7 +491,7 @@ public abstract class FileUploadBase {
                 }
                 // Continuation line found
                 end = parseEndOfLine(headerPart, nonWs);
-                header.append(' ').append(headerPart.substring(nonWs, end));
+                header.append(' ').append(headerPart, nonWs, end);
                 start = end + 2;
             }
             parseHeaderLine(headers, header.toString());

--- a/webapps/examples/WEB-INF/classes/async/Stockticker.java
+++ b/webapps/examples/WEB-INF/classes/async/Stockticker.java
@@ -186,11 +186,11 @@ public class Stockticker implements Runnable {
         public String toString() {
             StringBuilder buf = new StringBuilder("STOCK#");
             buf.append(getSymbol());
-            buf.append("#");
+            buf.append('#');
             buf.append(getValueAsString());
-            buf.append("#");
+            buf.append('#');
             buf.append(getLastChangeAsString());
-            buf.append("#");
+            buf.append('#');
             buf.append(String.valueOf(getCnt()));
             return buf.toString();
 

--- a/webapps/examples/WEB-INF/classes/filters/ExampleFilter.java
+++ b/webapps/examples/WEB-INF/classes/filters/ExampleFilter.java
@@ -93,10 +93,7 @@ public final class ExampleFilter extends GenericFilter {
      */
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder("TimingFilter(");
-        sb.append(getFilterConfig());
-        sb.append(")");
-        return sb.toString();
+        return "ExampleFilter(" + getFilterConfig() + ")";
     }
 }
 


### PR DESCRIPTION
Do not use StringBuilder when String concatenation is just fine.

Append char instead of String when possible.

Fix the toString of ExampleFilter