### PR TITLE
JsonErrorReportValve - fix json format typo

### DIFF
--- a/java/org/apache/catalina/valves/JsonErrorReportValve.java
+++ b/java/org/apache/catalina/valves/JsonErrorReportValve.java
@@ -83,7 +83,7 @@ public class JsonErrorReportValve extends ErrorReportValve {
         }
         String jsonReport = "{\n" +
                             "  \"type\": \"" + type + "\",\n" +
-                            "  \"message\": \"" + message + "\"\n" +
+                            "  \"message\": \"" + message + "\",\n" +
                             "  \"description\": \"" + description + "\"\n" +
                             "}";
         try {


### PR DESCRIPTION
Comma is missing breaking the json format