### PR TITLE
Add peerAddress to coyote request

### DIFF
--- a/java/org/apache/catalina/connector/Request.java
+++ b/java/org/apache/catalina/connector/Request.java
@@ -379,6 +379,12 @@ public class Request implements HttpServletRequest {
 
 
     /**
+     * Connection peer address.
+     */
+    protected String peerAddr = null;
+
+
+    /**
      * Remote host.
      */
     protected String remoteHost = null;
@@ -455,6 +461,7 @@ public class Request implements HttpServletRequest {
         localesParsed = false;
         secure = false;
         remoteAddr = null;
+        peerAddr = null;
         remoteHost = null;
         remotePort = -1;
         localPort = -1;
@@ -1265,6 +1272,18 @@ public class Request implements HttpServletRequest {
             remoteAddr = coyoteRequest.remoteAddr().toString();
         }
         return remoteAddr;
+    }
+
+
+    /**
+     * @return the connection peer IP address making this Request.
+     */
+    public String getPeerAddr() {
+        if (peerAddr == null) {
+            coyoteRequest.action(ActionCode.REQ_PEER_ADDR_ATTRIBUTE, coyoteRequest);
+            peerAddr = coyoteRequest.peerAddr().toString();
+        }
+        return peerAddr;
     }
 
 

--- a/java/org/apache/catalina/valves/AbstractAccessLogValve.java
+++ b/java/org/apache/catalina/valves/AbstractAccessLogValve.java
@@ -165,6 +165,13 @@ public abstract class AbstractAccessLogValve extends ValveBase implements Access
         LOCAL, REMOTE
     }
 
+    /**
+     * The list of our ip address types.
+     */
+    private enum RemoteAddressType {
+        REMOTE, PEER
+    }
+
     //------------------------------------------------------ Constructor
     public AbstractAccessLogValve() {
         super(true);
@@ -861,19 +868,50 @@ public abstract class AbstractAccessLogValve extends ValveBase implements Access
      * write remote IP address - %a
      */
     protected class RemoteAddrElement implements AccessLogElement, CachedElement {
+        /**
+         * Type of address to log
+         */
+        private static final String remoteAddress = "remote";
+        private static final String peerAddress = "peer";
+
+        private final RemoteAddressType remoteAddressType;
+
+        public RemoteAddrElement() {
+            remoteAddressType = RemoteAddressType.REMOTE;
+        }
+
+        public RemoteAddrElement(String type) {
+            switch (type) {
+            case remoteAddress:
+                remoteAddressType = RemoteAddressType.REMOTE;
+                break;
+            case peerAddress:
+                remoteAddressType = RemoteAddressType.PEER;
+                break;
+            default:
+                log.error(sm.getString("accessLogValve.invalidRemoteAddressType", type));
+                remoteAddressType = RemoteAddressType.REMOTE;
+                break;
+            }
+        }
+
         @Override
         public void addElement(CharArrayWriter buf, Date date, Request request,
                 Response response, long time) {
             String value = null;
-            if (requestAttributesEnabled) {
-                Object addr = request.getAttribute(REMOTE_ADDR_ATTRIBUTE);
-                if (addr == null) {
-                    value = request.getRemoteAddr();
-                } else {
-                    value = addr.toString();
-                }
+            if (remoteAddressType == RemoteAddressType.PEER) {
+                value = request.getPeerAddr();
             } else {
-                value = request.getRemoteAddr();
+                if (requestAttributesEnabled) {
+                    Object addr = request.getAttribute(REMOTE_ADDR_ATTRIBUTE);
+                    if (addr == null) {
+                        value = request.getRemoteAddr();
+                    } else {
+                        value = addr.toString();
+                    }
+                } else {
+                    value = request.getRemoteAddr();
+                }
             }
 
             if (ipv6Canonical) {
@@ -885,7 +923,11 @@ public abstract class AbstractAccessLogValve extends ValveBase implements Access
         @Override
         public void cache(Request request) {
             if (!requestAttributesEnabled) {
-                request.getRemoteAddr();
+                if (remoteAddressType == RemoteAddressType.PEER) {
+                    request.getPeerAddr();
+                } else {
+                    request.getRemoteAddr();
+                }
             }
         }
     }
@@ -1725,6 +1767,8 @@ public abstract class AbstractAccessLogValve extends ValveBase implements Access
             return new CookieElement(name);
         case 'o':
             return new ResponseHeaderElement(name);
+        case 'a':
+            return new RemoteAddrElement(name);
         case 'p':
             return new PortElement(name);
         case 'r':

--- a/java/org/apache/catalina/valves/LocalStrings.properties
+++ b/java/org/apache/catalina/valves/LocalStrings.properties
@@ -18,6 +18,7 @@ accessLogValve.closeFail=Failed to close access log file
 accessLogValve.deleteFail=Failed to delete old access log [{0}]
 accessLogValve.invalidLocale=Failed to set locale to [{0}]
 accessLogValve.invalidPortType=Invalid port type [{0}], using server (local) port
+accessLogValve.invalidRemoteAddressType=Invalid remote address type [{0}], using remote (non-peer) address
 accessLogValve.openDirFail=Failed to create directory [{0}] for access logs
 accessLogValve.openFail=Failed to open access log file [{0}]
 accessLogValve.renameFail=Failed to rename access log from [{0}] to [{1}]

--- a/java/org/apache/catalina/valves/RemoteAddrValve.java
+++ b/java/org/apache/catalina/valves/RemoteAddrValve.java
@@ -44,11 +44,14 @@ public final class RemoteAddrValve extends RequestFilterValve {
     @Override
     public void invoke(Request request, Response response) throws IOException, ServletException {
         String property;
-        if (getAddConnectorPort()) {
-            property = request.getRequest().getRemoteAddr() + ";" +
-                    request.getConnector().getPortWithOffset();
+        if (getUsePeerAddress()) {
+            property = request.getPeerAddr();
         } else {
             property = request.getRequest().getRemoteAddr();
+        }
+        if (getAddConnectorPort()) {
+            property = property + ";" +
+                request.getConnector().getPortWithOffset();
         }
         process(property, request, response);
     }

--- a/java/org/apache/catalina/valves/RemoteCIDRValve.java
+++ b/java/org/apache/catalina/valves/RemoteCIDRValve.java
@@ -129,11 +129,14 @@ public final class RemoteCIDRValve extends RequestFilterValve {
     @Override
     public void invoke(final Request request, final Response response) throws IOException, ServletException {
         String property;
-        if (getAddConnectorPort()) {
-            property = request.getRequest().getRemoteAddr() + ";" +
-                    request.getConnector().getPortWithOffset();
+        if (getUsePeerAddress()) {
+            property = request.getPeerAddr();
         } else {
             property = request.getRequest().getRemoteAddr();
+        }
+        if (getAddConnectorPort()) {
+            property = property + ";" +
+                request.getConnector().getPortWithOffset();
         }
         process(property, request, response);
     }

--- a/java/org/apache/catalina/valves/RequestFilterValve.java
+++ b/java/org/apache/catalina/valves/RequestFilterValve.java
@@ -139,6 +139,13 @@ public abstract class RequestFilterValve extends ValveBase {
      */
     private volatile boolean addConnectorPort = false;
 
+    /**
+     * Flag deciding whether we use the connection peer address
+     * or the remote address. This makes a dfifference when
+     * using AJP or the RemoteIpValve.
+     */
+    private volatile boolean usePeerAddress = false;
+
     // ------------------------------------------------------------- Properties
 
 
@@ -286,6 +293,29 @@ public abstract class RequestFilterValve extends ValveBase {
      */
     public void setAddConnectorPort(boolean addConnectorPort) {
         this.addConnectorPort = addConnectorPort;
+    }
+
+
+    /**
+     * Get the flag deciding whether we use the connection peer address
+     * or the remote address. This makes a dfifference when
+     * using AJP or the RemoteIpValve.
+     * @return <code>true</code> if we use the connection peer address
+     */
+    public boolean getUsePeerAddress() {
+        return usePeerAddress;
+    }
+
+
+    /**
+     * Set the flag deciding whether we use the connection peer address
+     * or the remote address. This makes a dfifference when
+     * using AJP or the RemoteIpValve.
+     *
+     * @param usePeerAddress The new flag
+     */
+    public void setUsePeerAddress(boolean usePeerAddress) {
+        this.usePeerAddress = usePeerAddress;
     }
 
     // --------------------------------------------------------- Public Methods

--- a/java/org/apache/coyote/AbstractProcessor.java
+++ b/java/org/apache/coyote/AbstractProcessor.java
@@ -451,6 +451,12 @@ public abstract class AbstractProcessor extends AbstractProcessorLight implement
             }
             break;
         }
+        case REQ_PEER_ADDR_ATTRIBUTE: {
+            if (getPopulateRequestAttributesFromSocket() && socketWrapper != null) {
+                request.peerAddr().setString(socketWrapper.getRemoteAddr());
+            }
+            break;
+        }
         case REQ_HOST_ATTRIBUTE: {
             populateRequestAttributeRemoteHost();
             break;

--- a/java/org/apache/coyote/ActionCode.java
+++ b/java/org/apache/coyote/ActionCode.java
@@ -77,6 +77,11 @@ public enum ActionCode {
     REQ_HOST_ADDR_ATTRIBUTE,
 
     /**
+     * Callback for lazy evaluation - extract the connection peer address.
+     */
+    REQ_PEER_ADDR_ATTRIBUTE,
+
+    /**
      * Callback for lazy evaluation - extract the SSL-related attributes
      * including the client certificate if present.
      */

--- a/java/org/apache/coyote/Constants.java
+++ b/java/org/apache/coyote/Constants.java
@@ -96,4 +96,11 @@ public final class Constants {
      * the X-Forwarded-For HTTP header.
      */
     public static final String REMOTE_ADDR_ATTRIBUTE = "org.apache.tomcat.remoteAddr";
+
+    /**
+     * The request attribute set by the RemoteIpFilter, RemoteIpValve (and may
+     * be set by other similar components) that identifies for the connector the
+     * conection peer IP address.
+     */
+    public static final String PEER_ADDR_ATTRIBUTE = "org.apache.tomcat.peerAddr";
 }

--- a/java/org/apache/coyote/Constants.java
+++ b/java/org/apache/coyote/Constants.java
@@ -100,7 +100,7 @@ public final class Constants {
     /**
      * The request attribute set by the RemoteIpFilter, RemoteIpValve (and may
      * be set by other similar components) that identifies for the connector the
-     * conection peer IP address.
+     * connection peer IP address.
      */
     public static final String PEER_ADDR_ATTRIBUTE = "org.apache.tomcat.peerAddr";
 }

--- a/java/org/apache/coyote/Request.java
+++ b/java/org/apache/coyote/Request.java
@@ -95,6 +95,7 @@ public final class Request {
 
     // remote address/host
     private final MessageBytes remoteAddrMB = MessageBytes.newInstance();
+    private final MessageBytes peerAddrMB = MessageBytes.newInstance();
     private final MessageBytes localNameMB = MessageBytes.newInstance();
     private final MessageBytes remoteHostMB = MessageBytes.newInstance();
     private final MessageBytes localAddrMB = MessageBytes.newInstance();
@@ -266,6 +267,10 @@ public final class Request {
 
     public MessageBytes remoteAddr() {
         return remoteAddrMB;
+    }
+
+    public MessageBytes peerAddr() {
+        return peerAddrMB;
     }
 
     public MessageBytes remoteHost() {
@@ -638,6 +643,7 @@ public final class Request {
         localAddrMB.recycle();
         localNameMB.recycle();
         localPort = -1;
+        peerAddrMB.recycle();
         remoteAddrMB.recycle();
         remoteHostMB.recycle();
         remotePort = -1;

--- a/java/org/apache/coyote/RequestInfo.java
+++ b/java/org/apache/coyote/RequestInfo.java
@@ -98,6 +98,11 @@ public class RequestInfo  {
         return req.remoteAddr().toString();
     }
 
+    public String getPeerAddr() {
+        req.action(ActionCode.REQ_PEER_ADDR_ATTRIBUTE, null);
+        return req.peerAddr().toString();
+    }
+
     /**
      * Obtain the remote address for this connection as reported by an
      * intermediate proxy (if any).

--- a/java/org/apache/coyote/ajp/AjpProcessor.java
+++ b/java/org/apache/coyote/ajp/AjpProcessor.java
@@ -671,6 +671,10 @@ public class AjpProcessor extends AbstractProcessor {
         requestHeaderMessage.getBytes(request.localName());
         request.setLocalPort(requestHeaderMessage.getInt());
 
+        if (socketWrapper != null) {
+            request.peerAddr().setString(socketWrapper.getRemoteAddr());
+        }
+
         boolean isSSL = requestHeaderMessage.getByte() != 0;
         if (isSSL) {
             request.scheme().setString("https");

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -117,6 +117,22 @@
         Especially add support for connector specific configuration
         using <code>addConnectorPort</code>. (rjung)
       </add>
+      <add>
+        Add <code>peerAddress</code> to coyote request, which contains
+        the IP address of the direct connection peer. If a reverse proxy
+        sits in front of Tomcat and the protocol used is AJP or HTTP
+        in combination with the <code>RemoteIp(Valve|Filter)</code>,
+        the peer address might differ from the <code>remoteAddress</code>.
+        The latter then contains the address of the client in front of the
+        reverse proxy, not the address of the proxy itself.
+        Support for the peer address has been added to the
+        RemoteAddrValve and RemoteCIDRValve with the new attribute
+        <code>usePeerAddress</code>. This can be used to restrict access
+        to Tomcat bsed on the reverse proxy IP address, which is especially
+        useful to harden access to AJP connecrtors. The peer address can also
+        be logged in the access log using the new <code>%{peer}a</code>
+        syntax. (rjung)
+      </add>
     </changelog>
   </subsection>
 </section>

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -128,8 +128,8 @@
         Support for the peer address has been added to the
         RemoteAddrValve and RemoteCIDRValve with the new attribute
         <code>usePeerAddress</code>. This can be used to restrict access
-        to Tomcat bsed on the reverse proxy IP address, which is especially
-        useful to harden access to AJP connecrtors. The peer address can also
+        to Tomcat based on the reverse proxy IP address, which is especially
+        useful to harden access to AJP connectors. The peer address can also
         be logged in the access log using the new <code>%{peer}a</code>
         syntax. (rjung)
       </add>

--- a/webapps/docs/config/valve.xml
+++ b/webapps/docs/config/valve.xml
@@ -284,7 +284,8 @@
     the current request and response.  The following pattern codes are
     supported:</p>
     <ul>
-    <li><b>%a</b> - Remote IP address</li>
+    <li><b>%a</b> - Remote IP address.
+        See also <code>%{xxx}a</code> below.</li>
     <li><b>%A</b> - Local IP address</li>
     <li><b>%b</b> - Bytes sent, excluding HTTP headers, or '-' if zero</li>
     <li><b>%B</b> - Bytes sent, excluding HTTP headers</li>
@@ -326,6 +327,8 @@
     syntax. Each of them can be used multiple times with different <code>xxx</code> keys:
     </p>
     <ul>
+    <li><b><code>%{xxx}a</code></b> write remote address (client) (<code>xxx==remote</code>) or
+        connection peer address (<code>xxx=peer</code>)</li>
     <li><b><code>%{xxx}i</code></b> write value of incoming header with name <code>xxx</code></li>
     <li><b><code>%{xxx}o</code></b> write value of outgoing header with name <code>xxx</code></li>
     <li><b><code>%{xxx}c</code></b> write value of cookie with name <code>xxx</code></li>
@@ -518,6 +521,12 @@
     <code>true</code>, one can append the server connector port separated with a
     semicolon (";") to allow different expressions for each connector.</p>
 
+    <p>By setting the attribute <code>usePeerAddress</code> to
+    <code>true</code>, the valve will use the connection peer address in its
+    checks. This will differ from the client IP, if a reverse proxy is used
+    in front of Tomcat in combination with either the AJP protocol, or the
+    HTTP protocol plus the <code>RemoteIp(Valve|Filter)</code>.</p>
+
     <p>A refused request will be answered a response with status code
     <code>403</code>. This status code can be overwritten using the attribute
     <code>denyStatus</code>.</p>
@@ -596,6 +605,13 @@
         even if the application does not have a security constraint configured.</p>
         <p>This can be combined with <code>addConnectorPort</code> to trigger authentication
         depending on the client and the connector that is used to access an application.</p>
+      </attribute>
+
+      <attribute name="usePeerAddress" required="false">
+        <p>Use the connection peer address instead of the client IP address.
+        They will differ, if a reverse proxy is used in front of Tomcat in
+        combination with either the AJP protocol, or the HTTP protocol plus
+        the <code>RemoteIp(Valve|Filter)</code>.</p>
       </attribute>
 
     </attributes>
@@ -777,6 +793,12 @@
     <code>true</code>, one can append the server connector port separated with a
     semicolon (";") to allow different expressions for each connector.</p>
 
+    <p>By setting the attribute <code>usePeerAddress</code> to
+    <code>true</code>, the valve will use the connection peer address in its
+    checks. This will differ from the client IP, if a reverse proxy is used
+    in front of Tomcat in combination with either the AJP protocol, or the
+    HTTP protocol plus the <code>RemoteIp(Valve|Filter)</code>.</p>
+
     <p>A refused request will be answered a response with status code
     <code>403</code>. This status code can be overwritten using the attribute
     <code>denyStatus</code>.</p>
@@ -861,6 +883,13 @@
         even if the application does not have a security constraint configured.</p>
         <p>This can be combined with <code>addConnectorPort</code> to trigger authentication
         depending on the client and the connector that is used to access an application.</p>
+      </attribute>
+
+      <attribute name="usePeerAddress" required="false">
+        <p>Use the connection peer address instead of the client IP address.
+        They will differ, if a reverse proxy is used in front of Tomcat in
+        combination with either the AJP protocol, or the HTTP protocol plus
+        the <code>RemoteIp(Valve|Filter)</code>.</p>
       </attribute>
 
     </attributes>


### PR DESCRIPTION
It contains the IP address of the direct connection peer.
If a reverse proxy sits in front of Tomcat and the protocol
used is AJP or HTTP in combination with the RemoteIp(Valve|Filter),
the peer address might differ from the remoteAddress.
The latter then contains the address of the client in front of the
reverse proxy, not the address of the proxy itself.

Support for the peer address has been added to the
RemoteAddrValve and RemoteCIDRValve with the new attribute
"usePeerAddress". This can be used to restrict access
to Tomcat bsed on the reverse proxy IP address, which is especially
useful to harden access to AJP connecrtors.

The peer address can also be logged in the access log
using the new %{peer}a syntax.