### PR TITLE
Remove White Spaces and extra lines from the JSP files

### DIFF
--- a/conf/catalina.properties
+++ b/conf/catalina.properties
@@ -204,3 +204,6 @@ tomcat.util.buf.StringCache.byte.enabled=true
 #tomcat.util.buf.StringCache.char.enabled=true
 #tomcat.util.buf.StringCache.trainThreshold=500000
 #tomcat.util.buf.StringCache.cacheSize=5000
+
+# This controls If the JSP compiler trims off all the unnecessary white space's, thus reducing the JVM metadata
+tomcat.JSPWhiteSpaceTrimming=false

--- a/conf/catalina.properties
+++ b/conf/catalina.properties
@@ -204,6 +204,3 @@ tomcat.util.buf.StringCache.byte.enabled=true
 #tomcat.util.buf.StringCache.char.enabled=true
 #tomcat.util.buf.StringCache.trainThreshold=500000
 #tomcat.util.buf.StringCache.cacheSize=5000
-
-# This controls If the JSP compiler trims off all the unnecessary white space's, thus reducing the JVM metadata
-tomcat.JSPWhiteSpaceTrimming=false

--- a/java/org/apache/jasper/compiler/Compiler.java
+++ b/java/org/apache/jasper/compiler/Compiler.java
@@ -50,6 +50,8 @@ import org.apache.tomcat.util.scan.JarFactory;
  */
 public abstract class Compiler {
 
+    private static final boolean JSP_WHITE_SPACE_TRIMMING = Boolean.getBoolean("tomcat.JSPWhiteSpaceTrimming");
+
     private final Log log = LogFactory.getLog(Compiler.class); // must not be static
 
     // ----------------------------------------------------- Instance Variables
@@ -316,7 +318,12 @@ public abstract class Compiler {
                     javaEncoding);
         }
 
+        if (JSP_WHITE_SPACE_TRIMMING) {
+            writer = new NewlineReductionServletWriter(new PrintWriter(osw));
+        } else {
         writer = new ServletWriter(new PrintWriter(osw));
+        }
+
         ctxt.setWriter(writer);
         return writer;
     }

--- a/java/org/apache/jasper/compiler/Compiler.java
+++ b/java/org/apache/jasper/compiler/Compiler.java
@@ -50,7 +50,7 @@ import org.apache.tomcat.util.scan.JarFactory;
  */
 public abstract class Compiler {
 
-    private static final boolean JSP_WHITE_SPACE_TRIMMING = Boolean.getBoolean("tomcat.JSPWhiteSpaceTrimming");
+    private static final String JSP_WHITE_SPACE_TRIMMING = "JSPWhiteSpaceTrimming";
 
     private final Log log = LogFactory.getLog(Compiler.class); // must not be static
 
@@ -318,7 +318,7 @@ public abstract class Compiler {
                     javaEncoding);
         }
 
-        if (JSP_WHITE_SPACE_TRIMMING) {
+        if (Boolean.parseBoolean(this.jsw.getServletContext().getInitParameter(JSP_WHITE_SPACE_TRIMMING))) {
             writer = new NewlineReductionServletWriter(new PrintWriter(osw));
         } else {
         writer = new ServletWriter(new PrintWriter(osw));

--- a/java/org/apache/jasper/compiler/Compiler.java
+++ b/java/org/apache/jasper/compiler/Compiler.java
@@ -318,7 +318,7 @@ public abstract class Compiler {
                     javaEncoding);
         }
 
-        if (Boolean.parseBoolean(this.jsw.getServletContext().getInitParameter(JSP_WHITE_SPACE_TRIMMING))) {
+        if ((this.jsw!=null) && Boolean.parseBoolean(this.jsw.getServletContext().getInitParameter(JSP_WHITE_SPACE_TRIMMING))) {
             writer = new NewlineReductionServletWriter(new PrintWriter(osw));
         } else {
         writer = new ServletWriter(new PrintWriter(osw));

--- a/java/org/apache/jasper/compiler/Generator.java
+++ b/java/org/apache/jasper/compiler/Generator.java
@@ -84,10 +84,10 @@ class Generator {
 
     private static final Class<?>[] OBJECT_CLASS = { Object.class };
 
-    //Flag to enable or disable the excess white space trimming.
-    private static final boolean JSP_WHITE_SPACE_TRIMMING = Boolean.getBoolean("tomcat.JSPWhiteSpaceTrimming");
+    //context param to enable or disable the excess white space trimming.
+    private static final String JSP_WHITE_SPACE_TRIMMING = "JSPWhiteSpaceTrimming";
 
-    private static final Pattern PRE_TAG_PATTERN = Pattern.compile(".*(<pre>|</pre>).*");
+    private static final Pattern PRE_TAG_PATTERN = Pattern.compile("(?s).*(<pre>|</pre>).*");
     private static final Pattern BLANK_LINE_PATTERN = Pattern.compile("(\\s*(\\n|\\r)+\\s*)");
 
     private static final String VAR_EXPRESSIONFACTORY =
@@ -2119,7 +2119,7 @@ class Generator {
             String text = n.getText();
             // If the flag is active, attempt to minimize the frequency of
             // regex operations.
-            if (JSP_WHITE_SPACE_TRIMMING && text.contains("\n")) {
+            if (Boolean.parseBoolean(ctxt.getServletContext().getInitParameter(JSP_WHITE_SPACE_TRIMMING)) && text.contains("\n")) {
                 // Ensure there are no <pre> or </pre> tags embedded in this
                 // text - if there are, we want to NOT modify the whitespace.
                 Matcher preMatcher = PRE_TAG_PATTERN.matcher(text);

--- a/java/org/apache/jasper/compiler/Generator.java
+++ b/java/org/apache/jasper/compiler/Generator.java
@@ -2119,7 +2119,7 @@ class Generator {
             String text = n.getText();
             // If the flag is active, attempt to minimize the frequency of
             // regex operations.
-            if (Boolean.parseBoolean(ctxt.getServletContext().getInitParameter(JSP_WHITE_SPACE_TRIMMING)) && text.contains("\n")) {
+            if ((ctxt!=null) && Boolean.parseBoolean(ctxt.getServletContext().getInitParameter(JSP_WHITE_SPACE_TRIMMING)) && text.contains("\n")) {
                 // Ensure there are no <pre> or </pre> tags embedded in this
                 // text - if there are, we want to NOT modify the whitespace.
                 Matcher preMatcher = PRE_TAG_PATTERN.matcher(text);

--- a/java/org/apache/jasper/compiler/NewlineReductionServletWriter.java
+++ b/java/org/apache/jasper/compiler/NewlineReductionServletWriter.java
@@ -1,0 +1,40 @@
+package org.apache.jasper.compiler;
+
+import java.io.PrintWriter;
+
+/**
+ * This class filters duplicate newlines instructions from the compiler output,
+ * and therefore from the runtime JSP. The duplicates typically happen because
+ * the compiler has multiple branches that write them, but they operate
+ * independently and don't realize that the previous output was identical.
+ *
+ * Removing these lines makes the JSP more efficient by executing fewer operations during runtime.
+ *
+ * @author Engebretson, John
+ * @author Kamnani, Jatin
+ *
+ */
+public class NewlineReductionServletWriter extends ServletWriter {
+    private static final String NEWLINE_WRITE_TEXT = "out.write('\\n');";
+    private boolean lastWriteWasNewline;
+
+    public NewlineReductionServletWriter(PrintWriter writer) {
+        super(writer);
+    }
+
+    @Override
+    public void printil(String s) {
+        if (s.equals(NEWLINE_WRITE_TEXT)) {
+            if (lastWriteWasNewline) {
+                // do nothing
+                return;
+            } else {
+                lastWriteWasNewline = true;
+            }
+        } else {
+            lastWriteWasNewline = false;
+        }
+        super.printil(s);
+    }
+
+}


### PR DESCRIPTION
The changes enables the compiler to remove excess white spaces and new lines from the JSP files & thus reduce the JVM metadata.
This can be controlled by providing context init params inside `web.xml` file. Example attached. 

By Default this remains false, and thus the source JSP files will not reflect any changes compared to the previous builds.

Note: 
1 ) The changes do not affect to the pre tags, to protect the behavioral changes on the tag. 
2 ) This change is for Tomcat 9 Version. 

If any official documentation is required, can you attach the links on the PR? 


```
<web-app>
<context-param>
    <param-name>JSPWhiteSpaceTrimming</param-name>
    <param-value>true</param-value>
</context-param> 
</web-app>

