### PR TITLE
NIO2: Call `accept` immediately if connection count is not close to max con…

### DIFF
--- a/java/org/apache/tomcat/util/net/Nio2Endpoint.java
+++ b/java/org/apache/tomcat/util/net/Nio2Endpoint.java
@@ -434,7 +434,7 @@ public class Nio2Endpoint extends AbstractJsseEndpoint<Nio2Channel,AsynchronousS
             if (isRunning() && !isPaused()) {
                 if (getMaxConnections() == -1) {
                     serverSock.accept(null, this);
-                } else if (getConnectionCount() < getMaxConnections() - getMaxThreads()) {
+                } else if (getConnectionCount() < getMaxConnections() / 2) {
                     // It is far enough from reaching max connections, so it won't block
                     try {
                         countUpOrAwaitConnection();

--- a/java/org/apache/tomcat/util/net/Nio2Endpoint.java
+++ b/java/org/apache/tomcat/util/net/Nio2Endpoint.java
@@ -434,6 +434,14 @@ public class Nio2Endpoint extends AbstractJsseEndpoint<Nio2Channel,AsynchronousS
             if (isRunning() && !isPaused()) {
                 if (getMaxConnections() == -1) {
                     serverSock.accept(null, this);
+                } else if (getConnectionCount() < getMaxConnections() - getMaxThreads()) {
+                    // It is far enough from reaching max connections, so it won't block
+                    try {
+                        countUpOrAwaitConnection();
+                    } catch (InterruptedException e) {
+                        // Ignore
+                    }
+                    serverSock.accept(null, this);
                 } else {
                     // Accept again on a new thread since countUpOrAwaitConnection may block
                     getExecutor().execute(this);


### PR DESCRIPTION
…nections

Under regular load, we observe NIO2 has better CPU utilization and slightly better latency compared to NIO1.  However, under heavy load or during spikes, we observed that the 99th percentile latency of NIO2 is significantly worse compared to NIO1.   

- We see that the latency is worse compared to NIO1 only for the requests that end up establishing a new connection.
- When `maxKeepAliveRequests=-1`, we do not observe the latency degradation with NIO2 at all.  But, we need and use Tomcat’s `maxKeepAliveRequests` feature, so setting it to `-1` is not an option.  
- The problem occurs only during spikes/high load, e.g., maxThreads=40, while the concurrent users sending requests is 100.
- The issue happens only for blocking scenarios, where Tomcat threads are blocked during request processing.  When non-blocking programming is used (where Tomcat threads are freed quickly), we do not see any degradation compared to NIO1.  However, we have many applications that would not be able to adopt non-blocking anytime soon.


While looking at Tomcat code, we saw that the `accept` is scheduled to be run on the thread pool.  Our hypothesis was that this scheduling was causing the `accept` to be delayed significantly under heavy load.  So, for a request with new connection establishment, it needs to go through the `TaskQueue` twice.  So, just for testing purpose we set `maxConnections=-1` to see the impact of immediate `accept` call (and in our test the number of concurrent connections does not get close to `maxConnections`), we observed that the 99th percentile latency problem with NIO2 disappeared.

Accordingly, proposing a change to call `accept` immediately if the number of connections are not close to `maxConnections`.