### PR TITLE
part.getString will cause OOM without checking maxPostSize, checking maxPostSize first will avoid OOM caused by huge string

### DIFF
--- a/java/org/apache/catalina/connector/Request.java
+++ b/java/org/apache/catalina/connector/Request.java
@@ -2896,22 +2896,14 @@ public class Request implements HttpServletRequest {
                     parts.add(part);
                     if (part.getSubmittedFileName() == null) {
                         String name = part.getName();
-                        String value = null;
-                        try {
-                            value = part.getString(charset.name());
-                        } catch (UnsupportedEncodingException uee) {
-                            // Not possible
-                        }
                         if (maxPostSize >= 0) {
                             // Have to calculate equivalent size. Not completely
                             // accurate but close enough.
                             postSize += name.getBytes(charset).length;
-                            if (value != null) {
-                                // Equals sign
-                                postSize++;
-                                // Value length
-                                postSize += part.getSize();
-                            }
+                            // Equals sign
+                            postSize++;
+                            // Value length
+                            postSize += part.getSize();
                             // Value separator
                             postSize++;
                             if (postSize > maxPostSize) {
@@ -2919,6 +2911,12 @@ public class Request implements HttpServletRequest {
                                 throw new IllegalStateException(sm.getString(
                                         "coyoteRequest.maxPostSizeExceeded"));
                             }
+                        }
+                        String value = null;
+                        try {
+                            value = part.getString(charset.name());
+                        } catch (UnsupportedEncodingException uee) {
+                            // Not possible
                         }
                         parameters.addParameter(name, value);
                     }


### PR DESCRIPTION
In our online server, when the client sends a huge string (hundreds of megabytes) to the server via multipart/form-data, OOM occurs, and the maxPostSize check logic is not executed