### PR TITLE
Set "Secure" session cookie attribute if called under SSL.

### DIFF
--- a/java/org/apache/catalina/valves/LoadBalancerDrainingValve.java
+++ b/java/org/apache/catalina/valves/LoadBalancerDrainingValve.java
@@ -19,6 +19,7 @@ package org.apache.catalina.valves;
 import java.io.IOException;
 
 import jakarta.servlet.ServletException;
+import jakarta.servlet.SessionCookieConfig;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -222,6 +223,9 @@ public class LoadBalancerDrainingValve extends ValveBase {
                 sessionCookie.setPath(SessionConfig.getSessionCookiePath(request.getContext()));
                 sessionCookie.setMaxAge(0); // Delete
                 sessionCookie.setValue(""); // Purge the cookie's value
+                SessionCookieConfig sessionCookieConfig = request.getContext().getServletContext().getSessionCookieConfig();
+                // Set "Secure" flag by default under SSL, or if explicitly wanted by configuration.
+                sessionCookie.setSecure(request.isSecure() || sessionCookieConfig.isSecure());
                 response.addCookie(sessionCookie);
             }
 

--- a/test/org/apache/catalina/valves/TestLoadBalancerDrainingValve.java
+++ b/test/org/apache/catalina/valves/TestLoadBalancerDrainingValve.java
@@ -238,6 +238,8 @@ public class TestLoadBalancerDrainingValve {
                 expectedCookie.setPath(cookieConfig.getPath());
                 expectedCookie.setMaxAge(0);
 
+                EasyMock.expect(request.isSecure()).andReturn(true);
+
                 // These two lines just mean EasyMock.expect(response.addCookie) but for a void method
                 response.addCookie(expectedCookie);
                 EasyMock.expect(ctx.getSessionCookieName()).andReturn(sessionCookieName); // Indirect call


### PR DESCRIPTION
Missing "Secure" flag may lead to redirect loops under certain
conditions, e.g. when sameSiteCookies=none has been set at the
CookieProcessor and browser is Chrome.

Fixes <https://bz.apache.org/bugzilla/show_bug.cgi?id=64921>.