### PR TITLE
[Patch] Support INDEX.LIST in jar file to speed up resource finding

### DIFF
--- a/java/org/apache/catalina/WebResourceSet.java
+++ b/java/org/apache/catalina/WebResourceSet.java
@@ -18,6 +18,7 @@ package org.apache.catalina;
 
 import java.io.InputStream;
 import java.net.URL;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -35,6 +36,10 @@ public interface WebResourceSet extends Lifecycle {
      * @return  The object that represents the resource at the given path
      */
     WebResource getResource(String path);
+
+    default WebResource getResource(String path, List<List<WebResourceSet>> allResources){
+        return getResource(path);
+    }
 
     /**
      * Obtain the list of the names of all of the files and directories located

--- a/java/org/apache/catalina/webresources/StandardRoot.java
+++ b/java/org/apache/catalina/webresources/StandardRoot.java
@@ -278,7 +278,7 @@ public class StandardRoot extends LifecycleMBeanBase implements WebResourceRoot 
             for (WebResourceSet webResourceSet : list) {
                 if (!useClassLoaderResources &&  !webResourceSet.getClassLoaderOnly() ||
                         useClassLoaderResources && !webResourceSet.getStaticOnly()) {
-                    result = webResourceSet.getResource(path);
+                    result = webResourceSet.getResource(path, allResources);
                     if (result.exists()) {
                         return result;
                     }

--- a/java/org/apache/tomcat/util/scan/JarIndex.java
+++ b/java/org/apache/tomcat/util/scan/JarIndex.java
@@ -1,0 +1,61 @@
+package org.apache.tomcat.util.scan;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.LinkedList;
+
+public class JarIndex {
+    private final HashMap<String,LinkedList<String>> indexMap;
+
+    public JarIndex(InputStream is) throws IOException {
+        indexMap = new HashMap<>();
+        read(is);
+    }
+
+    public LinkedList<String> get(String fileName) {
+        LinkedList<String> jarFiles;
+        if ((jarFiles = indexMap.get(fileName)) == null) {
+            int pos;
+            if((pos = fileName.lastIndexOf('/')) != -1) {
+                jarFiles = indexMap.get(fileName.substring(0, pos));
+            }
+        }
+        return jarFiles;
+    }
+
+    private void read(InputStream is) throws IOException {
+        BufferedReader br = new BufferedReader
+                (new InputStreamReader(is, StandardCharsets.UTF_8));
+        String line;
+        String currentJar = null;
+
+        while((line = br.readLine()) != null && !line.endsWith(".jar"));
+
+        for(;line != null; line = br.readLine()) {
+            if (line.length() == 0)
+                continue;
+
+            if (line.endsWith(".jar")) {
+                currentJar = line;
+            } else {
+                addToList(line,currentJar,indexMap);
+            }
+        }
+    }
+
+    private void addToList(String key, String value,
+                           HashMap<String, LinkedList<String>> t) {
+        LinkedList<String> list = t.get(key);
+        if (list == null) {
+            list = new LinkedList<>();
+            list.add(value);
+            t.put(key, list);
+        } else if (!list.contains(value)) {
+            list.add(value);
+        }
+    }
+}


### PR DESCRIPTION
`jdk.internal.util.jar.JarIndex` was introduced by JDK1.3, it's an old but useful technique. If third-party JAR files contain INDEX.LIST file(generated via `jar -i` command), these JAR files can be identified as loading into JVM. Class loader such as BuiltinClassLoader,URLClassLoader and subclasses of URLClassLoader can speed up their resource searching with the help of INDEX.LIST since it maps resource names to corresponding JAR names. 

The latest version of Tomcat does not aware of `INDEX.LIST`, when there are so many JAR files in `WEB-INF/lib`,  Tom cat have to search in all JAR files sequentially, which is obviously slow. This patch helps Tomcat to be aware of `INDEX.LIST`, speeds up the search of resources, especially when there are many JAR files in `WEB-INF/lib`