### PR TITLE
[perf] Lazy init ELContext#listeners to avoid unnecessary ArrayList and ArrayList$Itr

### DIFF
--- a/java/jakarta/el/ELContext.java
+++ b/java/jakarta/el/ELContext.java
@@ -35,7 +35,7 @@ public abstract class ELContext {
 
     private ImportHandler importHandler = null;
 
-    private List<EvaluationListener> listeners = new ArrayList<>();
+    private List<EvaluationListener> listeners;
 
     private Deque<Map<String,Object>> lambdaArguments = new LinkedList<>();
 
@@ -139,6 +139,10 @@ public abstract class ELContext {
      * @since EL 3.0
      */
     public void addEvaluationListener(EvaluationListener listener) {
+        if (listeners == null) {
+            listeners = new ArrayList<>();
+        }
+
         listeners.add(listener);
     }
 
@@ -150,7 +154,7 @@ public abstract class ELContext {
      * @since EL 3.0
      */
     public List<EvaluationListener> getEvaluationListeners() {
-        return listeners;
+        return listeners == null ? Collections.emptyList() : listeners;
     }
 
     /**
@@ -161,6 +165,10 @@ public abstract class ELContext {
      * @since EL 3.0
      */
     public void notifyBeforeEvaluation(String expression) {
+        if (listeners == null) {
+            return;
+        }
+
         for (EvaluationListener listener : listeners) {
             try {
                 listener.beforeEvaluation(this, expression);
@@ -179,6 +187,10 @@ public abstract class ELContext {
      * @since EL 3.0
      */
     public void notifyAfterEvaluation(String expression) {
+        if (listeners == null) {
+            return;
+        }
+        
         for (EvaluationListener listener : listeners) {
             try {
                 listener.afterEvaluation(this, expression);
@@ -198,6 +210,10 @@ public abstract class ELContext {
      * @since EL 3.0
      */
     public void notifyPropertyResolved(Object base, Object property) {
+        if (listeners == null) {
+            return;
+        }
+
         for (EvaluationListener listener : listeners) {
             try {
                 listener.propertyResolved(this, base, property);

--- a/java/jakarta/el/ELContext.java
+++ b/java/jakarta/el/ELContext.java
@@ -17,6 +17,7 @@
 package jakarta.el;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.LinkedList;


### PR DESCRIPTION
in case of a JSF view, this methods are called quite often and creates ArrayList and ArrayList$Itr instances, also if no listener is added.
This reduces the created objects of a simple view demo view (-54k objects in 400 requests)

We could even improve it a bit by using a index-loop, which also avoids a ArrayList$Itr instance, if listeners are available. Not sure if Tomcat maintainers likes such changes.

It would also be great if you could port it to older branches