### PR TITLE
Change log level from error to debug

### DIFF
--- a/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/ConnectionPool.java
+++ b/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/ConnectionPool.java
@@ -977,7 +977,7 @@ public class ConnectionPool {
                     return false;
                 }
             } catch(Exception e) {
-                log.error("Failed to re-connect connection ["+this+"] that expired because of maxAge",e);
+                log.debug("Failed to re-connect connection ["+this+"] that expired because of maxAge",e);
                 return false;
             }
         }


### PR DESCRIPTION
Currently, in reconnectIfExpired(), reconnection failure is producing an error level log. This causes a lot of false positive in our alerting systems. This should be changed to debug level log.