### PR TITLE
Optimizing Resource Lookup using  Bloom Filter

### DIFF
--- a/java/org/apache/catalina/Host.java
+++ b/java/org/apache/catalina/Host.java
@@ -128,6 +128,18 @@ public interface Host extends Container {
      */
     public void setAutoDeploy(boolean autoDeploy);
 
+    /**
+     * @return the value of the fast class path scan flag.  If true, it enables
+     * this bloom filter approach while finding the resources.
+     */
+    public boolean getFastClasspathScanning();
+
+    /**
+     * Set the fast class path scan flag value for this host.
+     *
+     * @param fastClasspathScanning The new fast class path scan flag
+     */
+    public void setFastClasspathScanning(boolean fastClasspathScanning);
 
     /**
      * @return the Java class name of the context configuration class

--- a/java/org/apache/catalina/core/StandardHost.java
+++ b/java/org/apache/catalina/core/StandardHost.java
@@ -105,6 +105,10 @@ public class StandardHost extends ContainerBase implements Host {
      */
     private boolean autoDeploy = true;
 
+    /**
+     * The fast classpath scan flag for this Host.
+     */
+    private boolean fastClasspathScanning = false;
 
     /**
      * The Java class name of the default context configuration class
@@ -348,6 +352,15 @@ public class StandardHost extends ContainerBase implements Host {
         return this.autoDeploy;
     }
 
+    /**
+     * @return the value of the fast classpath scan flag.  If true, it
+     * indicates that this host's resource lookup will use the
+     * Bloom Filter Approach.
+     */
+    @Override
+    public boolean getFastClasspathScanning() {
+        return this.fastClasspathScanning;
+    }
 
     /**
      * Set the auto deploy flag value for this host.
@@ -361,6 +374,21 @@ public class StandardHost extends ContainerBase implements Host {
         this.autoDeploy = autoDeploy;
         support.firePropertyChange("autoDeploy", oldAutoDeploy,
                                    this.autoDeploy);
+
+    }
+
+    /**
+     * Set the Fast Classpath Scanning flag value for this host.
+     *
+     * @param fastClasspathScanning The new fastClasspathScanning flag
+     */
+    @Override
+    public void setFastClasspathScanning(boolean fastClasspathScanning) {
+
+        boolean oldFastClasspathScanning = this.fastClasspathScanning;
+        this.fastClasspathScanning = fastClasspathScanning;
+        support.firePropertyChange("fastClasspathScanning", oldFastClasspathScanning,
+                this.fastClasspathScanning);
 
     }
 

--- a/java/org/apache/catalina/core/mbeans-descriptors.xml
+++ b/java/org/apache/catalina/core/mbeans-descriptors.xml
@@ -1077,6 +1077,10 @@
                description="The auto deploy flag for this Host"
                type="boolean"/>
 
+    <attribute name="fastClasspathScanning"
+               description="The fast class path scanning flag for this Host"
+               type="boolean"/>
+
     <attribute name="backgroundProcessorDelay"
                description="The processor delay for this component."
                type="int"/>

--- a/java/org/apache/catalina/manager/host/HostManagerServlet.java
+++ b/java/org/apache/catalina/manager/host/HostManagerServlet.java
@@ -253,12 +253,14 @@ public class HostManagerServlet
         String appBase = request.getParameter("appBase");
         boolean manager = booleanParameter(request, "manager", false, htmlMode);
         boolean autoDeploy = booleanParameter(request, "autoDeploy", true, htmlMode);
+        boolean fastClasspathScanning = booleanParameter(request, "fastClasspathScanning", false, htmlMode);
         boolean deployOnStartup = booleanParameter(request, "deployOnStartup", true, htmlMode);
         boolean deployXML = booleanParameter(request, "deployXML", true, htmlMode);
         boolean unpackWARs = booleanParameter(request, "unpackWARs", true, htmlMode);
         boolean copyXML = booleanParameter(request, "copyXML", false, htmlMode);
         add(writer, name, aliases, appBase, manager,
             autoDeploy,
+            fastClasspathScanning,
             deployOnStartup,
             deployXML,
             unpackWARs,
@@ -332,6 +334,7 @@ public class HostManagerServlet
      * @param autoDeploy Flag value
      * @param deployOnStartup Flag value
      * @param deployXML Flag value
+     * @param fastClasspathScanning Flag value
      * @param unpackWARs Flag value
      * @param copyXML Flag value
      * @param smClient StringManager for the client's locale
@@ -340,6 +343,7 @@ public class HostManagerServlet
         (PrintWriter writer, String name, String aliases, String appBase,
          boolean manager,
          boolean autoDeploy,
+         boolean fastClasspathScanning,
          boolean deployOnStartup,
          boolean deployXML,
          boolean unpackWARs,
@@ -418,6 +422,7 @@ public class HostManagerServlet
             }
         }
         host.setAutoDeploy(autoDeploy);
+        host.setFastClasspathScanning(fastClasspathScanning);
         host.setDeployOnStartup(deployOnStartup);
         host.setDeployXML(deployXML);
         host.setUnpackWARs(unpackWARs);

--- a/java/org/apache/catalina/mbeans/MBeanFactory.java
+++ b/java/org/apache/catalina/mbeans/MBeanFactory.java
@@ -480,6 +480,7 @@ public class MBeanFactory {
      * @param name Unique name of this Host
      * @param appBase Application base directory name
      * @param autoDeploy Should we auto deploy?
+     * @param fastClasspathScanning Should we use Fast class path scanning approach
      * @param deployOnStartup Deploy on server startup?
      * @param deployXML Should we deploy Context XML config files property?
      * @param unpackWARs Should we unpack WARs when auto deploying?
@@ -490,6 +491,7 @@ public class MBeanFactory {
     public String createStandardHost(String parent, String name,
                                      String appBase,
                                      boolean autoDeploy,
+                                     boolean fastClasspathScanning,
                                      boolean deployOnStartup,
                                      boolean deployXML,
                                      boolean unpackWARs)
@@ -500,6 +502,7 @@ public class MBeanFactory {
         host.setName(name);
         host.setAppBase(appBase);
         host.setAutoDeploy(autoDeploy);
+        host.setFastClasspathScanning(fastClasspathScanning);
         host.setDeployOnStartup(deployOnStartup);
         host.setDeployXML(deployXML);
         host.setUnpackWARs(unpackWARs);

--- a/java/org/apache/catalina/mbeans/mbeans-descriptors.xml
+++ b/java/org/apache/catalina/mbeans/mbeans-descriptors.xml
@@ -190,6 +190,9 @@
       <parameter name="autoDeploy"
           description="The auto deploy flag for this Host"
                type="boolean"/>
+      <parameter name="fastClasspathScanning"
+                 description="The fast class path scanning flag for this Host"
+                 type="boolean"/>
       <parameter name="deployOnStartup"
           description="The deploy on startup flag for this Host"
                type="boolean"/>

--- a/java/org/apache/catalina/startup/HostConfig.java
+++ b/java/org/apache/catalina/startup/HostConfig.java
@@ -121,6 +121,11 @@ public class HostConfig implements LifecycleListener {
      */
     protected boolean deployXML = false;
 
+    /**
+     * Should we use Bloom Filter While looking up Resources in JAR Files?
+     */
+    protected boolean fastClasspathScanning = false;
+
 
     /**
      * Should XML files be copied to
@@ -274,6 +279,14 @@ public class HostConfig implements LifecycleListener {
         this.unpackWARs = unpackWARs;
     }
 
+    /**
+     * Set the FastClasspathScanning flag.
+     *
+     * @param fastClasspathScanning The new fast class path scanning flag
+     */
+    public void setFastClasspathScanning(boolean fastClasspathScanning) {
+        this.fastClasspathScanning = fastClasspathScanning;
+    }
 
     // --------------------------------------------------------- Public Methods
 
@@ -292,6 +305,7 @@ public class HostConfig implements LifecycleListener {
             if (host instanceof StandardHost) {
                 setCopyXML(((StandardHost) host).isCopyXML());
                 setDeployXML(((StandardHost) host).isDeployXML());
+                setFastClasspathScanning(((StandardHost) host).getFastClasspathScanning());
                 setUnpackWARs(((StandardHost) host).isUnpackWARs());
                 setContextClass(((StandardHost) host).getContextClass());
             }

--- a/java/org/apache/catalina/webresources/JarContents.java
+++ b/java/org/apache/catalina/webresources/JarContents.java
@@ -1,0 +1,119 @@
+package org.apache.catalina.webresources;
+
+import java.util.BitSet;
+import java.util.Enumeration;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+/**
+ * This class represents the contents of a jar by determining whether a given
+ * resource <b>might</b> be in the cache, based on a bloom filter. This is not a
+ * general-purpose bloom filter because it contains logic to strip out
+ * characters from the beginning of the key.
+ *
+ * The hash methods are simple but good enough for this purpose.
+ */
+public final class JarContents {
+    private final BitSet bits1;
+    private final BitSet bits2;
+    /**
+     * Constant used by a typical hashing method.
+     */
+    private static final int HASH_PRIME_1 = 31;
+
+    /**
+     * Constant used by a typical hashing method.
+     */
+    private static final int HASH_PRIME_2 = 17;
+
+    /**
+     * Size of the fixed-length bit table. Larger reduces false positives,
+     * smaller saves memory.
+     */
+    private static final int TABLE_SIZE = 2048;
+
+    /**
+     * Parses the passed-in jar and populates the bit array.
+     *
+     * @param jar
+     */
+    public JarContents(JarFile jar) {
+        Enumeration<JarEntry> entries = jar.entries();
+        bits1 = new BitSet(TABLE_SIZE);
+        bits2 = new BitSet(TABLE_SIZE);
+
+        // Enumerations. When will they update this API?!
+        while (entries.hasMoreElements()) {
+            JarEntry entry = entries.nextElement();
+            String name = entry.getName();
+            int startPos = 0;
+
+            // If the path starts with a slash, that's not useful information.
+            // Skipping it increases the significance of our key by
+            // removing an insignificant character.
+            boolean precedingSlash = name.charAt(0) == '/';
+            if (precedingSlash) {
+                startPos = 1;
+            }
+
+            // Find the correct table slot
+            int pathHash1 = hashcode(name, startPos, HASH_PRIME_1);
+            int pathHash2 = hashcode(name, startPos, HASH_PRIME_2);
+
+            bits1.set(pathHash1 % TABLE_SIZE);
+            bits2.set(pathHash2 % TABLE_SIZE);
+        }
+    }
+
+    /**
+     * Simple hashcode of a portion of the string. Typically we would use
+     * substring, but memory and runtime speed are critical.
+     *
+     * @param content
+     *            Wrapping String.
+     * @param startPos
+     *            First character in the range.
+     * @return hashcode of the range.
+     */
+    private int hashcode(String content, int startPos, int hashPrime) {
+        int h = hashPrime/2;
+        int contentLength = content.length();
+        for (int i = startPos; i < contentLength; i++) {
+            h = hashPrime * h + content.charAt(i);
+        }
+
+        if (h < 0) {
+            h = h * -1;
+        }
+        return h;
+    }
+
+
+    /**
+     * Method that identifies whether a given path <b>MIGHT</b> be in this jar.
+     * Uses the Bloom filter mechanism.
+     *
+     * @param path
+     *            Requested path. Sometimes starts with "/WEB-INF/classes".
+     * @param webappRoot
+     *            The value of the webapp location, which can be stripped from
+     *            the path. Typically is "/WEB-INF/classes".
+     * @return Whether the prefix of the path is known to be in this jar.
+     */
+    public final boolean mightContainResource(String path, String webappRoot) {
+        int startPos = 0;
+        if (path.startsWith(webappRoot)) {
+            startPos = webappRoot.length();
+        }
+
+        if (path.charAt(startPos) == '/') {
+            // ignore leading slash
+            startPos++;
+        }
+
+        // calculate the hash lazyly and return a boolean value for this path
+        return (bits1.get(hashcode(path, startPos, HASH_PRIME_1) % TABLE_SIZE) &&
+                bits2.get(hashcode(path, startPos, HASH_PRIME_2) % TABLE_SIZE));
+    }
+
+}

--- a/java/org/apache/catalina/webresources/LocalStrings.properties
+++ b/java/org/apache/catalina/webresources/LocalStrings.properties
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 abstractArchiveResourceSet.setReadOnlyFalse=Archive based WebResourceSets such as those based on JARs are hard-coded to be read-only and may not be configured to be read-write
-
+abstractArchiveResourceSet.jarContentWarning=Warning: Exception occurred in class path scanning 
 abstractResource.getContentFail=Unable to return [{0}] as a byte array
 abstractResource.getContentTooLarge=Unable to return [{0}] as a byte array since the resource is [{1}] bytes in size which is larger than the maximum size of a byte array
 

--- a/test/org/apache/catalina/webresources/TestJarContents.java
+++ b/test/org/apache/catalina/webresources/TestJarContents.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.catalina.webresources;
+
+import java.io.File;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.BeforeClass;
+import java.util.jar.JarFile;
+
+import org.apache.catalina.WebResourceSet;
+
+/**
+ * @author Kamnani, Jatin
+ */
+public class TestJarContents {
+
+    private static File empty;
+    private static File jar;
+    private static TesterWebResourceRoot root;
+    private static WebResourceSet webResourceSet;
+    private static JarResourceSet test;
+    private static JarContents testJarContentsObject;
+
+    @BeforeClass
+    public static void setup() {
+        try {
+        empty = new File("test/webresources/dir3");
+        jar = new File("test/webresources/dir1.jar");
+
+        root = new TesterWebResourceRoot();
+
+        // Use empty dir for root of web app.
+        webResourceSet = new DirResourceSet(root, "/", empty.getAbsolutePath(), "/");
+        root.setMainResources(webResourceSet);
+
+        // If this JAR was in a web application, this is equivalent to how it
+        // would be added
+        test = new JarResourceSet(root, "/", jar.getAbsolutePath(), "/META-INF/resources");
+        test.setStaticOnly(true);
+        root.addJarResources(test);
+
+        testJarContentsObject = new JarContents(new JarFile("test/webresources/dir1.jar"));
+
+        } catch (Exception e) {
+            Assert.fail("Error happened while testing JarContents, " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testMightContainResource() {
+        Assert.assertTrue(testJarContentsObject.mightContainResource(
+                "/d1/d1-f1.txt", jar.getAbsolutePath()));
+
+        Assert.assertTrue(testJarContentsObject.mightContainResource(
+                "d1/d1-f1.txt", jar.getAbsolutePath()));
+
+        Assert.assertFalse(testJarContentsObject.mightContainResource(
+                "/d7/d1-f1.txt", jar.getAbsolutePath()));
+
+        Assert.assertFalse(testJarContentsObject.mightContainResource(
+                "/", jar.getAbsolutePath()));
+
+        Assert.assertFalse(testJarContentsObject.mightContainResource(
+                "/////", jar.getAbsolutePath()));
+
+    }
+
+    @Test(expected = StringIndexOutOfBoundsException.class)
+    public void testStringOutOfBoundExceptions() {
+        testJarContentsObject.mightContainResource("", jar.getAbsolutePath());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNullPointerExceptions() {
+        testJarContentsObject.mightContainResource(null, jar.getAbsolutePath());
+    }
+}

--- a/test/org/apache/tomcat/unittest/TesterHost.java
+++ b/test/org/apache/tomcat/unittest/TesterHost.java
@@ -301,6 +301,16 @@ public class TesterHost implements Host {
     }
 
     @Override
+    public boolean getFastClasspathScanning() {
+        return false;
+    }
+
+    @Override
+    public void setFastClasspathScanning(boolean fastClasspathScanning) {
+        // NO-OP
+    }
+
+    @Override
     public String getConfigClass() {
         return null;
     }


### PR DESCRIPTION
This is a redo of Previous PR: https://github.com/apache/tomcat/pull/348

The following changes have been made based on the suggestions earlier: 
1) Flag can be passed through Host Configuration. By default it remains false and Tomcat's default behavior will be untouched. See example below. 
2) Jar Contents will be refreshed every 60 seconds if corresponding jar file has been modified.  
3) PR is against master. 

Apologies in case something is missed. 

Example on Bloom Filter : https://llimllib.github.io/bloomfilter-tutorial/#:~:text=A%20Bloom%20filter%20is%20a,may%20be%20in%20the%20set.

```
<Host name="localhost"  appBase="webapps"
            unpackWARs="true" autoDeploy="true" fastClasspathScanning="true">