### PR TITLE
Fix https://bz.apache.org/bugzilla/show_bug.cgi?id=64614

### DIFF
--- a/java/org/apache/tomcat/util/net/LocalStrings.properties
+++ b/java/org/apache/tomcat/util/net/LocalStrings.properties
@@ -176,3 +176,4 @@ sslUtilBase.ssl3=SSLv3 has been explicitly enabled. This protocol is known to be
 sslUtilBase.tls13.auth=The JSSE TLS 1.3 implementation does not support authentication after the initial handshake and is therefore incompatible with optional client authentication
 sslUtilBase.trustedCertNotChecked=The validity dates of the trusted certificate with alias [{0}] were not checked as the certificate was of an unknown type
 sslUtilBase.trustedCertNotValid=The trusted certificate with alias [{0}] and DN [{1}] is not valid due to [{2}]. Certificates signed by this trusted certificate WILL be accepted
+sslUtilBase.alias_ignored=Alias name [{0}] is ignored

--- a/java/org/apache/tomcat/util/net/LocalStrings.properties
+++ b/java/org/apache/tomcat/util/net/LocalStrings.properties
@@ -176,4 +176,4 @@ sslUtilBase.ssl3=SSLv3 has been explicitly enabled. This protocol is known to be
 sslUtilBase.tls13.auth=The JSSE TLS 1.3 implementation does not support authentication after the initial handshake and is therefore incompatible with optional client authentication
 sslUtilBase.trustedCertNotChecked=The validity dates of the trusted certificate with alias [{0}] were not checked as the certificate was of an unknown type
 sslUtilBase.trustedCertNotValid=The trusted certificate with alias [{0}] and DN [{1}] is not valid due to [{2}]. Certificates signed by this trusted certificate WILL be accepted
-sslUtilBase.alias_ignored=Alias name [{0}] is ignored
+sslUtilBase.alias_ignored=FIPS enabled so alias name [{0}] will be ignored. If there is more than one key in the key store, the key used will depend on the key store implementation

--- a/java/org/apache/tomcat/util/net/SSLUtilBase.java
+++ b/java/org/apache/tomcat/util/net/SSLUtilBase.java
@@ -296,6 +296,15 @@ public abstract class SSLUtilBase implements SSLUtil {
 
         char[] keyPassArray = keyPass.toCharArray();
 
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance(algorithm);
+        if (kmf.getProvider().getInfo().indexOf("FIPS") != -1) {
+            // FIPS doesn't like ANY wrapping nor key manipulation.
+            if (keyAlias != null)
+                log.warn(sm.getString("sslUtilBase.alias_ignored", keyAlias));
+            kmf.init(ksUsed, keyPassArray);
+            return kmf.getKeyManagers();
+        }
+
         if (ks == null) {
             if (certificate.getCertificateFile() == null) {
                 throw new IOException(sm.getString("sslUtilBase.noCertFile"));
@@ -358,7 +367,6 @@ public abstract class SSLUtilBase implements SSLUtil {
         }
 
 
-        KeyManagerFactory kmf = KeyManagerFactory.getInstance(algorithm);
         kmf.init(ksUsed, keyPassArray);
 
         KeyManager[] kms = kmf.getKeyManagers();


### PR DESCRIPTION
I was not able to convince the JVM in "FIPS mode" to use an alias, if there are several key/cert in the keystore it will use the latest one, therefore the following patch.