### PR TITLE
Ensure ExpressionFactory SPI registration is compatible with javax/jakarta API jar

### DIFF
--- a/res/META-INF/jasper-el.jar/services/jakarta.el.ExpressionFactory
+++ b/res/META-INF/jasper-el.jar/services/jakarta.el.ExpressionFactory
@@ -1,16 +1,1 @@
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 org.apache.el.ExpressionFactoryImpl


### PR DESCRIPTION
https://github.com/javaee/el-spec/blob/master/api/src/main/java/javax/el/FactoryFinder.java#L151 only reads one line (jakarta el-api jar), tomcat license header breaks it and is not strictly required (there is a tolerance for these files which sometimes don't support headers) so let's drop it.