### PR TITLE
[65022] Use of font with distinct lowercase l , capital I (i) and one 1 tomcat access log pattern definition

### DIFF
--- a/java/org/apache/catalina/valves/AbstractAccessLogValve.java
+++ b/java/org/apache/catalina/valves/AbstractAccessLogValve.java
@@ -68,31 +68,31 @@ import org.apache.tomcat.util.net.IPv6Utils;
  * following replacement strings, for which the corresponding information
  * from the specified Response is substituted:</p>
  * <ul>
- * <li><b>%a</b> - Remote IP address
- * <li><b>%A</b> - Local IP address
- * <li><b>%b</b> - Bytes sent, excluding HTTP headers, or '-' if no bytes
+ * <li><b><code>%a</code></b> - Remote IP address
+ * <li><b><code>%A</code></b> - Local IP address
+ * <li><b><code>%b</code></b> - Bytes sent, excluding HTTP headers, or '-' if no bytes
  *     were sent
- * <li><b>%B</b> - Bytes sent, excluding HTTP headers
- * <li><b>%h</b> - Remote host name (or IP address if
+ * <li><b><code>%B</code></b> - Bytes sent, excluding HTTP headers
+ * <li><b><code>%h</code></b> - Remote host name (or IP address if
  * <code>enableLookups</code> for the connector is false)
- * <li><b>%H</b> - Request protocol
- * <li><b>%l</b> - Remote logical username from identd (always returns '-')
- * <li><b>%m</b> - Request method
- * <li><b>%p</b> - Local port
- * <li><b>%q</b> - Query string (prepended with a '?' if it exists, otherwise
+ * <li><b><code>%H</code></b> - Request protocol
+ * <li><b><code>%l</code></b> - Remote logical username from identd (always returns '-')
+ * <li><b><code>%m</code></b> - Request method
+ * <li><b><code>%p</code></b> - Local port
+ * <li><b><code>%q</code></b> - Query string (prepended with a '?' if it exists, otherwise
  *     an empty string
- * <li><b>%r</b> - First line of the request
- * <li><b>%s</b> - HTTP status code of the response
- * <li><b>%S</b> - User session ID
- * <li><b>%t</b> - Date and time, in Common Log Format format
- * <li><b>%u</b> - Remote user that was authenticated
- * <li><b>%U</b> - Requested URL path
- * <li><b>%v</b> - Local server name
- * <li><b>%D</b> - Time taken to process the request, in microseconds
- * <li><b>%T</b> - Time taken to process the request, in seconds
- * <li><b>%F</b> - Time taken to commit the response, in milliseconds
- * <li><b>%I</b> - current Request thread name (can compare later with stacktraces)
- * <li><b>%X</b> - Connection status when response is completed:
+ * <li><b><code>%r</code></b> - First line of the request
+ * <li><b><code>%s</code></b> - HTTP status code of the response
+ * <li><b><code>%S</code></b> - User session ID
+ * <li><b><code>%t</code></b> - Date and time, in Common Log Format format
+ * <li><b><code>%u</code></b> - Remote user that was authenticated
+ * <li><b><code>%U</code></b> - Requested URL path
+ * <li><b><code>%v</code></b> - Local server name
+ * <li><b><code>%D</code></b> - Time taken to process the request, in microseconds
+ * <li><b><code>%T</code></b> - Time taken to process the request, in seconds
+ * <li><b><code>%F</code></b> - Time taken to commit the response, in milliseconds
+ * <li><b><code>%I</code></b> - current Request thread name (can compare later with stacktraces)
+ * <li><b><code>%X</code></b> - Connection status when response is completed:
  *   <ul>
  *   <li><code>X</code> = Connection aborted before the response completed.</li>
  *   <li><code>+</code> = Connection may be kept alive after the response is sent.</li>

--- a/webapps/docs/config/valve.xml
+++ b/webapps/docs/config/valve.xml
@@ -284,32 +284,32 @@
     the current request and response.  The following pattern codes are
     supported:</p>
     <ul>
-    <li><b>%a</b> - Remote IP address.
+    <li><b><code>%a</code></b> - Remote IP address.
         See also <code>%{xxx}a</code> below.</li>
-    <li><b>%A</b> - Local IP address</li>
-    <li><b>%b</b> - Bytes sent, excluding HTTP headers, or '-' if zero</li>
-    <li><b>%B</b> - Bytes sent, excluding HTTP headers</li>
-    <li><b>%h</b> - Remote host name (or IP address if
+    <li><b><code>%A</code></b> - Local IP address</li>
+    <li><b><code>%b</code></b> - Bytes sent, excluding HTTP headers, or '-' if zero</li>
+    <li><b><code>%B</code></b> - Bytes sent, excluding HTTP headers</li>
+    <li><b><code>%h</code></b> - Remote host name (or IP address if
         <code>enableLookups</code> for the connector is false)</li>
-    <li><b>%H</b> - Request protocol</li>
-    <li><b>%l</b> - Remote logical username from identd (always returns
+    <li><b><code>%H</code></b> - Request protocol</li>
+    <li><b><code>%l</code></b> - Remote logical username from identd (always returns
         '-')</li>
-    <li><b>%m</b> - Request method (GET, POST, etc.)</li>
-    <li><b>%p</b> - Local port on which this request was received.
+    <li><b><code>%m</code></b> - Request method (GET, POST, etc.)</li>
+    <li><b><code>%p</code></b> - Local port on which this request was received.
         See also <code>%{xxx}p</code> below.</li>
-    <li><b>%q</b> - Query string (prepended with a '?' if it exists)</li>
-    <li><b>%r</b> - First line of the request (method and request URI)</li>
-    <li><b>%s</b> - HTTP status code of the response</li>
-    <li><b>%S</b> - User session ID</li>
-    <li><b>%t</b> - Date and time, in Common Log Format</li>
-    <li><b>%u</b> - Remote user that was authenticated (if any), else '-' (escaped if required)</li>
-    <li><b>%U</b> - Requested URL path</li>
-    <li><b>%v</b> - Local server name</li>
-    <li><b>%D</b> - Time taken to process the request in microseconds</li>
-    <li><b>%T</b> - Time taken to process the request, in seconds</li>
-    <li><b>%F</b> - Time taken to commit the response, in milliseconds</li>
-    <li><b>%I</b> - Current request thread name (can compare later with stacktraces)</li>
-    <li><b>%X</b> - Connection status when response is completed:
+    <li><b><code>%q</code></b> - Query string (prepended with a '?' if it exists)</li>
+    <li><b><code>%r</code></b> - First line of the request (method and request URI)</li>
+    <li><b><code>%s</code></b> - HTTP status code of the response</li>
+    <li><b><code>%S</code></b> - User session ID</li>
+    <li><b><code>%t</code></b> - Date and time, in Common Log Format</li>
+    <li><b><code>%u</code></b> - Remote user that was authenticated (if any), else '-' (escaped if required)</li>
+    <li><b><code>%U</code></b> - Requested URL path</li>
+    <li><b><code>%v</code></b> - Local server name</li>
+    <li><b><code>%D</code></b> - Time taken to process the request in microseconds</li>
+    <li><b><code>%T</code></b> - Time taken to process the request, in seconds</li>
+    <li><b><code>%F</code></b> - Time taken to commit the response, in milliseconds</li>
+    <li><b><code>%I</code></b> - Current request thread name (can compare later with stacktraces)</li>
+    <li><b><code>%X</code></b> - Connection status when response is completed:
       <ul>
       <li><code>X</code> = Connection aborted before the response completed.</li>
       <li><code>+</code> = Connection may be kept alive after the response is sent.</li>


### PR DESCRIPTION
In the current and older tomcat docs the distinction between capital i and l is not evident with use of open sans font[1]. This is common typography issue which could be avoided with font that have distinctions in commonly confused characters similar to http's log format doc.[2] 

~~~
%l - Remote logical username from identd (always returns '-')
%I - Current request thread name (can compare later with stacktraces)
~~~

[1] https://tomcat.apache.org/tomcat-9.0-doc/config/valve.html#Introduction 
[2] http://httpd.apache.org/docs/2.4/mod/mod_log_config.html#formats