### PR TITLE
Fix SSHA documentation and cleanup the code

### DIFF
--- a/java/org/apache/catalina/realm/MessageDigestCredentialHandler.java
+++ b/java/org/apache/catalina/realm/MessageDigestCredentialHandler.java
@@ -36,7 +36,7 @@ import org.apache.tomcat.util.security.ConcurrentMessageDigest;
  * <li><b>{MD5}encodedCredential</b> - a Base64 encoded MD5 digest of the password</li>
  * <li><b>{SHA}encodedCredential</b> - a Base64 encoded SHA1 digest of the password</li>
  * <li><b>{SSHA}encodedCredential</b> - 20 character SHA1 digest Base64 encoded followed by salt</li>
- * <li><b>{SSHA2}encodedCredential</b> - 20 character salt followed by the salted digest Base64 encoded</li>
+ * <li><b>{SSHAv2}encodedCredential</b> - 20 character salt followed by the salted digest Base64 encoded</li>
  * <li><b>salt$iterationCount$encodedCredential</b> - a hex encoded salt, iteration code and a hex encoded
  *        credential, each separated by $</li>
  * </ul>

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -48,10 +48,10 @@
   <subsection name="Catalina">
     <changelog>
       <fix>
-        Fix in MessageDigestCredentialHandler.
+        Fix javadoc in MessageDigestCredentialHandler.
         For {SSHA} the documentation says that the format is like "{SSHA}&lt;salt:20&gt;&lt;digest&gt;"
-        but the code parses it it wrongly. The code only works with SHA-1 because then the salt and the
-        digest have the same length. And the code parsed it like "{SSHA}&lt;digest:20&gt;&lt;salt:20&gt;"
+        but the code parses it it differently. SSHA is more or less a standard and should be
+        like "{SSHA}&lt;digest:20&gt;&lt;salt:20&gt;". This is the way the code handles it.
         Patch provided by Milo van der Zee (MilovdZee).
       </fix>
       <fix>

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -48,7 +48,7 @@
   <subsection name="Catalina">
     <changelog>
       <fix>
-        Fix javadoc in MessageDigestCredentialHandler.
+        Fix javadoc in MessageDigestCredentialHandler and code rearrange.
         For {SSHA} the documentation says that the format is like "{SSHA}&lt;salt:20&gt;&lt;digest&gt;"
         but the code parses it it differently. SSHA is more or less a standard and should be
         like "{SSHA}&lt;digest:20&gt;&lt;salt:20&gt;". This is the way the code handles it.

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -48,6 +48,13 @@
   <subsection name="Catalina">
     <changelog>
       <fix>
+        Fix in MessageDigestCredentialHandler.
+        For {SSHA} the documentation says that the format is like "{SSHA}&lt;salt:20&gt;&lt;digest&gt;"
+        but the code parses it it wrongly. The code only works with SHA-1 because then the salt and the
+        digest have the same length. And the code parsed it like "{SSHA}&lt;digest:20&gt;&lt;salt:20&gt;"
+        Patch provided by Milo van der Zee (MilovdZee).
+      </fix>
+      <fix>
         <bug>64582</bug>: Pre-load the <code>CoyoteOutputStream</code> class to
         prevent a potential exception when running under a security manager.
         Patch provided by Johnathan Gilday. (markt)


### PR DESCRIPTION
For SSHA the order of salt and digest was reversed to the documentation. It actually was "{SSHA}&lt;digest:20&gt;&lt;salt:20&gt;".

I added SSHAv2 to also allow for SHA-256 and other algorithms. I introduced {SSHAv2} for this. SSHA keeps on working like it did so the change it backward compatible.

The same holds for tomcat-10 but let us first fix the 9.x.x branch. If accepted I'll also create a 10.x.x PR.