### PR TITLE
Adding default manager roles in tomcat users config.

### DIFF
--- a/conf/tomcat-users.xml
+++ b/conf/tomcat-users.xml
@@ -20,15 +20,26 @@
               xsi:schemaLocation="http://tomcat.apache.org/xml tomcat-users.xsd"
               version="1.0">
 <!--
-  NOTE:  By default, no user is included in the "manager-gui" role required
+  By default, no user is included in the "manager-gui" role required
   to operate the "/manager/html" web application.  If you wish to use this app,
-  you must define such a user - the username and password are arbitrary. It is
-  strongly recommended that you do NOT use one of the users in the commented out
-  section below since they are intended for use with the examples web
-  application.
+  you must define such a user - the username and password are arbitrary.
+
+  Tomcat manager roles:
+    - manager-gui    - allows access to the HTML GUI and the status pages
+    - manager-script - allows access to the text interface and the status pages
+    - manager-jmx    - allows access to the JMX proxy and the status pages
+    - manager-status - allows access to the status pages only
 -->
 <!--
-  NOTE:  The sample user and role entries below are intended for use with the
+  <role rolename="manager-gui"/>
+  <role rolename="manager-script"/>
+  <role rolename="manager-jmx"/>
+  <role rolename="manager-status"/>
+  <user username="admin" password="<must-be-changed>" roles="manager-gui,manager-jmx"/>
+  <user username="robot" password="<must-be-changed>" roles="manager-script"/>
+-->
+<!--
+  The sample user and role entries below are intended for use with the
   examples web application. They are wrapped in a comment and thus are ignored
   when reading this file. If you wish to configure these users for use with the
   examples web application, do not forget to remove the <!.. ..> that surrounds

--- a/conf/tomcat-users.xml
+++ b/conf/tomcat-users.xml
@@ -24,18 +24,14 @@
   to operate the "/manager/html" web application.  If you wish to use this app,
   you must define such a user - the username and password are arbitrary.
 
-  Tomcat manager roles:
+  Built-in Tomcat manager roles:
     - manager-gui    - allows access to the HTML GUI and the status pages
-    - manager-script - allows access to the text interface and the status pages
+    - manager-script - allows access to the HTTP API and the status pages
     - manager-jmx    - allows access to the JMX proxy and the status pages
     - manager-status - allows access to the status pages only
 -->
 <!--
-  <role rolename="manager-gui"/>
-  <role rolename="manager-script"/>
-  <role rolename="manager-jmx"/>
-  <role rolename="manager-status"/>
-  <user username="admin" password="<must-be-changed>" roles="manager-gui,manager-jmx"/>
+  <user username="admin" password="<must-be-changed>" roles="manager-gui"/>
   <user username="robot" password="<must-be-changed>" roles="manager-script"/>
 -->
 <!--

--- a/res/confinstall/tomcat-users_2.xml
+++ b/res/confinstall/tomcat-users_2.xml
@@ -1,13 +1,24 @@
 <!--
-  NOTE:  By default, no user is included in the "manager-gui" role required
+  By default, no user is included in the "manager-gui" role required
   to operate the "/manager/html" web application.  If you wish to use this app,
-  you must define such a user - the username and password are arbitrary. It is
-  strongly recommended that you do NOT use one of the users in the commented out
-  section below since they are intended for use with the examples web
-  application.
+  you must define such a user - the username and password are arbitrary.
+
+  Tomcat manager roles:
+    - manager-gui    - allows access to the HTML GUI and the status pages
+    - manager-script - allows access to the text interface and the status pages
+    - manager-jmx    - allows access to the JMX proxy and the status pages
+    - manager-status - allows access to the status pages only
 -->
 <!--
-  NOTE:  The sample user and role entries below are intended for use with the
+  <role rolename="manager-gui"/>
+  <role rolename="manager-script"/>
+  <role rolename="manager-jmx"/>
+  <role rolename="manager-status"/>
+  <user username="admin" password="<must-be-changed>" roles="manager-gui,manager-jmx"/>
+  <user username="robot" password="<must-be-changed>" roles="manager-script"/>
+-->
+<!--
+  The sample user and role entries below are intended for use with the
   examples web application. They are wrapped in a comment and thus are ignored
   when reading this file. If you wish to configure these users for use with the
   examples web application, do not forget to remove the <!.. ..> that surrounds

--- a/res/confinstall/tomcat-users_2.xml
+++ b/res/confinstall/tomcat-users_2.xml
@@ -3,18 +3,14 @@
   to operate the "/manager/html" web application.  If you wish to use this app,
   you must define such a user - the username and password are arbitrary.
 
-  Tomcat manager roles:
+  Built-in Tomcat manager roles:
     - manager-gui    - allows access to the HTML GUI and the status pages
-    - manager-script - allows access to the text interface and the status pages
+    - manager-script - allows access to the HTTP API and the status pages
     - manager-jmx    - allows access to the JMX proxy and the status pages
     - manager-status - allows access to the status pages only
 -->
 <!--
-  <role rolename="manager-gui"/>
-  <role rolename="manager-script"/>
-  <role rolename="manager-jmx"/>
-  <role rolename="manager-status"/>
-  <user username="admin" password="<must-be-changed>" roles="manager-gui,manager-jmx"/>
+  <user username="admin" password="<must-be-changed>" roles="manager-gui"/>
   <user username="robot" password="<must-be-changed>" roles="manager-script"/>
 -->
 <!--


### PR DESCRIPTION
Every time I install a tomcat, I first add the tomcat manager users, and I think a lot of people do this as well. However, currently, it's kind of a pain because you have to look it up first what exactly should be written and create the roles/users manually. This here makes it trivial.