### PR TITLE
UserDatabaseRealm does not rely on cached roles only

### DIFF
--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -160,6 +160,17 @@
         AprLifecycleListener does not show dev version suffix for libtcnative
         and libapr. (michaelo)
       </fix>
+      <update>
+        Remove class <code>UserDatabasePrincipal</code> and the <code>hasRole</code>
+        override from class <code>UserDatabaseRealm</code> in order to make the
+        Realm work with cached roles only during a user's login (according to the
+        documentation).
+      </update>
+      <update>
+        Ignore duplicates when collecting the effective roles list from Roles and
+        Groups in <code>UserDatabaseRealm.getPrincipal(String)</code> by using a
+        <code>HashSet</code> instead of an <code>ArrayList</code>.
+      </update>
     </changelog>
   </subsection>
   <subsection name="Coyote">


### PR DESCRIPTION
The UserDatabaseRealm queries its UserDatabase in override hasRole() in order to return a correct result, if the passed Principal is a GenericPrincipal with an associated userPrincipal of type UserDatabasePrincipal. That userPrincipal more or less acts like a tag interface to determine whether that special handling is required. If not, the override calls its super method.

The UserDatabase can be updated through JMX at any time. Currently, such changes are taken into account instantly (at every invocation of hasRole()), which is different from other Realms and the UserDatabaseRealm's documentation.

Since the logged on user's effective roles are calculated and stored in the GenericPrincipal returned from method getPrincipal, these could be used instead. This eliminates both the hasRole() override as well as the private class UserDatabaseRealm.UserDatabasePrincipal and makes the Realm behave according to the documentation (and like e. g. DataSourcRealm).

Also, duplicates will be ignored when effective roles are calculated from the User's Roles and Groups, simply by using a HashSet instead of an ArrayList in method getPrincipal(String),