### PR TITLE
Fix 64735 ServletContext.addJspFile() always fails with SecurityManager

### DIFF
--- a/java/org/apache/catalina/core/ApplicationContextFacade.java
+++ b/java/org/apache/catalina/core/ApplicationContextFacade.java
@@ -117,6 +117,7 @@ public class ApplicationContextFacade implements ServletContext {
         classCache.put("getAttribute", clazz);
         classCache.put("log", clazz);
         classCache.put("setSessionTrackingModes", new Class[]{Set.class} );
+        classCache.put("addJspFile", new Class[]{String.class, String.class});
     }
 
 


### PR DESCRIPTION
Fix for: https://bz.apache.org/bugzilla/show_bug.cgi?id=64735