### PR TITLE
Ensure StandardContext#postWorkDirectory is protected

### DIFF
--- a/java/org/apache/catalina/core/StandardContext.java
+++ b/java/org/apache/catalina/core/StandardContext.java
@@ -6003,7 +6003,7 @@ public class StandardContext extends ContainerBase
     /**
      * Set the appropriate context attribute for our work directory.
      */
-    private void postWorkDirectory() {
+    protected void postWorkDirectory() {
 
         // Acquire (or calculate) the work directory path
         String workDir = getWorkDir();


### PR DESCRIPTION
Goal is to enable to run tomcat without any temporary files.
For programmatic cases it is often possible and desired (note it is ok to skip jakarta.servlet.context.tempdir for such case).