### PR TITLE
Optimize Server startup time using multi-threading for annotation scanning

### DIFF
--- a/java/org/apache/catalina/Host.java
+++ b/java/org/apache/catalina/Host.java
@@ -114,6 +114,21 @@ public interface Host extends Container {
 
 
     /**
+     * @return the value of the parallel annotation scanning flag.  If true,
+     * it enables multithreading while annotation scanning, with default
+     * thread as 1.
+     */
+    public boolean isParallelAnnotationScanning();
+
+    /**
+     * Set the parallel annotation scanning value for this host.
+     *
+     * @param parallelAnnotationScanning new parallel annotation scanning flag
+     */
+    public void setParallelAnnotationScanning(boolean parallelAnnotationScanning);
+
+
+    /**
      * @return the value of the auto deploy flag.  If true, it indicates that
      * this host's child webapps should be discovered and automatically
      * deployed dynamically.

--- a/java/org/apache/catalina/core/StandardHost.java
+++ b/java/org/apache/catalina/core/StandardHost.java
@@ -91,6 +91,13 @@ public class StandardHost extends ContainerBase implements Host {
     private volatile File appBaseFile = null;
 
     /**
+     * parallelAnnotationScanning for this Host.
+     * Allows Multithreading to be enabled for annotation scanning.
+     */
+    private boolean parallelAnnotationScanning = false;
+
+
+    /**
      * The XML root for this Host.
      */
     private String xmlBase = null;
@@ -366,12 +373,38 @@ public class StandardHost extends ContainerBase implements Host {
 
 
     /**
+     * Set the parallel annotation scanning flag.
+     *
+     * @param parallelAnnotationScanning
+     */
+    @Override
+    public void setParallelAnnotationScanning(boolean parallelAnnotationScanning) {
+
+        boolean oldParallelAnnotationScanning = this.parallelAnnotationScanning;
+        this.parallelAnnotationScanning = parallelAnnotationScanning;
+        support.firePropertyChange("parallelAnnotationScanning", parallelAnnotationScanning,
+                this.parallelAnnotationScanning);
+
+    }
+
+
+    /**
      * @return the Java class name of the context configuration class
      * for new web applications.
      */
     @Override
     public String getConfigClass() {
         return this.configClass;
+    }
+
+
+    /**
+     * @return the value of the parallel annotation scanning flag.
+     *  If true, it enables multithreading with one default thread.
+     */
+    @Override
+    public boolean isParallelAnnotationScanning() {
+        return this.parallelAnnotationScanning;
     }
 
 

--- a/java/org/apache/catalina/core/mbeans-descriptors.xml
+++ b/java/org/apache/catalina/core/mbeans-descriptors.xml
@@ -1077,6 +1077,10 @@
                description="The auto deploy flag for this Host"
                type="boolean"/>
 
+    <attribute name="parallelAnnotationScanning"
+               description="The parallel annotation scanning flag for this Host"
+               type="boolean"/>
+
     <attribute name="backgroundProcessorDelay"
                description="The processor delay for this component."
                type="int"/>

--- a/java/org/apache/catalina/manager/host/HostManagerServlet.java
+++ b/java/org/apache/catalina/manager/host/HostManagerServlet.java
@@ -94,6 +94,7 @@ public class HostManagerServlet
 
     private static final long serialVersionUID = 1L;
 
+
     // ----------------------------------------------------- Instance Variables
 
 
@@ -253,12 +254,14 @@ public class HostManagerServlet
         String appBase = request.getParameter("appBase");
         boolean manager = booleanParameter(request, "manager", false, htmlMode);
         boolean autoDeploy = booleanParameter(request, "autoDeploy", true, htmlMode);
+        boolean parallelAnnotationScanning = booleanParameter(request, "parallelAnnotationScanning", false, htmlMode);
         boolean deployOnStartup = booleanParameter(request, "deployOnStartup", true, htmlMode);
         boolean deployXML = booleanParameter(request, "deployXML", true, htmlMode);
         boolean unpackWARs = booleanParameter(request, "unpackWARs", true, htmlMode);
         boolean copyXML = booleanParameter(request, "copyXML", false, htmlMode);
         add(writer, name, aliases, appBase, manager,
             autoDeploy,
+            parallelAnnotationScanning,
             deployOnStartup,
             deployXML,
             unpackWARs,
@@ -330,6 +333,7 @@ public class HostManagerServlet
      * @param appBase application base for the host
      * @param manager should the manager webapp be deployed to the new host ?
      * @param autoDeploy Flag value
+     * @param parallelAnnotationScanning Flag value
      * @param deployOnStartup Flag value
      * @param deployXML Flag value
      * @param unpackWARs Flag value
@@ -340,6 +344,7 @@ public class HostManagerServlet
         (PrintWriter writer, String name, String aliases, String appBase,
          boolean manager,
          boolean autoDeploy,
+         boolean parallelAnnotationScanning,
          boolean deployOnStartup,
          boolean deployXML,
          boolean unpackWARs,
@@ -418,6 +423,7 @@ public class HostManagerServlet
             }
         }
         host.setAutoDeploy(autoDeploy);
+        host.setParallelAnnotationScanning(parallelAnnotationScanning);
         host.setDeployOnStartup(deployOnStartup);
         host.setDeployXML(deployXML);
         host.setUnpackWARs(unpackWARs);

--- a/java/org/apache/catalina/startup/HostConfig.java
+++ b/java/org/apache/catalina/startup/HostConfig.java
@@ -131,6 +131,12 @@ public class HostConfig implements LifecycleListener {
 
 
     /**
+     * Should we use multi threading fpr annotation scanning
+     */
+    protected boolean parallelAnnotationScanning = false;
+
+
+    /**
      * Should we unpack WAR files when auto-deploying applications in the
      * <code>appBase</code> directory?
      */
@@ -275,6 +281,16 @@ public class HostConfig implements LifecycleListener {
     }
 
 
+    /**
+     * Set the parallel annotation scanning flag.
+     *
+     * @param parallelAnnotationScanning
+     */
+    public void setParallelAnnotationScanning(boolean parallelAnnotationScanning) {
+        this.parallelAnnotationScanning = parallelAnnotationScanning;
+    }
+
+
     // --------------------------------------------------------- Public Methods
 
 
@@ -292,6 +308,7 @@ public class HostConfig implements LifecycleListener {
             if (host instanceof StandardHost) {
                 setCopyXML(((StandardHost) host).isCopyXML());
                 setDeployXML(((StandardHost) host).isDeployXML());
+                setParallelAnnotationScanning(((StandardHost) host).isParallelAnnotationScanning());
                 setUnpackWARs(((StandardHost) host).isUnpackWARs());
                 setContextClass(((StandardHost) host).getContextClass());
             }

--- a/java/org/apache/catalina/startup/LocalStrings.properties
+++ b/java/org/apache/catalina/startup/LocalStrings.properties
@@ -72,6 +72,7 @@ contextConfig.noAntiLocking=The value [{0}] configured for java.io.tmpdir does n
 contextConfig.processAnnotationsDir.debug=Scanning directory for class files with annotations [{0}]
 contextConfig.processAnnotationsJar.debug=Scanning jar file for class files with annotations [{0}]
 contextConfig.processAnnotationsWebDir.debug=Scanning web application directory for class files with annotations [{0}]
+contextConfig.processAnnotationsInParallelFailure=Parallel execution failed
 contextConfig.resourceJarFail=Failed to process JAR found at URL [{0}] for static resources to be included in context with name [{1}]
 contextConfig.role.auth=Security role name [{0}] used in an <auth-constraint> without being defined in a <security-role>
 contextConfig.role.link=Security role name [{0}] used in a <role-link> without being defined in a <security-role>

--- a/test/org/apache/tomcat/unittest/TesterHost.java
+++ b/test/org/apache/tomcat/unittest/TesterHost.java
@@ -291,6 +291,17 @@ public class TesterHost implements Host {
     }
 
     @Override
+    public boolean isParallelAnnotationScanning() {
+        return false;
+    }
+
+    @Override
+    public void setParallelAnnotationScanning(boolean parallelAnnotationScanning) {
+        // NO-OP
+    }
+
+
+    @Override
     public boolean getAutoDeploy() {
         return false;
     }


### PR DESCRIPTION
This is a redo of Previous PR: https://github.com/apache/tomcat/pull/349

The following changes have been made based on the suggestions earlier: 
1) Flag (parallelAnnotationScanning) can be passed through Host Configuration. See example below. 
2) By default parallelAnnotationScanning remains disabled and thus default tomcat behavior is untouched.
3) Number of threads could be triggered by startStopThreads parameter. 
3) PR is against master. 

Apologies in case something is missed. 

```
<Host name="localhost"  appBase="webapps"
            unpackWARs="true" autoDeploy="true" parallelAnnotationScanning="true" >