### PR TITLE
Replace C-style array declaring with Java-style array declaring

### DIFF
--- a/java/org/apache/catalina/startup/Catalina.java
+++ b/java/org/apache/catalina/startup/Catalina.java
@@ -318,7 +318,7 @@ public class Catalina {
      * @param args Command line arguments to process
      * @return <code>true</code> if we should continue processing
      */
-    protected boolean arguments(String args[]) {
+    protected boolean arguments(String[] args) {
 
         boolean isConfig = false;
         boolean isGenerateCode = false;

--- a/java/org/apache/catalina/startup/Catalina.java
+++ b/java/org/apache/catalina/startup/Catalina.java
@@ -762,7 +762,7 @@ public class Catalina {
     /*
      * Load using arguments
      */
-    public void load(String args[]) {
+    public void load(String[] args) {
 
         try {
             if (arguments(args)) {


### PR DESCRIPTION
Replace the C-style parameter declaring of the method `Catalina.load(String args[])` with Java-style `load(String[] args)`