### PR TITLE
BZ 64265 Fix and simplify weak ETag matching

### DIFF
--- a/test/org/apache/catalina/servlets/TestDefaultServletIfMatchRequests.java
+++ b/test/org/apache/catalina/servlets/TestDefaultServletIfMatchRequests.java
@@ -18,6 +18,7 @@ package org.apache.catalina.servlets;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -46,23 +47,23 @@ public class TestDefaultServletIfMatchRequests extends TomcatBaseTest {
         String strongETag =  "\"" + index.length() + "-" + index.lastModified() + "\"";
         String weakETag = "W/" + strongETag;
 
-        List<Object[]> parameterSets = new ArrayList<>();
-
-        parameterSets.add(new Object[] { null, Integer.valueOf(200) });
-        parameterSets.add(new Object[] { "*", Integer.valueOf(200) });
-        parameterSets.add(new Object[] { weakETag, Integer.valueOf(200) });
-        parameterSets.add(new Object[] { strongETag, Integer.valueOf(200) });
-        parameterSets.add(new Object[] { weakETag + ",123456789", Integer.valueOf(200) });
-        parameterSets.add(new Object[] { strongETag + ",123456789", Integer.valueOf(200) });
-        parameterSets.add(new Object[] { weakETag + " ,123456789", Integer.valueOf(200) });
-        parameterSets.add(new Object[] { strongETag + " ,123456789", Integer.valueOf(200) });
-        parameterSets.add(new Object[] { "123456789," + weakETag, Integer.valueOf(200) });
-        parameterSets.add(new Object[] { "123456789," + strongETag, Integer.valueOf(200) });
-        parameterSets.add(new Object[] { "123456789, " + weakETag, Integer.valueOf(200) });
-        parameterSets.add(new Object[] { "123456789, " + strongETag, Integer.valueOf(200) });
-        parameterSets.add(new Object[] { "123456789", Integer.valueOf(412) });
-        parameterSets.add(new Object[] { "W/123456789", Integer.valueOf(412) });
-        parameterSets.add(new Object[] { "W/", Integer.valueOf(412) });
+        List<Object[]> parameterSets = Arrays.asList(
+            new Object[] { null, Integer.valueOf(200) },
+            new Object[] { "*", Integer.valueOf(200) },
+            new Object[] { weakETag, Integer.valueOf(200) },
+            new Object[] { strongETag, Integer.valueOf(200) },
+            new Object[] { weakETag + ",123456789", Integer.valueOf(200) },
+            new Object[] { strongETag + ",123456789", Integer.valueOf(200) },
+            new Object[] { weakETag + " ,123456789", Integer.valueOf(200) },
+            new Object[] { strongETag + " ,123456789", Integer.valueOf(200) },
+            new Object[] { "123456789," + weakETag, Integer.valueOf(200) },
+            new Object[] { "123456789," + strongETag, Integer.valueOf(200) },
+            new Object[] { "123456789, " + weakETag, Integer.valueOf(200) },
+            new Object[] { "123456789, " + strongETag, Integer.valueOf(200) },
+            new Object[] { "123456789", Integer.valueOf(412) },
+            new Object[] { "W/123456789", Integer.valueOf(412) },
+            new Object[] { "W/", Integer.valueOf(412) }
+        );
 
         return parameterSets;
     }

--- a/test/org/apache/catalina/servlets/TestDefaultServletIfMatchRequests.java
+++ b/test/org/apache/catalina/servlets/TestDefaultServletIfMatchRequests.java
@@ -48,20 +48,19 @@ public class TestDefaultServletIfMatchRequests extends TomcatBaseTest {
         String weakETag = "W/" + strongETag;
 
         List<Object[]> parameterSets = Arrays.asList(
-            new Object[] { null, Integer.valueOf(200) },
             new Object[] { "*", Integer.valueOf(200) },
             new Object[] { weakETag, Integer.valueOf(200) },
             new Object[] { strongETag, Integer.valueOf(200) },
-            new Object[] { weakETag + ",123456789", Integer.valueOf(200) },
-            new Object[] { strongETag + ",123456789", Integer.valueOf(200) },
-            new Object[] { weakETag + " ,123456789", Integer.valueOf(200) },
-            new Object[] { strongETag + " ,123456789", Integer.valueOf(200) },
-            new Object[] { "123456789," + weakETag, Integer.valueOf(200) },
-            new Object[] { "123456789," + strongETag, Integer.valueOf(200) },
-            new Object[] { "123456789, " + weakETag, Integer.valueOf(200) },
-            new Object[] { "123456789, " + strongETag, Integer.valueOf(200) },
-            new Object[] { "123456789", Integer.valueOf(412) },
-            new Object[] { "W/123456789", Integer.valueOf(412) },
+            new Object[] { weakETag + ",\"anotherETag\"", Integer.valueOf(200) },
+            new Object[] { strongETag + ",\"anotherETag\"", Integer.valueOf(200) },
+            new Object[] { weakETag + " ,\"anotherETag\"", Integer.valueOf(200) },
+            new Object[] { strongETag + " ,\"anotherETag\"", Integer.valueOf(200) },
+            new Object[] { "\"anotherETag\"," + weakETag, Integer.valueOf(200) },
+            new Object[] { "\"anotherETag\"," + strongETag, Integer.valueOf(200) },
+            new Object[] { "\"anotherETag\", " + weakETag, Integer.valueOf(200) },
+            new Object[] { "\"anotherETag\", " + strongETag, Integer.valueOf(200) },
+            new Object[] { "\"anotherETag\"", Integer.valueOf(412) },
+            new Object[] { "W/\"anotherETag\"", Integer.valueOf(412) },
             new Object[] { "W/", Integer.valueOf(412) }
         );
 
@@ -94,12 +93,10 @@ public class TestDefaultServletIfMatchRequests extends TomcatBaseTest {
         Map<String,List<String>> responseHeaders = new HashMap<>();
 
         Map<String,List<String>> requestHeaders = null;
-        if (ifMatchHeader != null) {
-            requestHeaders = new HashMap<>();
-            List<String> values = new ArrayList<>(1);
-            values.add(ifMatchHeader);
-            requestHeaders.put("If-Match", values);
-        }
+        requestHeaders = new HashMap<>();
+        List<String> values = new ArrayList<>(1);
+        values.add(ifMatchHeader);
+        requestHeaders.put("If-Match", values);
 
         int rc = getUrl(path, responseBody, requestHeaders, responseHeaders);
 

--- a/test/org/apache/catalina/servlets/TestDefaultServletIfMatchRequests.java
+++ b/test/org/apache/catalina/servlets/TestDefaultServletIfMatchRequests.java
@@ -48,30 +48,30 @@ public class TestDefaultServletIfMatchRequests extends TomcatBaseTest {
         String weakETag = "W/" + strongETag;
 
         List<Object[]> parameterSets = Arrays.asList(
-            new Object[] { "*", Integer.valueOf(200) },
-            new Object[] { weakETag, Integer.valueOf(200) },
-            new Object[] { strongETag, Integer.valueOf(200) },
-            new Object[] { weakETag + ",\"anotherETag\"", Integer.valueOf(200) },
-            new Object[] { strongETag + ",\"anotherETag\"", Integer.valueOf(200) },
-            new Object[] { weakETag + " ,\"anotherETag\"", Integer.valueOf(200) },
-            new Object[] { strongETag + " ,\"anotherETag\"", Integer.valueOf(200) },
-            new Object[] { "\"anotherETag\"," + weakETag, Integer.valueOf(200) },
-            new Object[] { "\"anotherETag\"," + strongETag, Integer.valueOf(200) },
-            new Object[] { "\"anotherETag\", " + weakETag, Integer.valueOf(200) },
-            new Object[] { "\"anotherETag\", " + strongETag, Integer.valueOf(200) },
-            new Object[] { "\"anotherETag\"", Integer.valueOf(412) },
-            new Object[] { "W/\"anotherETag\"", Integer.valueOf(412) },
-            new Object[] { "W/", Integer.valueOf(412) }
+            new Object[] { "*", Boolean.TRUE },
+            new Object[] { weakETag, Boolean.TRUE },
+            new Object[] { strongETag, Boolean.TRUE },
+            new Object[] { weakETag + ",\"anotherETag\"", Boolean.TRUE },
+            new Object[] { strongETag + ",\"anotherETag\"", Boolean.TRUE },
+            new Object[] { weakETag + " ,\"anotherETag\"", Boolean.TRUE },
+            new Object[] { strongETag + " ,\"anotherETag\"", Boolean.TRUE },
+            new Object[] { "\"anotherETag\"," + weakETag, Boolean.TRUE },
+            new Object[] { "\"anotherETag\"," + strongETag, Boolean.TRUE },
+            new Object[] { "\"anotherETag\", " + weakETag, Boolean.TRUE },
+            new Object[] { "\"anotherETag\", " + strongETag, Boolean.TRUE },
+            new Object[] { "\"anotherETag\"", Boolean.FALSE },
+            new Object[] { "W/\"anotherETag\"", Boolean.FALSE },
+            new Object[] { "W/", Boolean.FALSE }
         );
 
         return parameterSets;
     }
 
     @Parameter(0)
-    public String ifMatchHeader;
+    public String matchHeader;
 
     @Parameter(1)
-    public int responseCodeExpected;
+    public boolean ifMatchCondition;
 
 
     @Test
@@ -87,10 +87,10 @@ public class TestDefaultServletIfMatchRequests extends TomcatBaseTest {
 
         tomcat.start();
 
-        int rc = performRequest("If-Match", ifMatchHeader);
+        int rc = performRequest("If-Match", matchHeader);
 
         // Check the result
-        Assert.assertEquals(responseCodeExpected, rc);
+        Assert.assertEquals(ifMatchCondition ? 200 : 412, rc);
     }
 
     private int performRequest(String headerName, String matchHeader) throws IOException {

--- a/test/org/apache/catalina/servlets/TestDefaultServletIfMatchRequests.java
+++ b/test/org/apache/catalina/servlets/TestDefaultServletIfMatchRequests.java
@@ -17,10 +17,10 @@
 package org.apache.catalina.servlets;
 
 import java.io.File;
-import java.util.ArrayList;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -87,20 +87,21 @@ public class TestDefaultServletIfMatchRequests extends TomcatBaseTest {
 
         tomcat.start();
 
-        // Set up parameters
-        String path = "http://localhost:" + getPort() + "/index.html";
-        ByteChunk responseBody = new ByteChunk();
-        Map<String,List<String>> responseHeaders = new HashMap<>();
-
-        Map<String,List<String>> requestHeaders = null;
-        requestHeaders = new HashMap<>();
-        List<String> values = new ArrayList<>(1);
-        values.add(ifMatchHeader);
-        requestHeaders.put("If-Match", values);
-
-        int rc = getUrl(path, responseBody, requestHeaders, responseHeaders);
+        int rc = performRequest("If-Match", ifMatchHeader);
 
         // Check the result
         Assert.assertEquals(responseCodeExpected, rc);
+    }
+
+    private int performRequest(String headerName, String matchHeader) throws IOException {
+        // Set up parameters
+        String path = "http://localhost:" + getPort() + "/index.html";
+        ByteChunk responseBody = new ByteChunk();
+
+        List<String> values = Collections.singletonList(matchHeader);
+        Map<String,List<String>> requestHeaders = Collections.singletonMap(headerName, values);
+
+        int rc = getUrl(path, responseBody, requestHeaders, null);
+        return rc;
     }
 }


### PR DESCRIPTION
The If-None-Match header may have multiple ETags https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.26
Even if Tomcat returns a single ETag clients may want to send few of them.
But Tomcat also makes weak matching while resource ETag is a weak by default. This functionality was implemented in b26ad77f659de34d49dda5a248566a38383cec0e but only for `If-Match` header while `If-None-Match` header remains unfixed. 

The PR contains a fix of weak matching for `If-None-Match`.

Also since ETags are always quoted the easiest way to check is just to check a substring.
This will reduce amount of memory consumed by full ETag parsing.

A commands to check:

    curl -vv http://localhost:8080/tomcat.png -H 'If-None-Match: W/"5103-1595246577000", "etag2"'
    curl -vv http://localhost:8080/tomcat.png -H 'If-None-Match: "5103-1595246577000", "etag2"'

Both returns 304 Not Modified.

