### PR TITLE
Compare entity tag

### DIFF
--- a/java/org/apache/catalina/servlets/DefaultServlet.java
+++ b/java/org/apache/catalina/servlets/DefaultServlet.java
@@ -43,7 +43,6 @@ import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Locale;
-import java.util.Set;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -2176,7 +2175,7 @@ public class DefaultServlet extends HttpServlet {
                 String resourceETag = generateETag(resource);
 
                 // RFC 7232 requires strong comparison for If-Match headers
-                Boolean matched = EntityTag.parseEntityTag(new StringReader(headerValue), false, resourceETag);
+                Boolean matched = EntityTag.compareEntityTag(new StringReader(headerValue), false, resourceETag);
                 if (matched == null) {
                     if (debug > 10) {
                         log("DefaultServlet.checkIfMatch:  Invalid header value [" + headerValue + "]");
@@ -2265,7 +2264,7 @@ public class DefaultServlet extends HttpServlet {
                     comparisonETag = resourceETag;
                 }
 
-                Boolean matched = EntityTag.parseEntityTag(new StringReader(headerValue), true, comparisonETag);
+                Boolean matched = EntityTag.compareEntityTag(new StringReader(headerValue), true, comparisonETag);
                 if (matched == null) {
                     if (debug > 10) {
                         log("DefaultServlet.checkIfNoneMatch:  Invalid header value [" + headerValue + "]");

--- a/java/org/apache/catalina/servlets/DefaultServlet.java
+++ b/java/org/apache/catalina/servlets/DefaultServlet.java
@@ -2169,21 +2169,24 @@ public class DefaultServlet extends HttpServlet {
         String headerValue = request.getHeader("If-Match");
         if (headerValue != null) {
 
-            boolean conditionSatisfied = false;
+            boolean conditionSatisfied;
 
             if (!headerValue.equals("*")) {
                 String resourceETag = generateETag(resource);
-
-                // RFC 7232 requires strong comparison for If-Match headers
-                Boolean matched = EntityTag.compareEntityTag(new StringReader(headerValue), false, resourceETag);
-                if (matched == null) {
-                    if (debug > 10) {
-                        log("DefaultServlet.checkIfMatch:  Invalid header value [" + headerValue + "]");
+                if (resourceETag == null) {
+                    conditionSatisfied = false;
+                } else {
+                    // RFC 7232 requires strong comparison for If-Match headers
+                    Boolean matched = EntityTag.compareEntityTag(new StringReader(headerValue), false, resourceETag);
+                    if (matched == null) {
+                        if (debug > 10) {
+                            log("DefaultServlet.checkIfMatch:  Invalid header value [" + headerValue + "]");
+                        }
+                        response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+                        return false;
                     }
-                    response.sendError(HttpServletResponse.SC_BAD_REQUEST);
-                    return false;
+                    conditionSatisfied = matched.booleanValue();
                 }
-                conditionSatisfied = matched.booleanValue();
             } else {
                 conditionSatisfied = true;
             }
@@ -2250,29 +2253,32 @@ public class DefaultServlet extends HttpServlet {
         String headerValue = request.getHeader("If-None-Match");
         if (headerValue != null) {
 
-            boolean conditionSatisfied = false;
+            boolean conditionSatisfied;
 
             String resourceETag = generateETag(resource);
             if (!headerValue.equals("*")) {
-
-                // RFC 7232 requires weak comparison for If-None-Match headers
-                // This is done by removing any weak markers before comparison
-                String comparisonETag;
-                if (resourceETag.startsWith("W/")) {
-                    comparisonETag = resourceETag.substring(2);
+                if (resourceETag == null) {
+                    conditionSatisfied = false;
                 } else {
-                    comparisonETag = resourceETag;
-                }
-
-                Boolean matched = EntityTag.compareEntityTag(new StringReader(headerValue), true, comparisonETag);
-                if (matched == null) {
-                    if (debug > 10) {
-                        log("DefaultServlet.checkIfNoneMatch:  Invalid header value [" + headerValue + "]");
+                    // RFC 7232 requires weak comparison for If-None-Match headers
+                    // This is done by removing any weak markers before comparison
+                    String comparisonETag;
+                    if (resourceETag.startsWith("W/")) {
+                        comparisonETag = resourceETag.substring(2);
+                    } else {
+                        comparisonETag = resourceETag;
                     }
-                    response.sendError(HttpServletResponse.SC_BAD_REQUEST);
-                    return false;
+
+                    Boolean matched = EntityTag.compareEntityTag(new StringReader(headerValue), true, comparisonETag);
+                    if (matched == null) {
+                        if (debug > 10) {
+                            log("DefaultServlet.checkIfNoneMatch:  Invalid header value [" + headerValue + "]");
+                        }
+                        response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+                        return false;
+                    }
+                    conditionSatisfied = matched.booleanValue();
                 }
-                conditionSatisfied = matched.booleanValue();
             } else {
                 conditionSatisfied = true;
             }

--- a/java/org/apache/catalina/servlets/DefaultServlet.java
+++ b/java/org/apache/catalina/servlets/DefaultServlet.java
@@ -2261,15 +2261,7 @@ public class DefaultServlet extends HttpServlet {
                     conditionSatisfied = false;
                 } else {
                     // RFC 7232 requires weak comparison for If-None-Match headers
-                    // This is done by removing any weak markers before comparison
-                    String comparisonETag;
-                    if (resourceETag.startsWith("W/")) {
-                        comparisonETag = resourceETag.substring(2);
-                    } else {
-                        comparisonETag = resourceETag;
-                    }
-
-                    Boolean matched = EntityTag.compareEntityTag(new StringReader(headerValue), true, comparisonETag);
+                    Boolean matched = EntityTag.compareEntityTag(new StringReader(headerValue), true, resourceETag);
                     if (matched == null) {
                         if (debug > 10) {
                             log("DefaultServlet.checkIfNoneMatch:  Invalid header value [" + headerValue + "]");

--- a/java/org/apache/catalina/servlets/DefaultServlet.java
+++ b/java/org/apache/catalina/servlets/DefaultServlet.java
@@ -2176,15 +2176,15 @@ public class DefaultServlet extends HttpServlet {
                 String resourceETag = generateETag(resource);
 
                 // RFC 7232 requires strong comparison for If-Match headers
-                Set<String> headerETags = EntityTag.parseEntityTag(new StringReader(headerValue), false);
-                if (headerETags == null) {
+                Boolean matched = EntityTag.parseEntityTag(new StringReader(headerValue), false, resourceETag);
+                if (matched == null) {
                     if (debug > 10) {
                         log("DefaultServlet.checkIfMatch:  Invalid header value [" + headerValue + "]");
                     }
                     response.sendError(HttpServletResponse.SC_BAD_REQUEST);
                     return false;
                 }
-                conditionSatisfied = headerETags.contains(resourceETag);
+                conditionSatisfied = matched.booleanValue();
             } else {
                 conditionSatisfied = true;
             }
@@ -2265,15 +2265,15 @@ public class DefaultServlet extends HttpServlet {
                     comparisonETag = resourceETag;
                 }
 
-                Set<String> headerETags = EntityTag.parseEntityTag(new StringReader(headerValue), true);
-                if (headerETags == null) {
+                Boolean matched = EntityTag.parseEntityTag(new StringReader(headerValue), true, comparisonETag);
+                if (matched == null) {
                     if (debug > 10) {
                         log("DefaultServlet.checkIfNoneMatch:  Invalid header value [" + headerValue + "]");
                     }
                     response.sendError(HttpServletResponse.SC_BAD_REQUEST);
                     return false;
                 }
-                conditionSatisfied = headerETags.contains(comparisonETag);
+                conditionSatisfied = matched.booleanValue();
             } else {
                 conditionSatisfied = true;
             }

--- a/java/org/apache/tomcat/util/http/parser/EntityTag.java
+++ b/java/org/apache/tomcat/util/http/parser/EntityTag.java
@@ -18,13 +18,11 @@ package org.apache.tomcat.util.http.parser;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.util.HashSet;
-import java.util.Set;
 
 public class EntityTag {
 
     /**
-     * Parse the given input as (per RFC 7232) 1#entity-tag.
+     * Compare the given input as (per RFC 7232) 1#entity-tag.
      *
      * @param input         The input to parse
      * @param includeWeak   Should weak tags be included in the set of returned
@@ -35,9 +33,9 @@ public class EntityTag {
      *
      * @throws IOException If an I/O occurs during the parsing
      */
-    public static Boolean parseEntityTag(StringReader input, boolean includeWeak, String comparisonETag) throws IOException {
+    public static Boolean compareEntityTag(StringReader input, boolean includeWeak, String comparisonETag) throws IOException {
 
-        HashSet<String> result = new HashSet<>();
+        Boolean result = Boolean.FALSE;
 
         while (true) {
             boolean strong = false;
@@ -64,14 +62,16 @@ public class EntityTag {
             }
 
             if (strong || includeWeak) {
-                result.add(value);
+                if (comparisonETag.equals(value)) {
+                    result = Boolean.TRUE;
+                }
             }
 
             HttpParser.skipLws(input);
 
             switch (HttpParser.skipConstant(input, ",")) {
                 case EOF:
-                    return result.contains(comparisonETag);
+                    return result;
                 case NOT_FOUND:
                     // Not EOF and not "," so must be invalid
                     return null;

--- a/java/org/apache/tomcat/util/http/parser/EntityTag.java
+++ b/java/org/apache/tomcat/util/http/parser/EntityTag.java
@@ -22,18 +22,25 @@ import java.io.StringReader;
 public class EntityTag {
 
     /**
-     * Compare the given input as (per RFC 7232) 1#entity-tag.
+     * Parse the given input as (per RFC 7232) 1#entity-tag.
+     * Compare it resource ETag as described in RFC 7232 sec. 2.3.2.
      *
-     * @param input         The input to parse
-     * @param includeWeak   Should weak tags be included in the set of returned
-     *                          values?
+     * @param input        The input to parse
+     * @param compareWeak  Use weak comparison e.g. match "etag" with W/"etag"
      *
-     * @param comparisonETag Resource's ETag
+     * @param resourceETag Resource's ETag
      * @return true if etag matched or {@code null} if the header is invalid
      *
      * @throws IOException If an I/O occurs during the parsing
      */
-    public static Boolean compareEntityTag(StringReader input, boolean includeWeak, String comparisonETag) throws IOException {
+    public static Boolean compareEntityTag(StringReader input, boolean compareWeak, String resourceETag) throws IOException {
+        // The resourceETag may be weak so to do weak comparison remove /W before comparison
+        String comparisonETag;
+        if (compareWeak && resourceETag.startsWith("W/")) {
+            comparisonETag = resourceETag.substring(2);
+        } else {
+            comparisonETag = resourceETag;
+        }
 
         Boolean result = Boolean.FALSE;
 
@@ -61,7 +68,7 @@ public class EntityTag {
                 return null;
             }
 
-            if (strong || includeWeak) {
+            if (strong || compareWeak) {
                 if (comparisonETag.equals(value)) {
                     result = Boolean.TRUE;
                 }

--- a/java/org/apache/tomcat/util/http/parser/EntityTag.java
+++ b/java/org/apache/tomcat/util/http/parser/EntityTag.java
@@ -30,12 +30,12 @@ public class EntityTag {
      * @param includeWeak   Should weak tags be included in the set of returned
      *                          values?
      *
-     * @return The set of parsed entity tags or {@code null} if the header is
-     *         invalid
+     * @param comparisonETag Resource's ETag
+     * @return true if etag matched or {@code null} if the header is invalid
      *
      * @throws IOException If an I/O occurs during the parsing
      */
-    public static Set<String> parseEntityTag(StringReader input, boolean includeWeak) throws IOException {
+    public static Boolean parseEntityTag(StringReader input, boolean includeWeak, String comparisonETag) throws IOException {
 
         HashSet<String> result = new HashSet<>();
 
@@ -71,7 +71,7 @@ public class EntityTag {
 
             switch (HttpParser.skipConstant(input, ",")) {
                 case EOF:
-                    return result;
+                    return result.contains(comparisonETag);
                 case NOT_FOUND:
                     // Not EOF and not "," so must be invalid
                     return null;


### PR DESCRIPTION
Sorry for being annoying, this is just refactoring and performance optimization.
Instead of parsing `If-Match` header to a HashSet we can make in-place comparison.
Thus we can avoid of generation of garbage.