### PR TITLE
Remove White Spaces from the JSP files

### DIFF
--- a/java/org/apache/jasper/EmbeddedServletOptions.java
+++ b/java/org/apache/jasper/EmbeddedServletOptions.java
@@ -85,6 +85,11 @@ public final class EmbeddedServletOptions implements Options {
     private boolean classDebugInfo = true;
 
     /**
+     * Do we want to trim white spaces in the in JSP Files?
+     */
+    private boolean jspWhiteSpaceTrimming = false;
+
+    /**
      * Background compile thread check interval in seconds.
      */
     private int checkInterval = 0;
@@ -288,6 +293,14 @@ public final class EmbeddedServletOptions implements Options {
     @Override
     public boolean getClassDebugInfo() {
         return classDebugInfo;
+    }
+
+    /**
+     * Will the white space be trimmed from the JSP Files?
+     */
+    @Override
+    public boolean getJSPWhiteSpaceTrimFlag() {
+        return jspWhiteSpaceTrimming;
     }
 
     /**
@@ -631,6 +644,19 @@ public final class EmbeddedServletOptions implements Options {
             } else {
                 if (log.isWarnEnabled()) {
                     log.warn(Localizer.getMessage("jsp.warning.classDebugInfo"));
+                }
+            }
+        }
+
+        String jspWhiteSpaceTrim = config.getInitParameter("jspWhiteSpaceTrimming");
+        if (jspWhiteSpaceTrim != null) {
+            if (jspWhiteSpaceTrim.equalsIgnoreCase("true")) {
+                this.jspWhiteSpaceTrimming  = true;
+            } else if (jspWhiteSpaceTrim.equalsIgnoreCase("false")) {
+                this.jspWhiteSpaceTrimming  = false;
+            } else {
+                if (log.isWarnEnabled()) {
+                    log.warn(Localizer.getMessage("jsp.warning.jspWhiteSpaceTrimming"));
                 }
             }
         }

--- a/java/org/apache/jasper/JspC.java
+++ b/java/org/apache/jasper/JspC.java
@@ -137,6 +137,7 @@ public class JspC extends Task implements Options {
     protected static final String SWITCH_POOLING = "-poolingEnabled";
     protected static final String SWITCH_ENCODING = "-javaEncoding";
     protected static final String SWITCH_SMAP = "-smap";
+    protected static final String JSP_WHITE_SPACE_TRIM = "-jspWhiteSpaceTrimming";
     protected static final String SWITCH_DUMP_SMAP = "-dumpsmap";
     protected static final String SWITCH_VALIDATE_TLD = "-validateTld";
     protected static final String SWITCH_VALIDATE_XML = "-validateXml";
@@ -195,6 +196,7 @@ public class JspC extends Task implements Options {
     protected boolean compile = false;
     protected boolean failFast = false;
     protected boolean smapSuppressed = true;
+    protected boolean jspWhiteSpaceTrimming = false;
     protected boolean smapDumped = false;
     protected boolean caching = true;
     protected final Map<String, TagLibraryInfo> cache = new HashMap<>();
@@ -410,6 +412,8 @@ public class JspC extends Task implements Options {
                 smapSuppressed = false;
             } else if (tok.equals(SWITCH_DUMP_SMAP)) {
                 smapDumped = true;
+            } else if (tok.equals(JSP_WHITE_SPACE_TRIM)) {
+                setJSPWhiteSpaceTrimming(true);
             } else if (tok.equals(SWITCH_VALIDATE_TLD)) {
                 setValidateTld(true);
             } else if (tok.equals(SWITCH_VALIDATE_XML)) {
@@ -581,6 +585,16 @@ public class JspC extends Task implements Options {
     public boolean getClassDebugInfo() {
         // compile with debug info
         return classDebugInfo;
+    }
+
+    /**
+     * It returns the value of jspWhiteSpaceTrimming Flag.
+     * @return boolean flag value
+     */
+    @Override
+    public boolean getJSPWhiteSpaceTrimFlag() {
+        // return boolean flag
+        return this.jspWhiteSpaceTrimming;
     }
 
     /**
@@ -939,6 +953,11 @@ public class JspC extends Task implements Options {
 
     public void setValidateTld( boolean b ) {
         this.validateTld = b;
+    }
+
+
+    public void setJSPWhiteSpaceTrimming( boolean b ) {
+        this.jspWhiteSpaceTrimming = b;
     }
 
     public boolean isValidateTld() {

--- a/java/org/apache/jasper/Options.java
+++ b/java/org/apache/jasper/Options.java
@@ -48,6 +48,14 @@ public interface Options {
     public boolean getKeepGenerated();
 
     /**
+     * Returns the value of jspWhiteSpaceTrimming Flag - if set, it allows the removal of
+     * extra white spaces from the JSP files
+     * @return <code>true</code> if jspWhiteSpaceTrimming is set,
+     * <code>false</code> otherwise.
+     */
+    public boolean getJSPWhiteSpaceTrimFlag();
+
+    /**
      * @return <code>true</code> if tag handler pooling is enabled,
      *  <code>false</code> otherwise.
      */

--- a/java/org/apache/jasper/compiler/Compiler.java
+++ b/java/org/apache/jasper/compiler/Compiler.java
@@ -316,7 +316,13 @@ public abstract class Compiler {
                     javaEncoding);
         }
 
-        writer = new ServletWriter(new PrintWriter(osw));
+        if ((ctxt!=null) &&
+            ctxt.getOptions().getJSPWhiteSpaceTrimFlag()) {
+            writer = new NewlineReductionServletWriter(new PrintWriter(osw));
+        } else {
+            writer = new ServletWriter(new PrintWriter(osw));
+        }
+
         ctxt.setWriter(writer);
         return writer;
     }

--- a/java/org/apache/jasper/compiler/NewlineReductionServletWriter.java
+++ b/java/org/apache/jasper/compiler/NewlineReductionServletWriter.java
@@ -1,0 +1,41 @@
+package org.apache.jasper.compiler;
+
+import java.io.PrintWriter;
+
+/**
+ * This class filters duplicate newlines instructions from the compiler output,
+ * and therefore from the runtime JSP. The duplicates typically happen because
+ * the compiler has multiple branches that write them, but they operate
+ * independently and don't realize that the previous output was identical.
+ *
+ * Removing these lines makes the JSP more efficient by executing fewer operations during runtime.
+ *
+ * @author Engebretson, John
+ * @author Kamnani, Jatin
+ *
+ */
+public class NewlineReductionServletWriter extends ServletWriter {
+    private static final String NEWLINE_WRITE_TEXT = "out.write('\\n');";
+
+    private boolean lastWriteWasNewline;
+
+    public NewlineReductionServletWriter(PrintWriter writer) {
+        super(writer);
+    }
+
+    @Override
+    public void printil(String s) {
+        if (s.equals(NEWLINE_WRITE_TEXT)) {
+            if (lastWriteWasNewline) {
+                // do nothing
+                return;
+            } else {
+                lastWriteWasNewline = true;
+            }
+        } else {
+            lastWriteWasNewline = false;
+        }
+        super.printil(s);
+    }
+
+}

--- a/java/org/apache/jasper/resources/LocalStrings.properties
+++ b/java/org/apache/jasper/resources/LocalStrings.properties
@@ -273,6 +273,7 @@ jsp.tldCache.tldInJar=TLD files were found in JAR [{0}].
 jsp.tldCache.tldInResourcePath=TLD files were found in resource path [{0}].
 jsp.warning.bad.urlpattern.propertygroup=Bad value [{0}] in the url-pattern subelement in web.xml
 jsp.warning.checkInterval=Warning: Invalid value for the initParam checkInterval. Will use the default value of "300" seconds
+jsp.warning.jspWhiteSpaceTrimming=Warning: Invalid value for initParam jspWhiteSpaceTrimming. Will use the default value of "false"
 jsp.warning.classDebugInfo=Warning: Invalid value for the initParam classdebuginfo. Will use the default value of "false"
 jsp.warning.classpathUrl=Invalid URL found in class path. This URL will be ignored
 jsp.warning.compiler.classfile.delete.fail=Failed to delete generated class file [{0}]

--- a/java/org/apache/jasper/resources/LocalStrings_es.properties
+++ b/java/org/apache/jasper/resources/LocalStrings_es.properties
@@ -235,6 +235,7 @@ jsp.tldCache.noTldSummary=Al menos un JAR, que se ha explorado buscando TLDs, a�
 jsp.tldCache.tldInDir=Se encontraron archivos TLD en el directorio [{0}].\n
 jsp.warning.bad.urlpattern.propertygroup=Valor malo [{0}] en el subelemento url-pattern en web.xml
 jsp.warning.checkInterval=Aviso: valor incorrecto para el initParam checkInterval. Se usará el valor por defecto de "300" segundos
+jsp.warning.jspWhiteSpaceTrimming=Aviso: valor no válido para initParam jspWhiteSpaceTrimming. Utilizará el valor predeterminado de "false"
 jsp.warning.classDebugInfo=Aviso: valor incorrecto para el initParam classdebuginfo. Se usará el valor por defecto de "false"
 jsp.warning.compiler.classfile.delete.fail=No pude borrar el fichero generado de clase [{0}]
 jsp.warning.compiler.classfile.delete.fail.unknown=No pude borrar los ficheros generados de clase

--- a/java/org/apache/jasper/resources/LocalStrings_fr.properties
+++ b/java/org/apache/jasper/resources/LocalStrings_fr.properties
@@ -273,6 +273,7 @@ jsp.tldCache.tldInJar=Des TLDs ont été trouvée dans le JAR [{0}]
 jsp.tldCache.tldInResourcePath=Des fichiers TLD ont été trouvé dans le chemin de ressources [{0}]
 jsp.warning.bad.urlpattern.propertygroup=Mauvaise valeur [{0}] dans le sous-élément (subelement) url-pattern du fichier web.xml
 jsp.warning.checkInterval=WARNING : Valeur incorrecte pour le initParam checkInterval. Utilisation de la valeur par défaut "300" secondes
+jsp.warning.jspWhiteSpaceTrimming=WARNING: valeur non valide pour initParam jspWhiteSpaceTrimming. Utilisera la valeur par défaut "false
 jsp.warning.classDebugInfo=WARNING : Valeur incorrecte pour le initParam classdebuginfo. Utilisation de la valeur par défaut "false"
 jsp.warning.classpathUrl=Une URL invalide a été trouvée dans le chemin des classes, elle sera ignorée
 jsp.warning.compiler.classfile.delete.fail=Impossible d''effacer le fichier classe généré [{0}]

--- a/java/org/apache/jasper/resources/LocalStrings_ja.properties
+++ b/java/org/apache/jasper/resources/LocalStrings_ja.properties
@@ -274,6 +274,7 @@ jsp.tldCache.tldInJar=JAR ファイル [{0}] の内部に TLD ファイルを発
 jsp.tldCache.tldInResourcePath=リソースパス[{0}]にTLDファイルが見つかりました。
 jsp.warning.bad.urlpattern.propertygroup=web.xml中のurl-pattern副要素中に誤った値 [{0}] があります
 jsp.warning.checkInterval=警告: initParam checkIntervalの値は無効です。既定値 "300" 秒が使用されます
+jsp.warning.jspWhiteSpaceTrimming=警告: initParam jspWhiteSpaceTrimmingの値が無効です。デフォルト値「false」を使用します
 jsp.warning.classDebugInfo=警告: initParam の classDebugInfo の値は無効です。既定値 "false" が使用されます
 jsp.warning.classpathUrl=クラスパスに無効なURLが見つかりました。 このURLは無視されます。
 jsp.warning.compiler.classfile.delete.fail=生成されたクラスファイル[{0}]を削除できませんでした

--- a/java/org/apache/jasper/resources/LocalStrings_ko.properties
+++ b/java/org/apache/jasper/resources/LocalStrings_ko.properties
@@ -272,6 +272,7 @@ jsp.tldCache.tldInJar=JAR [{0}] 내에서 TLD 파일들을 찾지 못했습니�
 jsp.tldCache.tldInResourcePath=리소스 경로 [{0}]에서 TLD 파일들이 발견되었습니다.
 jsp.warning.bad.urlpattern.propertygroup=web.xml 내 url-pattern 하위 엘리먼트에 잘못된 값: [{0}]
 jsp.warning.checkInterval=경고: initParam인 checkInterval에 유효하지 않은 값. 기본 값인 "300" 초를 사용할 것입니다.
+jsp.warning.jspWhiteSpaceTrimming=경고 : initParam jspWhiteSpaceTrimming의 값이 잘못되었습니다. 기본값 인 "false"를 사용합니다.
 jsp.warning.classDebugInfo=경고: initParam인 classdebuginfo에 유효하지 않은 값. 기본 값인 "false"를 사용할 것입니다.
 jsp.warning.classpathUrl=클래스패스 내에 유효하지 않은 URL이 발견됨. 이 URL은 무시될 것입니다.
 jsp.warning.compiler.classfile.delete.fail=생성된 클래스 파일 [{0}]을(를) 삭제하지 못했습니다.

--- a/java/org/apache/jasper/resources/LocalStrings_zh_CN.properties
+++ b/java/org/apache/jasper/resources/LocalStrings_zh_CN.properties
@@ -272,6 +272,7 @@ jsp.tldCache.tldInJar=在JAR[{0}]中找到了TLD文件。
 jsp.tldCache.tldInResourcePath=在资源路径{0}中找到TLD文件。
 jsp.warning.bad.urlpattern.propertygroup=web.xml中url模式子元素中的值[{0}]错误
 jsp.warning.checkInterval=警告：initParam checkInterval的值无效。将使用默认值“300”秒
+jsp.warning.jspWhiteSpaceTrimming=警告：initParam jspWhiteSpaceTrimming的值无效。将使用默认值“ false”
 jsp.warning.classDebugInfo=警告：initParam classdebuginfo的值无效。将使用默认值“false”
 jsp.warning.classpathUrl=在类路径中找到无效的URL。此URL将被忽略
 jsp.warning.compiler.classfile.delete.fail=未能删除生成的类文件[{0}]

--- a/test/org/apache/jasper/compiler/TestGenerator.java
+++ b/test/org/apache/jasper/compiler/TestGenerator.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.startup.TomcatBaseTest;
 import org.apache.tomcat.util.buf.ByteChunk;
+import java.util.Scanner;
 
 public class TestGenerator extends TomcatBaseTest {
 
@@ -284,5 +285,22 @@ public class TestGenerator extends TomcatBaseTest {
         String result = res.toString();
         System.out.println(result);
         assertEcho(result, "ASYNC");
+    }
+
+    @Test
+    public void testJSPWhiteSpaceTrimming() throws Exception {
+        getTomcatInstanceTestWebapp(false, true);
+
+        ByteChunk res = getUrl("http://localhost:" + getPort() + "/test/jsp/whiteSpaceTrim.jsp");
+
+        String result = res.toString();
+        Scanner scanner = new Scanner(result);
+        while (scanner.hasNextLine()) {
+            String line = scanner.nextLine();
+            if(line.length()==0){
+                Assert.fail("JSP Optimisation does not allow the line to be just a new line character");
+            }
+        }
+        scanner.close();
     }
 }

--- a/test/webapp/WEB-INF/web.xml
+++ b/test/webapp/WEB-INF/web.xml
@@ -100,6 +100,14 @@
       org.apache.catalina.core.TestStandardContext$Bug49922TargetServlet
     </servlet-class>
   </servlet>
+  <servlet>
+    <servlet-name>whiteSpaceTrim</servlet-name>
+    <jsp-file>/jsp/whiteSpaceTrim.jsp</jsp-file>
+    <init-param>
+      <param-name>jspWhiteSpaceTrimming</param-name>
+      <param-value>true</param-value>
+    </init-param>
+  </servlet>
   <servlet-mapping>
     <servlet-name>Bug49922Target</servlet-name>
     <url-pattern>/bug49922/target</url-pattern>

--- a/test/webapp/jsp/whiteSpaceTrim.jsp
+++ b/test/webapp/jsp/whiteSpaceTrim.jsp
@@ -1,0 +1,31 @@
+<!doctype html>
+<html>
+<head>
+    <title>Apache Tomcat JSP White Space Trim Optimisation Configuration</title>
+</head>
+<body>
+
+
+
+<h4>Apache Tomcat JSP white space trim test page</h4>
+<p>If the value of init param jspWhiteSpaceTrimming is set to true, the compiler trims all the excess white spaces and empty line characters from the JSP files & thus reduces build size.</p>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</body>
+</html>


### PR DESCRIPTION
This is a redo of Previous CR : https://github.com/apache/tomcat/pull/331

These changes enable the compiler to remove excess white space from the JSP files & thus reduce the JVM metadata 
_(Constant whitespace in a JSP is passed unchanged to the client browser (indentations, newlines, etc.).  This results in bloated constant strings, and general waste in I/O operations. Trimming this whitespace results in smaller constants)._

This can be controlled by providing context init params inside web.xml file. Example attached.

Based on your previous suggestions the following changes have been made:
1) Pre tags will be left untouched - to protect the behavioral changes on that tag.
2) By default this remains false, and thus will not affect any other supporting feature (SMAP for instance as suggested in previous CR) .
3) The flag is now initialized as a JSP init param as mentioned in the example below. 
4) PR is against master. 

Apologies in case something is missed out. 

If any official documentation is required, can you attach the links on the PR?
