### PR TITLE
Fix BZ 65272. Restore the use of LF as an HTTP line terminator

### DIFF
--- a/java/org/apache/coyote/http11/Http11InputBuffer.java
+++ b/java/org/apache/coyote/http11/Http11InputBuffer.java
@@ -550,9 +550,14 @@ public class Http11InputBuffer implements InputBuffer, ApplicationBufferHandler 
                 prevChr = chr;
                 chr = byteBuffer.get();
                 if (chr == Constants.CR) {
-                    // Possible end of request line. Need LF next.
+                    // Possible end of request line. Need LF next else invalid.
                 } else if (prevChr == Constants.CR && chr == Constants.LF) {
+                    // CRLF is the standard line terminator
                     end = pos - 1;
+                    parsingRequestLineEol = true;
+                } else if (chr == Constants.LF) {
+                    // LF is an optional line terminator
+                    end = pos;
                     parsingRequestLineEol = true;
                 } else if (prevChr == Constants.CR || !HttpParser.isHttpProtocol(chr)) {
                     String invalidProtocol = parseInvalid(parsingRequestLineStart, byteBuffer);
@@ -841,7 +846,8 @@ public class Http11InputBuffer implements InputBuffer, ApplicationBufferHandler 
 
             if (chr == Constants.CR && prevChr != Constants.CR) {
                 // Possible start of CRLF - process the next byte.
-            } else if (prevChr == Constants.CR && chr == Constants.LF) {
+            } else if (chr == Constants.LF) {
+                // CRLF or LF is an acceptable line terminator
                 return HeaderParseStatus.DONE;
             } else {
                 if (prevChr == Constants.CR) {
@@ -953,7 +959,8 @@ public class Http11InputBuffer implements InputBuffer, ApplicationBufferHandler 
                     chr = byteBuffer.get();
                     if (chr == Constants.CR) {
                         // Possible start of CRLF - process the next byte.
-                    } else if (prevChr == Constants.CR && chr == Constants.LF) {
+                    } else if (chr == Constants.LF) {
+                        // CRLF or LF is an acceptable line terminator
                         eol = true;
                     } else if (prevChr == Constants.CR) {
                         // Invalid value
@@ -1031,7 +1038,8 @@ public class Http11InputBuffer implements InputBuffer, ApplicationBufferHandler 
             chr = byteBuffer.get();
             if (chr == Constants.CR) {
                 // Skip
-            } else if (prevChr == Constants.CR && chr == Constants.LF) {
+            } else if (chr == Constants.LF) {
+                // CRLF or LF is an acceptable line terminator
                 eol = true;
             } else {
                 headerData.lastSignificantChar = pos;

--- a/test/org/apache/coyote/http11/TestHttp11InputBuffer.java
+++ b/test/org/apache/coyote/http11/TestHttp11InputBuffer.java
@@ -198,6 +198,10 @@ public class TestHttp11InputBuffer extends TomcatBaseTest {
                 // TAB is allowed
                 continue;
             }
+            if (i == '\n') {
+                // LF is the optional line terminator
+                continue;
+            }
             doTestBug51557InvalidCharInValue((char) i);
             tearDown();
             setUp();
@@ -675,24 +679,6 @@ public class TestHttp11InputBuffer extends TomcatBaseTest {
         String[] request = new String[1];
         request[0] =
                 "GET /test HTTP/1.1" + CR +
-                "Host: localhost:8080" + CRLF +
-                "Connection: close" + CRLF +
-                CRLF;
-
-        InvalidClient client = new InvalidClient(request);
-
-        client.doRequest();
-        Assert.assertTrue(client.getResponseLine(), client.isResponse400());
-        Assert.assertTrue(client.isResponseBodyOK());
-    }
-
-
-    @Test
-    public void testInvalidEndOfRequestLine02() {
-
-        String[] request = new String[1];
-        request[0] =
-                "GET /test HTTP/1.1" + LF +
                 "Host: localhost:8080" + CRLF +
                 "Connection: close" + CRLF +
                 CRLF;

--- a/test/org/apache/coyote/http11/TestHttp11InputBufferCRLF.java
+++ b/test/org/apache/coyote/http11/TestHttp11InputBufferCRLF.java
@@ -109,6 +109,14 @@ public class TestHttp11InputBufferCRLF extends TomcatBaseTest {
                 CRLF,
                 Boolean.FALSE, Boolean.FALSE, parameterSets);
 
+        // Standard HTTP/1.1 request using LF rather than CRLF
+        addRequestWithSplits("GET /test HTTP/1.1" + LF +
+                "Host: localhost:8080" + LF +
+                "Connection: close" + LF +
+                LF,
+                Boolean.FALSE, parameterSets);
+
+
         return parameterSets;
     }
 

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -143,6 +143,13 @@
         request line, ensure that all the available data is included in the
         error message. (markt)
       </fix>
+      <fix>
+        <bug>65272</bug>: Restore the optional HTTP feature that allows
+        <code>LF</code> to be treated as a line terminator for the request line
+        and/or HTTP headers lines as well as the standard <code>CRLF</code>.
+        This behaviour was previously removed as a side-effect of the fix for 
+        CVE-2020-1935. (markt)
+      </fix>
     </changelog>
   </subsection>
   <subsection name="Jasper">


### PR DESCRIPTION
Potential fix for https://bz.apache.org/bugzilla/show_bug.cgi?id=65272

Needs careful review, hence using a PR.
If you spot any potential ways an invalid HTTP request line or header could be:
 - accepted as valid
 - rejected later than necessary
 - rejected for the 'wrong' reason

or any other potential parsing error please report it. For bonus points provide a test case that demonstrates the issue.

As always, anything that might have security implications for a current Tomcat release should go to security@a.o rather than here.