### PR TITLE
Change ETag format to Nginx like

### DIFF
--- a/java/org/apache/catalina/webresources/AbstractResource.java
+++ b/java/org/apache/catalina/webresources/AbstractResource.java
@@ -32,7 +32,7 @@ public abstract class AbstractResource implements WebResource {
     private final String webAppPath;
 
     private String mimeType = null;
-    private volatile String weakETag;
+    private volatile String etag;
 
 
     protected AbstractResource(WebResourceRoot root, String webAppPath) {
@@ -61,19 +61,19 @@ public abstract class AbstractResource implements WebResource {
 
     @Override
     public final String getETag() {
-        if (weakETag == null) {
+        if (etag == null) {
             synchronized (this) {
-                if (weakETag == null) {
+                if (etag == null) {
                     long contentLength = getContentLength();
                     long lastModified = getLastModified();
                     if ((contentLength >= 0) || (lastModified >= 0)) {
-                        weakETag = "W/\"" + contentLength + "-" +
-                                   lastModified + "\"";
+                        etag = '\"' + contentLength + '-' +
+                                   lastModified + '\"';
                     }
                 }
             }
         }
-        return weakETag;
+        return etag;
     }
 
     @Override

--- a/java/org/apache/catalina/webresources/AbstractResource.java
+++ b/java/org/apache/catalina/webresources/AbstractResource.java
@@ -65,10 +65,10 @@ public abstract class AbstractResource implements WebResource {
             synchronized (this) {
                 if (etag == null) {
                     long contentLength = getContentLength();
-                    long lastModified = getLastModified();
+                    long lastModified = getLastModified() / 1000; // msec to sec
                     if ((contentLength >= 0) || (lastModified >= 0)) {
-                        etag = '\"' + contentLength + '-' +
-                                   lastModified + '\"';
+                        etag = '\"' + Long.toHexString(lastModified) + '-' +
+                                Long.toHexString(contentLength) + '\"';
                     }
                 }
             }


### PR DESCRIPTION
Currently Tomcat 9 generates ETag like `W/"1047-1578315296666"` i.e. `Weak"Size-MTime in Milliseconds"`.
This is incorrect ETag because it should be strong as for a static file i.e. octal compatibility.
Also to make ETag working for load balancing between Tomcat and Nginx we need to change format to `"hex(MTime in seconds)-hex(Size)"` e.g. `"5e132e20-417"`.
Nginx is not configurable but ether Tomcat is not. In the same time Nginx is more widely used while Tomcat returns incorrect ETag.
This small PR fixes the problem.
As a downside after update Tomcat will discard existing ETags but then they'll be updated on clients and everything will work fine.

I created a bug ticket https://bz.apache.org/bugzilla/show_bug.cgi?id=64616
See the W3C discussion for details https://lists.w3.org/Archives/Public/ietf-http-wg/2020JulSep/0041.html
ETag spec https://tools.ietf.org/html/rfc7232#section-2.3.2

