### PR TITLE
Fix so ResponseUtil:addVaryFieldName() stop adding duplicate values

### DIFF
--- a/java/org/apache/tomcat/util/http/ResponseUtil.java
+++ b/java/org/apache/tomcat/util/http/ResponseUtil.java
@@ -95,13 +95,15 @@ public class ResponseUtil {
 
         // Build single header to replace current multiple headers
         // Replace existing header(s) to ensure any invalid values are removed
-        fieldNames.add(name);
-        StringBuilder varyHeader = new StringBuilder();
-        varyHeader.append(name);
-        for (String fieldName : fieldNames) {
-            varyHeader.append(',');
-            varyHeader.append(fieldName);
+        if (!fieldNames.contains(name)) {
+            fieldNames.add(name);
         }
+        StringBuilder varyHeader = new StringBuilder();
+        for (String fieldName : fieldNames) {
+            varyHeader.append(fieldName);
+            varyHeader.append(',');
+        }
+        varyHeader.deleteCharAt(varyHeader.length() - 1);
         adapter.setHeader(VARY_HEADER, varyHeader.toString());
     }
 

--- a/test/org/apache/tomcat/util/http/TestResponseUtil.java
+++ b/test/org/apache/tomcat/util/http/TestResponseUtil.java
@@ -16,6 +16,8 @@
  */
 package org.apache.tomcat.util.http;
 
+import java.util.List;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -121,15 +123,24 @@ public class TestResponseUtil {
 
 
     @Test
-    public void testAddValidWithValidHeadersAlreadyPresent() {
+    public void testAddValidWithValidHeadersAlreadyPresentNoDuplicates() {
         TesterResponse response = new TesterResponse();
         response.getCoyoteResponse();
         response.addHeader("vary", "foo");
         response.addHeader("vary", "bar");
-        Set<String> expected = new HashSet<>();
+        List<String> expected = new ArrayList<>();
         expected.add("bar");
         expected.add("foo");
-        doTestAddVaryFieldName(response, "foo", expected);
+
+        ResponseUtil.addVaryFieldName(response, "foo");
+
+        String resultHeader = response.getHeader("vary");
+        List<String> result = new ArrayList<>();
+        for (String value : resultHeader.split(",")) {
+            result.add(value.trim());
+        }
+
+        Assert.assertEquals(expected, result);
     }
 
 


### PR DESCRIPTION
Currently addVaryFieldName() adds a value twice when there already is named value (not asterisk).
The existing tests did not catch this, since they assert using a HashMap thus containing no duplicates.
I have updated one of the test case, inlining parts of the doTestAddVaryFieldName() that can be reused.

Adding `System.out.println("adding " + name + " with " + adapter.getHeaders(VARY_HEADER) + " already present = " + varyHeader);` at the end of addVaryFieldName() we can track what happens when running the tests:

    test-nio:
    [junit] Running org.apache.tomcat.util.http.TestResponseUtil
    [junit] adding too with [foo, bar] already present = too,bar,too,foo
    [junit] adding too with [{{{, bar] already present = too,bar,too
    [junit] adding foo with [foo, bar] already present = foo,bar,foo
    [junit] adding bar with [{{{, bar] already present = bar,bar
    [junit] adding too with [foo, bar] already present = too,bar,too,foo
    [junit] adding too with [foo, bar] already present = too,bar,too,foo
    [junit] adding foo with [foo, bar] already present = foo,bar,foo
    ...

After applying my patch, this looks like:

    test-nio:
    [junit] Running org.apache.tomcat.util.http.TestResponseUtil
    [junit] adding too with [foo, bar] already present = bar,too,foo
    [junit] adding too with [{{{, bar] already present = bar,too
    [junit] adding foo with [foo, bar] already present = bar,foo
    [junit] adding bar with [{{{, bar] already present = bar
    [junit] adding too with [foo, bar] already present = bar,too,foo
    [junit] adding too with [foo, bar] already present = bar,too,foo
    [junit] adding foo with [foo, bar] already present = bar,foo


Perhaps a better change to the tests would be to rewrite doTestAddVaryFieldName() so none of the tests use HashSet. 
I assume the order of fields listed as Vary should not matter. I don't think the rfc mentions either order or what duplicates should mean.