### PR TITLE
Fix BZ 60781 Escape access log output where httpd does

### DIFF
--- a/java/org/apache/catalina/valves/AbstractAccessLogValve.java
+++ b/java/org/apache/catalina/valves/AbstractAccessLogValve.java
@@ -1869,37 +1869,37 @@ public abstract class AbstractAccessLogValve extends ValveBase implements Access
 
         for (char c : input.toCharArray()) {
             switch (c) {
-                // " and \
-                case '\\':
-                    dest.append("\\\\");
-                    break;
-                case '\"':
-                    dest.append("\\\"");
+            // " and \
+            case '\\':
+                dest.append("\\\\");
                 break;
-                // Standard C escapes for whitespace (not all standard C escapes)
-                case '\f':
-                    dest.append("\\f");
-                    break;
-                case '\n':
-                    dest.append("\\n");
-                    break;
-                case '\r':
-                    dest.append("\\r");
-                    break;
-                case '\t':
-                    dest.append("\\t");
-                    break;
-                case '\u000b':
-                    dest.append("\\v");
-                    break;
-                default:
-                    // Control, delete (127) or above 127
-                    if (c < 32 || c > 126) {
-                        dest.append("\\u");
-                        dest.append(HexUtils.toHexString(c));
-                    } else {
-                        dest.append(c);
-                    }
+            case '\"':
+                dest.append("\\\"");
+            break;
+            // Standard C escapes for whitespace (not all standard C escapes)
+            case '\f':
+                dest.append("\\f");
+                break;
+            case '\n':
+                dest.append("\\n");
+                break;
+            case '\r':
+                dest.append("\\r");
+                break;
+            case '\t':
+                dest.append("\\t");
+                break;
+            case '\u000b':
+                dest.append("\\v");
+                break;
+            default:
+                // Control, delete (127) or above 127
+                if (c < 32 || c > 126) {
+                    dest.append("\\u");
+                    dest.append(HexUtils.toHexString(c));
+                } else {
+                    dest.append(c);
+                }
             }
         }
     }

--- a/java/org/apache/catalina/valves/AbstractAccessLogValve.java
+++ b/java/org/apache/catalina/valves/AbstractAccessLogValve.java
@@ -52,6 +52,7 @@ import org.apache.coyote.RequestInfo;
 import org.apache.juli.logging.Log;
 import org.apache.juli.logging.LogFactory;
 import org.apache.tomcat.util.ExceptionUtils;
+import org.apache.tomcat.util.buf.HexUtils;
 import org.apache.tomcat.util.collections.SynchronizedStack;
 import org.apache.tomcat.util.net.IPv6Utils;
 
@@ -966,7 +967,7 @@ public abstract class AbstractAccessLogValve extends ValveBase implements Access
             if (request != null) {
                 String value = request.getRemoteUser();
                 if (value != null) {
-                    buf.append(value);
+                    escapeAndAppend(value, buf);
                 } else {
                     buf.append('-');
                 }
@@ -1478,9 +1479,10 @@ public abstract class AbstractAccessLogValve extends ValveBase implements Access
                 Response response, long time) {
             Enumeration<String> iter = request.getHeaders(header);
             if (iter.hasMoreElements()) {
-                buf.append(iter.nextElement());
+                escapeAndAppend(iter.nextElement(), buf);
                 while (iter.hasMoreElements()) {
-                    buf.append(',').append(iter.nextElement());
+                    buf.append(',');
+                    escapeAndAppend(iter.nextElement(), buf);
                 }
                 return;
             }
@@ -1511,7 +1513,7 @@ public abstract class AbstractAccessLogValve extends ValveBase implements Access
                     }
                 }
             }
-            buf.append(value);
+            escapeAndAppend(value, buf);
         }
     }
 
@@ -1531,9 +1533,10 @@ public abstract class AbstractAccessLogValve extends ValveBase implements Access
             if (null != response) {
                 Iterator<String> iter = response.getHeaders(header).iterator();
                 if (iter.hasNext()) {
-                    buf.append(iter.next());
+                    escapeAndAppend(iter.next(), buf);
                     while (iter.hasNext()) {
-                        buf.append(',').append(iter.next());
+                        buf.append(',');
+                        escapeAndAppend(iter.next(), buf);
                     }
                     return;
                 }
@@ -1563,9 +1566,9 @@ public abstract class AbstractAccessLogValve extends ValveBase implements Access
             }
             if (value != null) {
                 if (value instanceof String) {
-                    buf.append((String) value);
+                    escapeAndAppend((String) value, buf);
                 } else {
-                    buf.append(value.toString());
+                    escapeAndAppend(value.toString(), buf);
                 }
             } else {
                 buf.append('-');
@@ -1597,9 +1600,9 @@ public abstract class AbstractAccessLogValve extends ValveBase implements Access
             }
             if (value != null) {
                 if (value instanceof String) {
-                    buf.append((String) value);
+                    escapeAndAppend((String) value, buf);
                 } else {
-                    buf.append(value.toString());
+                    escapeAndAppend(value.toString(), buf);
                 }
             } else {
                 buf.append('-');
@@ -1803,6 +1806,101 @@ public abstract class AbstractAccessLogValve extends ValveBase implements Access
             return new ConnectionStatusElement();
         default:
             return new StringElement("???" + pattern + "???");
+        }
+    }
+
+
+    /*
+     * This method is intended to mimic the escaping performed by httpd and
+     * mod_log_config. mod_log_config escapes more elements than indicated by the
+     * documentation. See:
+     * https://github.com/apache/httpd/blob/trunk/modules/loggers/mod_log_config.c
+     *
+     * The following escaped elements are not supported by Tomcat:
+     * - %C   cookie value (see %{}c below)
+     * - %e   environment variable
+     * - %f   filename
+     * - %l   remote logname (always logs "-")
+     * - %n   note
+     * - %R   handler
+     * - %ti  trailer request header
+     * - %to  trailer response header
+     * - %V   server name per UseCanonicalName setting
+     *
+     * The following escaped elements are not escaped in Tomcat because values
+     * that would require escaping are rejected before they reach the
+     * AccessLogValve:
+     * - %h   remote host
+     * - %H   request protocol
+     * - %m   request method
+     * - %q   query string
+     * - %r   request line
+     * - %U   request URI
+     * - %v   canonical server name
+     *
+     * The following escaped elements are supported by Tomcat:
+     * - %{}i request header
+     * - %{}o response header
+     * - %u   remote user
+     *
+     * The following additional Tomcat elements are escaped for consistency:
+     * - %{}c cookie value
+     * - %{}r request attribute
+     * - %{}s session attribute
+     *
+     * giving a total of 6 elements that are escaped in Tomcat.
+     *
+     *  Quoting from the httpd docs:
+     * "...non-printable and other special characters in %r, %i and %o are
+     *  escaped using \xhh sequences, where hh stands for the hexadecimal
+     *  representation of the raw byte. Exceptions from this rule are " and \,
+     *  which are escaped by prepending a backslash, and all whitespace
+     *  characters, which are written in their C-style notation (\n, \t, etc)."
+     *
+     *  Reviewing the httpd code, characters with the high bit set are escaped.
+     *  The httpd is assuming a single byte encoding which may not be true for
+     *  Tomcat so Tomcat uses the Java \\uXXXX encoding.
+     */
+    protected static void escapeAndAppend(String input, CharArrayWriter dest) {
+        if (input == null || input.isEmpty()) {
+            dest.append('-');
+            return;
+        }
+
+        for (char c : input.toCharArray()) {
+            switch (c) {
+                // " and \
+                case '\\':
+                    dest.append("\\\\");
+                    break;
+                case '\"':
+                    dest.append("\\\"");
+                break;
+                // Standard C escapes for whitespace (not all standard C escapes)
+                case '\f':
+                    dest.append("\\f");
+                    break;
+                case '\n':
+                    dest.append("\\n");
+                    break;
+                case '\r':
+                    dest.append("\\r");
+                    break;
+                case '\t':
+                    dest.append("\\t");
+                    break;
+                case '\u000b':
+                    dest.append("\\v");
+                    break;
+                default:
+                    // Control, delete (127) or above 127
+                    if (c < 32 || c > 126) {
+                        dest.append("\\u");
+                        dest.append(HexUtils.toHexString(c));
+                    } else {
+                        dest.append(c);
+                    }
+            }
         }
     }
 }

--- a/java/org/apache/catalina/valves/AbstractAccessLogValve.java
+++ b/java/org/apache/catalina/valves/AbstractAccessLogValve.java
@@ -1875,7 +1875,7 @@ public abstract class AbstractAccessLogValve extends ValveBase implements Access
                 break;
             case '\"':
                 dest.append("\\\"");
-            break;
+                break;
             // Standard C escapes for whitespace (not all standard C escapes)
             case '\f':
                 dest.append("\\f");

--- a/test/org/apache/catalina/valves/TestAbstractAccessLogValveEscape.java
+++ b/test/org/apache/catalina/valves/TestAbstractAccessLogValveEscape.java
@@ -45,6 +45,7 @@ public class TestAbstractAccessLogValveEscape {
         parameters.add(new String[] { "o\u007fk", "o\\u007fk" });
         parameters.add(new String[] { "o\u0080k", "o\\u0080k" });
         parameters.add(new String[] { "o\u00ffk", "o\\u00ffk" });
+        parameters.add(new String[] { "o\"k", "o\\\"k" });
 
         return parameters;
     }

--- a/test/org/apache/catalina/valves/TestAbstractAccessLogValveEscape.java
+++ b/test/org/apache/catalina/valves/TestAbstractAccessLogValveEscape.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.catalina.valves;
+
+import java.io.CharArrayWriter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+
+@RunWith(Parameterized.class)
+public class TestAbstractAccessLogValveEscape {
+
+    @Parameters(name = "{index}: [{0}]")
+    public static Collection<Object[]> parameters() {
+
+        List<Object[]> parameters = new ArrayList<>();
+
+        parameters.add(new String[] { null, "-" });
+        parameters.add(new String[] { "", "-" });
+        parameters.add(new String[] { "ok", "ok" });
+        parameters.add(new String[] { "o\tk", "o\\tk" });
+        parameters.add(new String[] { "o\u0002k", "o\\u0002k" });
+        parameters.add(new String[] { "o\u007fk", "o\\u007fk" });
+        parameters.add(new String[] { "o\u0080k", "o\\u0080k" });
+        parameters.add(new String[] { "o\u00ffk", "o\\u00ffk" });
+
+        return parameters;
+    }
+
+    @Parameter(0)
+    public String input;
+
+    @Parameter(1)
+    public String expected;
+
+
+    @Test
+    public void testEscape() {
+        CharArrayWriter actual = new CharArrayWriter();
+        AbstractAccessLogValve.escapeAndAppend(input, actual);
+        Assert.assertEquals(expected, actual.toString());
+    }
+}

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -106,6 +106,11 @@
 <section name="Tomcat 10.0.1 (markt)" rtext="in development">
   <subsection name="Catalina">
     <changelog>
+      <fix>
+        <bug>60781</bug>: Escape elements in the access log that need to be
+        escaped for the access log to be parsed unambiguously.
+        (fschumacher/markt)
+      </fix>
       <add>
         <bug>64110</bug>: Add support for additional TLS related request
         attributes that provide details of the protocols and ciphers requested

--- a/webapps/docs/config/valve.xml
+++ b/webapps/docs/config/valve.xml
@@ -301,7 +301,7 @@
     <li><b>%s</b> - HTTP status code of the response</li>
     <li><b>%S</b> - User session ID</li>
     <li><b>%t</b> - Date and time, in Common Log Format</li>
-    <li><b>%u</b> - Remote user that was authenticated (if any), else '-'</li>
+    <li><b>%u</b> - Remote user that was authenticated (if any), else '-' (escaped if required)</li>
     <li><b>%U</b> - Requested URL path</li>
     <li><b>%v</b> - Local server name</li>
     <li><b>%D</b> - Time taken to process the request in microseconds</li>
@@ -326,11 +326,11 @@
     syntax. Each of them can be used multiple times with different <code>xxx</code> keys:
     </p>
     <ul>
-    <li><b><code>%{xxx}i</code></b> write value of incoming header with name <code>xxx</code></li>
-    <li><b><code>%{xxx}o</code></b> write value of outgoing header with name <code>xxx</code></li>
-    <li><b><code>%{xxx}c</code></b> write value of cookie with name <code>xxx</code></li>
-    <li><b><code>%{xxx}r</code></b> write value of ServletRequest attribute with name <code>xxx</code></li>
-    <li><b><code>%{xxx}s</code></b> write value of HttpSession attribute with name <code>xxx</code></li>
+    <li><b><code>%{xxx}i</code></b> write value of incoming header with name <code>xxx</code> (escaped if required)</li>
+    <li><b><code>%{xxx}o</code></b> write value of outgoing header with name <code>xxx</code> (escaped if required)</li>
+    <li><b><code>%{xxx}c</code></b> write value of cookie with name <code>xxx</code> (escaped if required)</li>
+    <li><b><code>%{xxx}r</code></b> write value of ServletRequest attribute with name <code>xxx</code> (escaped if required)</li>
+    <li><b><code>%{xxx}s</code></b> write value of HttpSession attribute with name <code>xxx</code> (escaped if required)</li>
     <li><b><code>%{xxx}p</code></b> write local (server) port (<code>xxx==local</code>) or
         remote (client) port (<code>xxx=remote</code>)</li>
     <li><b><code>%{xxx}t</code></b> write timestamp at the end of the request formatted using the
@@ -361,6 +361,17 @@
     </ul>
     <p>By adding multiple <code>%{xxx}t</code> tokens to the pattern, one can
     also log both timestamps.</p>
+
+    <p>Escaping is applied as follows:</p>
+    <ul>
+    <li><code>&quot;</code> is escaped as <code>\&quot;</code></li>
+    <li><code>\</code> is escaped as <code>\\</code></li>
+    <li>Standard C escaping are used for <code>\f</code>, <code>\n</code>,
+        <code>\r</code>, <code>\t</code> and <code>\v</code></li>
+    <li>Any other control characters or characters with code points above 127
+        are encoded using the standard Java unicode escaping
+        (<code>\uXXXX</code>)</li>
+    </ul>
 
     <p>The shorthand pattern <code>pattern=&quot;common&quot;</code>
     corresponds to the Common Log Format defined by


### PR DESCRIPTION
https://bz.apache.org/bugzilla/show_bug.cgi?id=60781

It isn't quite as simple just escape where httpd does as httpd and Tomcat support slightly different things and validate at different points. See the code comments.

I was concerned about performance but after checking which elements need escaping (see code comments) I think this should be OK. I used Felix's original patch as my starting point but used chars rather than bytes and appended directly to the buffer. Give the potential performance issues, doing this as a PR.