### PR TITLE
Update FileHandler.java

### DIFF
--- a/java/org/apache/juli/FileHandler.java
+++ b/java/org/apache/juli/FileHandler.java
@@ -100,7 +100,7 @@ public class FileHandler extends Handler {
     public static final int DEFAULT_BUFFER_SIZE = -1;
 
 
-    private static final ExecutorService DELETE_FILES_SERVICE =
+    private final ExecutorService DELETE_FILES_SERVICE =
             Executors.newSingleThreadExecutor(new ThreadFactory() {
                 private static final String NAME_PREFIX = "FileHandlerLogFilesCleaner-";
                 private final boolean isSecurityEnabled;


### PR DESCRIPTION
remove static keyword from  `DELETE_FILES_SERVICE` to avoid class `ThreadPoolExecutor` loaded earlier than agent start.
It can cause agent enhance  class `ThreadPoolExecutor` failed.