### PR TITLE
Enhancement: Additional user attributes queried by (some) realms

### DIFF
--- a/conf/tomcat-users.xsd
+++ b/conf/tomcat-users.xsd
@@ -45,6 +45,7 @@
             <xs:attribute name="password" type="xs:string" />
             <xs:attribute name="roles" type="xs:string" />
             <xs:attribute name="groups" type="xs:string" />
+            <xs:anyAttribute processContents="skip" />
           </xs:complexType>
         </xs:element>
       </xs:choice>

--- a/java/org/apache/catalina/TomcatPrincipal.java
+++ b/java/org/apache/catalina/TomcatPrincipal.java
@@ -17,6 +17,7 @@
 package org.apache.catalina;
 
 import java.security.Principal;
+import java.util.Enumeration;
 
 import org.ietf.jgss.GSSCredential;
 
@@ -47,4 +48,58 @@ public interface TomcatPrincipal extends Principal {
      *                   exception to LoginContext
      */
     void logout() throws Exception;
+
+    /**
+     * Returns the value of the named attribute as an <code>Object</code>, or
+     * <code>null</code> if no attribute of the given name exists. May also
+     * return <code>null</code>, if the named attribute exists but cannot be
+     * returned in a way that ensures that changes made to the returned object
+     * are not reflected by objects returned by subsequent calls to this method.
+     * <p>
+     * Only the servlet container may set attributes to make available custom
+     * information about a Principal or the user it represents. For example,
+     * some of the Realm implementations can be configured to additionally query
+     * user attributes from the <i>user database</i>, which then are provided
+     * through the Principal's attributes map.
+     * <p>
+     * In order to keep the attributes map <i>immutable</i>, the objects
+     * returned by this method should always be <i>defensive copies</i> of the
+     * objects contained in the attributes map. Any changes applied to these
+     * objects must not be reflected by objects returned by subsequent calls to
+     * this method. If that cannot be guaranteed (e. g. there is no way to copy
+     * the object), the object's string representation (or even
+     * <code>null</code>) shall be returned.
+     * <p>
+     * Attribute names and naming conventions are maintained by the Tomcat
+     * components that contribute to this map, like some of the Realm
+     * implementations.
+     *
+     * @param name a <code>String</code> specifying the name of the attribute
+     * @return an <code>Object</code> containing the value of the attribute, or
+     *         <code>null</code> if the attribute does not exist, or the
+     *         object's string representation or <code>null</code> if its value
+     *         cannot be copied in order to keep the attributes immutable
+     */
+    Object getAttribute(String name);
+
+    /**
+     * Returns an <code>Enumeration</code> containing the names of the
+     * attributes available to this Principal. This method returns an empty
+     * <code>Enumeration</code> if the Principal has no attributes available to
+     * it.
+     *
+     * @return an <code>Enumeration</code> of strings containing the names of
+     *         the Principal's attributes
+     */
+    Enumeration<String> getAttributeNames();
+
+    /**
+     * Determines whether attribute names are case-insensitive. May be
+     * <code>true</code> if using <em>JNDIRealm</em> and then, depends on the
+     * configured directory server.
+     * 
+     * @return <code>true</code>, if attribute names are case-insensitive;
+     *         <code>false</code> otherwise
+     */
+    boolean isAttributesCaseIgnored();
 }

--- a/java/org/apache/catalina/TomcatPrincipal.java
+++ b/java/org/apache/catalina/TomcatPrincipal.java
@@ -51,24 +51,24 @@ public interface TomcatPrincipal extends Principal {
 
     /**
      * Returns the value of the named attribute as an <code>Object</code>, or
-     * <code>null</code> if no attribute of the given name exists. May also
-     * return <code>null</code>, if the named attribute exists but cannot be
-     * returned in a way that ensures that changes made to the returned object
-     * are not reflected by objects returned by subsequent calls to this method.
+     * <code>null</code> if no attribute of the given name exists, or if
+     * <code>null</code> has been specified as the attribute's name. May also return
+     * <code>null</code>, if the named attribute exists but cannot be returned in a
+     * way that ensures that changes made to the returned object are not reflected
+     * by objects returned by subsequent calls to this method.
      * <p>
      * Only the servlet container may set attributes to make available custom
-     * information about a Principal or the user it represents. For example,
-     * some of the Realm implementations can be configured to additionally query
-     * user attributes from the <i>user database</i>, which then are provided
-     * through the Principal's attributes map.
+     * information about a Principal or the user it represents. For example, some of
+     * the Realm implementations can be configured to additionally query user
+     * attributes from the <i>user database</i>, which then are provided through the
+     * Principal's attributes map.
      * <p>
-     * In order to keep the attributes map <i>immutable</i>, the objects
-     * returned by this method should always be <i>defensive copies</i> of the
-     * objects contained in the attributes map. Any changes applied to these
-     * objects must not be reflected by objects returned by subsequent calls to
-     * this method. If that cannot be guaranteed (e. g. there is no way to copy
-     * the object), the object's string representation (or even
-     * <code>null</code>) shall be returned.
+     * In order to keep the attributes map <i>immutable</i>, the objects returned by
+     * this method should always be <i>defensive copies</i> of the objects contained
+     * in the attributes map. Any changes applied to these objects must not be
+     * reflected by objects returned by subsequent calls to this method. If that
+     * cannot be guaranteed (e. g. there is no way to copy the object), the object's
+     * string representation (or even <code>null</code>) shall be returned.
      * <p>
      * Attribute names and naming conventions are maintained by the Tomcat
      * components that contribute to this map, like some of the Realm
@@ -76,7 +76,8 @@ public interface TomcatPrincipal extends Principal {
      *
      * @param name a <code>String</code> specifying the name of the attribute
      * @return an <code>Object</code> containing the value of the attribute, or
-     *         <code>null</code> if the attribute does not exist, or the
+     *         <code>null</code> if the attribute does not exist, or if
+     *         <code>null</code> has been specified as the attribute's name, or the
      *         object's string representation or <code>null</code> if its value
      *         cannot be copied in order to keep the attributes immutable
      */
@@ -92,14 +93,4 @@ public interface TomcatPrincipal extends Principal {
      *         the Principal's attributes
      */
     Enumeration<String> getAttributeNames();
-
-    /**
-     * Determines whether attribute names are case-insensitive. May be
-     * <code>true</code> if using <em>JNDIRealm</em> and then, depends on the
-     * configured directory server.
-     * 
-     * @return <code>true</code>, if attribute names are case-insensitive;
-     *         <code>false</code> otherwise
-     */
-    boolean isAttributesCaseIgnored();
 }

--- a/java/org/apache/catalina/TomcatPrincipal.java
+++ b/java/org/apache/catalina/TomcatPrincipal.java
@@ -52,23 +52,13 @@ public interface TomcatPrincipal extends Principal {
     /**
      * Returns the value of the named attribute as an <code>Object</code>, or
      * <code>null</code> if no attribute of the given name exists, or if
-     * <code>null</code> has been specified as the attribute's name. May also return
-     * <code>null</code>, if the named attribute exists but cannot be returned in a
-     * way that ensures that changes made to the returned object are not reflected
-     * by objects returned by subsequent calls to this method.
+     * <code>null</code> has been specified as the attribute's name.
      * <p>
      * Only the servlet container may set attributes to make available custom
      * information about a Principal or the user it represents. For example, some of
      * the Realm implementations can be configured to additionally query user
      * attributes from the <i>user database</i>, which then are provided through the
      * Principal's attributes map.
-     * <p>
-     * In order to keep the attributes map <i>immutable</i>, the objects returned by
-     * this method should always be <i>defensive copies</i> of the objects contained
-     * in the attributes map. Any changes applied to these objects must not be
-     * reflected by objects returned by subsequent calls to this method. If that
-     * cannot be guaranteed (e. g. there is no way to copy the object), the object's
-     * string representation (or even <code>null</code>) shall be returned.
      * <p>
      * Attribute names and naming conventions are maintained by the Tomcat
      * components that contribute to this map, like some of the Realm
@@ -77,9 +67,7 @@ public interface TomcatPrincipal extends Principal {
      * @param name a <code>String</code> specifying the name of the attribute
      * @return an <code>Object</code> containing the value of the attribute, or
      *         <code>null</code> if the attribute does not exist, or if
-     *         <code>null</code> has been specified as the attribute's name, or the
-     *         object's string representation or <code>null</code> if its value
-     *         cannot be copied in order to keep the attributes immutable
+     *         <code>null</code> has been specified as the attribute's name
      */
     Object getAttribute(String name);
 

--- a/java/org/apache/catalina/User.java
+++ b/java/org/apache/catalina/User.java
@@ -19,6 +19,7 @@ package org.apache.catalina;
 
 import java.security.Principal;
 import java.util.Iterator;
+import java.util.Set;
 
 
 /**
@@ -167,6 +168,44 @@ public interface User extends Principal {
      * Remove all {@link Role}s from those assigned to this user.
      */
     public void removeRoles();
+
+
+    /**
+     * Return the value of the attribute identified by the specified name or
+     * <code>null</code>, if the specified attribute does not exist.
+     * 
+     * @param name the name of the attribute for which to return its value
+     */
+    public String getAttribute(String name);
+
+
+    /**
+     * Set the value of the attribute identified by the specified name. Return the
+     * value previously assigned to the attribute identified by the specified name
+     * or <code>null</code>, if no such attribute exists.
+     * 
+     * @param name the name of the attribute to set the value for
+     * @param value the new value to set
+     */
+    public String setAttribute(String name, String value);
+
+
+    /**
+     * Remove all attributes from this user. 
+     */
+    public void removeAttributes();
+
+
+    /**
+     * @return the set of attributes names assigned to this user.
+     */
+    public Iterator<String> getAttributesNames();
+
+
+    /**
+     * Return a set of reserved names that cannot be used as attribute names.
+     */
+    public Set<String> getReservedAttributeNames();
 
 
 }

--- a/java/org/apache/catalina/realm/DataSourceRealm.java
+++ b/java/org/apache/catalina/realm/DataSourceRealm.java
@@ -134,20 +134,20 @@ public class DataSourceRealm extends RealmBase {
     private volatile boolean connectionSuccess = true;
 
 
-	/**
-	 * The comma separated names of user attributes to additionally query from
-	 * the user table. These will be provided to the user through the created
-	 * Principal's <i>attributes</i> map.
-	 */
-	protected String userAttributes;
+    /**
+     * The comma separated names of user attributes to additionally query from the
+     * user table. These will be provided to the user through the created
+     * Principal's <i>attributes</i> map.
+     */
+    protected String userAttributes;
 
 
     /**
      * Generated SQL statement to query additional user attributes from the user
      * table.
      */
-	private volatile String userAttributesStatement;
-	private final Object userAttributesStatementLock = new Object();
+    private volatile String userAttributesStatement;
+    private final Object userAttributesStatementLock = new Object();
 
 
     // ------------------------------------------------------------- Properties
@@ -267,12 +267,12 @@ public class DataSourceRealm extends RealmBase {
     }
 
     /**
-	 * @return the comma separated names of user attributes to additionally
-	 *         query from the user table
-	 */
-	public String getUserAttributes() {
-		return userAttributes;
-	}
+     * @return the comma separated names of user attributes to additionally query
+     *         from the user table
+     */
+    public String getUserAttributes() {
+        return userAttributes;
+    }
 
     /**
      * Set the comma separated names of user attributes to additionally query from
@@ -290,9 +290,9 @@ public class DataSourceRealm extends RealmBase {
      *
      * @param userAttributes the comma separated names of user attributes
      */
-	public void setUserAttributes(String userAttributes) {
-		this.userAttributes = userAttributes;
-	}
+    public void setUserAttributes(String userAttributes) {
+        this.userAttributes = userAttributes;
+    }
 
 
     // --------------------------------------------------------- Public Methods
@@ -612,51 +612,57 @@ public class DataSourceRealm extends RealmBase {
     }
 
 
-	protected Map<String, Object> getUserAttributesMap(Connection dbConnection,
-			String username) {
+    /**
+     * Return the specified user's requested user attributes as a map.
+     * 
+     * @param dbConnection The database connection to be used
+     * @param username User name for which to return user attributes
+     * 
+     * @return a map containing the specified user's requested user attributes
+     */
+    protected Map<String, Object> getUserAttributesMap(Connection dbConnection, String username) {
 
-	    String preparedAttributes = getUserAttributesStatement(dbConnection);
+        String preparedAttributes = getUserAttributesStatement(dbConnection);
         if (preparedAttributes == null || preparedAttributes == USER_ATTRIBUTES_NONE_REQUESTED) {
             // The above reference comparison is intentional. USER_ATTRIBUTES_NONE_REQUESTED
             // is a tag object (empty String) to distinguish between null (not yet
             // initialized) and empty (no attributes requested).
-	        // TODO Could as well be changed to `preparedAttributes.lenghth() = 0` 
+            // TODO Could as well be changed to `preparedAttributes.lenghth() = 0`
 
             // Return null if no user attributes are requested (or if the statement was not
-            // yet built successfully) 
-			return null;
-		}
+            // yet built successfully)
+            return null;
+        }
 
-	    try (PreparedStatement stmt =
-				dbConnection.prepareStatement(preparedAttributes)) {
-			stmt.setString(1, username);
+        try (PreparedStatement stmt = dbConnection.prepareStatement(preparedAttributes)) {
+            stmt.setString(1, username);
 
-			try (ResultSet rs = stmt.executeQuery()) {
+            try (ResultSet rs = stmt.executeQuery()) {
 
-			    if (rs.next()) {
-			        Map<String, Object> attrs = new LinkedHashMap<>();
-				    ResultSetMetaData md = rs.getMetaData();
-				    int ncols = md.getColumnCount();
-				    for (int columnIndex = 1; columnIndex <= ncols; columnIndex++) {
-				        String columnName = md.getColumnName(columnIndex);
-				        // Ignore case, database may have case-insensitive field names
-				        if (columnName.equalsIgnoreCase(userCredCol)) {
+                if (rs.next()) {
+                    Map<String, Object> attrs = new LinkedHashMap<>();
+                    ResultSetMetaData md = rs.getMetaData();
+                    int ncols = md.getColumnCount();
+                    for (int columnIndex = 1; columnIndex <= ncols; columnIndex++) {
+                        String columnName = md.getColumnName(columnIndex);
+                        // Ignore case, database may have case-insensitive field names
+                        if (columnName.equalsIgnoreCase(userCredCol)) {
                             // Always skip userCredCol (must be there if all columns
-                            // have been requested)  
-				            continue;
-				        }
-				        attrs.put(columnName, rs.getObject(columnIndex));
-					}
-				    return attrs.size() > 0 ? attrs : null;
-				}
-			}
-		} catch (SQLException e) {
-			containerLog.error(sm.getString(
-					"dataSourceRealm.getUserAttributes.exception", username), e);
-		}
+                            // have been requested)
+                            continue;
+                        }
+                        attrs.put(columnName, rs.getObject(columnIndex));
+                    }
+                    return attrs.size() > 0 ? attrs : null;
+                }
+            }
+        } catch (SQLException e) {
+            containerLog.error(
+                    sm.getString("dataSourceRealm.getUserAttributes.exception", username), e);
+        }
 
-		return null;
-	}
+        return null;
+    }
 
 
     /**
@@ -715,7 +721,7 @@ public class DataSourceRealm extends RealmBase {
      * 
      * @param dbConnection connection for accessing the database
      */
-	private List<String> getAvailableUserAttributes(Connection dbConnection) {
+    private List<String> getAvailableUserAttributes(Connection dbConnection) {
 
         try (PreparedStatement stmt =
                 dbConnection.prepareStatement(preparedAttributesAvailable)) {

--- a/java/org/apache/catalina/realm/DataSourceRealm.java
+++ b/java/org/apache/catalina/realm/DataSourceRealm.java
@@ -735,7 +735,7 @@ public class DataSourceRealm extends RealmBase {
                     if (requestedAttributes == null) {
                         return USER_ATTRIBUTES_NONE_REQUESTED;
                     }
-                    if (requestedAttributes.size() > 0
+                    if (requestedAttributes.size() == 1
                             && requestedAttributes.get(0).equals(USER_ATTRIBUTES_WILDCARD)) {
                         userAttributesStatement = "SELECT *" + preparedAttributesTail;
                         return userAttributesStatement;
@@ -747,8 +747,13 @@ public class DataSourceRealm extends RealmBase {
                         // uninitialized, will try again next time).
                         return null;
                     }
-                    requestedAttributes = validateUserAttributes(requestedAttributes,
+                    requestedAttributes = validateUserAttributes(containerLog, requestedAttributes,
                             getDeniedUserAttributes(), availableUserAttributes);
+                    if (requestedAttributes.size() == 0) {
+                        // None of the requested attributes are actually available. Do not query any
+                        // attributes for now. 
+                        return USER_ATTRIBUTES_NONE_REQUESTED;
+                    }
                     StringBuilder sb = new StringBuilder("SELECT ");
                     boolean first = true;
                     for (String attr : requestedAttributes) {

--- a/java/org/apache/catalina/realm/GenericPrincipal.java
+++ b/java/org/apache/catalina/realm/GenericPrincipal.java
@@ -38,7 +38,6 @@ import java.util.UUID;
 import javax.security.auth.login.LoginContext;
 
 import org.apache.catalina.TomcatPrincipal;
-import org.apache.tomcat.util.collections.CaseInsensitiveKeyMap;
 import org.ietf.jgss.GSSCredential;
 
 /**
@@ -335,7 +334,7 @@ public class GenericPrincipal implements TomcatPrincipal, Serializable {
 
     @Override
     public Object getAttribute(String name) {
-        if (attributes == null) {
+        if (attributes == null || name == null) {
             return null;
         }
         Object value = attributes.get(name);
@@ -353,12 +352,6 @@ public class GenericPrincipal implements TomcatPrincipal, Serializable {
             return Collections.emptyEnumeration();
         }
         return Collections.enumeration(attributes.keySet());
-    }
-
-
-    @Override
-    public boolean isAttributesCaseIgnored() {
-        return (attributes instanceof CaseInsensitiveKeyMap<?>);
     }
 
 

--- a/java/org/apache/catalina/realm/GenericPrincipal.java
+++ b/java/org/apache/catalina/realm/GenericPrincipal.java
@@ -369,6 +369,7 @@ public class GenericPrincipal implements TomcatPrincipal, Serializable {
      * this method returns <code>null</code>.
      * 
      * @param obj the object to copy
+     * 
      * @return a deep copied clone of the specified object, or <code>null</code>
      *         if deep-copying was not possible
      */
@@ -464,6 +465,7 @@ public class GenericPrincipal implements TomcatPrincipal, Serializable {
      * </ul>
      * 
      * @param obj the object to copy
+     * 
      * @return a deep copied clone of the specified object or <code>null</code>,
      *         if the specified object does not implement
      *         <code>java.io.Serializable</code> or an error occurred while the

--- a/java/org/apache/catalina/realm/GenericPrincipal.java
+++ b/java/org/apache/catalina/realm/GenericPrincipal.java
@@ -16,24 +16,13 @@
  */
 package org.apache.catalina.realm;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.io.Serializable;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
 import java.security.Principal;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import javax.security.auth.login.LoginContext;
 
@@ -337,12 +326,7 @@ public class GenericPrincipal implements TomcatPrincipal, Serializable {
         if (attributes == null || name == null) {
             return null;
         }
-        Object value = attributes.get(name);
-        if (value == null) {
-            return null;
-        }
-        Object copy = copyObject(value);
-        return copy != null ? copy : value.toString();
+        return attributes.get(name);
     }
 
 
@@ -354,132 +338,6 @@ public class GenericPrincipal implements TomcatPrincipal, Serializable {
         return Collections.enumeration(attributes.keySet());
     }
 
-
-    /**
-     * Creates and returns a deep copy of the specified object. Deep-copying
-     * works only for objects of a couple of <i>hard coded</i> types or, if the
-     * object implements <code>java.io.Serializable</code>. In all other cases,
-     * this method returns <code>null</code>.
-     * 
-     * @param obj the object to copy
-     * 
-     * @return a deep copied clone of the specified object, or <code>null</code>
-     *         if deep-copying was not possible
-     */
-    private Object copyObject(Object obj) {
-
-        // first, try some commonly used object types
-        if (obj instanceof String) {
-            return new String((String) obj);
-
-        } else if (obj instanceof Integer) {
-            return Integer.valueOf((int) obj);
-
-        } else if (obj instanceof Long) {
-            return Long.valueOf((long) obj);
-
-        } else if (obj instanceof Boolean) {
-            return Boolean.valueOf((boolean) obj);
-
-        } else if (obj instanceof Double) {
-            return Double.valueOf((double) obj);
-
-        } else if (obj instanceof Float) {
-            return Float.valueOf((float) obj);
-
-        } else if (obj instanceof Character) {
-            return Character.valueOf((char) obj);
-
-        } else if (obj instanceof Byte) {
-            return Byte.valueOf((byte) obj); 
-
-        } else if (obj instanceof Short) {
-            return Short.valueOf((short) obj);
-
-        } else if (obj instanceof BigDecimal) {
-            return new BigDecimal(((BigDecimal) obj).toString());
-
-        } else if (obj instanceof BigInteger) {
-            return new BigInteger(((BigInteger) obj).toString());
-
-        }
-
-        // Date and JDBC date and time types
-        else if (obj instanceof java.sql.Date) {
-            return ((java.sql.Date) obj).clone();
-
-        } else if (obj instanceof java.sql.Time) {
-            return ((java.sql.Time) obj).clone();
-
-        } else if (obj instanceof java.sql.Timestamp) {
-            return ((java.sql.Timestamp) obj).clone();
-
-        } else if (obj instanceof Date) {
-            return ((Date) obj).clone();
-
-        }
-
-        // these types may come up as well
-        else if (obj instanceof URI) {
-            try {
-                return new URI(((URI) obj).toString());
-            } catch (URISyntaxException e) {
-                // not expected
-            }
-        } else if (obj instanceof URL) {
-            try {
-                return new URI(((URL) obj).toString());
-            } catch (URISyntaxException e) {
-                // not expected
-            }
-        } else if (obj instanceof UUID) {
-            return new UUID(((UUID) obj).getMostSignificantBits(),
-                    ((UUID) obj).getLeastSignificantBits());
-
-        }
-
-        // return a deep copy created by serialization/deserialization (if the
-        // specified object implements java.io.Serializable), null otherwise
-        return copySerializableObject(obj);
-    }
-
-
-    /**
-     * Creates and returns a deep copy of the specified object. This method
-     * tries to deep-copy the object by serializing and deserializing it to and
-     * from a memory buffer, respectively.
-     * <p>
-     * This method returns <code>null</code>, if
-     * <ul>
-     * <li>the specified object does not implement
-     * <code>java.io.Serializable</code></li>
-     * <li>an error occurred while the object was serialized to memory</li>
-     * <li>an error occurred while the object was deserialized from memory</li>
-     * </ul>
-     * 
-     * @param obj the object to copy
-     * 
-     * @return a deep copied clone of the specified object or <code>null</code>,
-     *         if the specified object does not implement
-     *         <code>java.io.Serializable</code> or an error occurred while the
-     *         object was serialized/deserialized
-     */
-    private Object copySerializableObject(Object obj) {
-        if (!(obj instanceof Serializable)) {
-            return null;
-        }
-        try {
-            ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
-            ObjectOutputStream out = new ObjectOutputStream(outBuf);
-            out.writeObject(obj);
-            ByteArrayInputStream inBuf = new ByteArrayInputStream(outBuf.toByteArray());
-            ObjectInputStream in = new ObjectInputStream(inBuf);
-            return in.readObject();
-        } catch (Exception e) {
-            // no-op
-        }
-        return null;
-    }
 
     // ----------------------------------------------------------- Serialization
 

--- a/java/org/apache/catalina/realm/JNDIRealm.java
+++ b/java/org/apache/catalina/realm/JNDIRealm.java
@@ -1626,21 +1626,21 @@ public class JNDIRealm extends RealmBase {
         String[] attrIds = null;
         if (userAttributesList == null
                 || !userAttributesList.get(0).equals(USER_ATTRIBUTES_WILDCARD)) {
-            Set<String> list = new HashSet<>();
+            Set<String> attrSet = new HashSet<>();
             if (userPassword != null) {
-                list.add(userPassword);
+                attrSet.add(userPassword);
             }
             if (userRoleName != null) {
-                list.add(userRoleName);
+                attrSet.add(userRoleName);
             }
             if (userRoleAttribute != null) {
-                list.add(userRoleAttribute);
+                attrSet.add(userRoleAttribute);
             }
             if (userAttributesList != null) {
-                list.addAll(userAttributesList);
+                attrSet.addAll(userAttributesList);
             }
-            attrIds = new String[list.size()];
-            list.toArray(attrIds);
+            attrIds = new String[attrSet.size()];
+            attrSet.toArray(attrIds);
         }
 
         // Use pattern or search for user entry

--- a/java/org/apache/catalina/realm/JNDIRealm.java
+++ b/java/org/apache/catalina/realm/JNDIRealm.java
@@ -33,7 +33,6 @@ import java.util.Hashtable;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;

--- a/java/org/apache/catalina/realm/LocalStrings.properties
+++ b/java/org/apache/catalina/realm/LocalStrings.properties
@@ -32,6 +32,8 @@ dataSourceRealm.commit=Exception committing connection before closing
 dataSourceRealm.exception=Exception performing authentication
 dataSourceRealm.getPassword.exception=Exception retrieving password for [{0}]
 dataSourceRealm.getRoles.exception=Exception retrieving roles for [{0}]
+dataSourceRealm.getUserAttributes.exception=Exception retrieving user attributes for [{0}]
+dataSourceRealm.getAvailableUserAttributes.exception=Exception retrieving names of all available user attributes
 
 jaasCallback.username=Returned username [{0}]
 
@@ -75,6 +77,8 @@ jndiRealm.multipleEntries=User name [{0}] has multiple entries
 jndiRealm.negotiatedTls=Negotiated tls connection using protocol [{0}]
 jndiRealm.open=Exception opening directory server connection
 jndiRealm.tlsClose=Exception closing tls response
+jndiRealm.userAttributeNotFound=Specified user attribute [{0}] was not found for user [{1}]
+jndiRealm.userAttributeNotRequested=Directory sent not explicitly requested user attribute [{0}] for user [{1}]
 
 lockOutRealm.authLockedUser=An attempt was made to authenticate the locked user [{0}]
 lockOutRealm.removeWarning=User [{0}] was removed from the failed users cache after [{1}] seconds to keep the cache size within the limit set
@@ -107,6 +111,8 @@ realmBase.hasRoleFailure=Username [{0}] does NOT have role [{1}]
 realmBase.hasRoleSuccess=Username [{0}] has role [{1}]
 realmBase.invalidDigestEncoding=Invalid digest encoding [{0}]
 realmBase.unknownAllRolesMode=Unknown mode [{0}], must be one of: strict, authOnly, strictAuthOnly
+realmBase.userAttributeNotFound=Specified user attribute [{0}] does not exist
+realmBase.userAttributeAccessDenied=Access to specified user attribute [{0}] has been denied
 
 userDatabaseRealm.lookup=Exception looking up UserDatabase under key [{0}]
 userDatabaseRealm.noDatabase=No UserDatabase component found under key [{0}]

--- a/java/org/apache/catalina/realm/MemoryRealm.java
+++ b/java/org/apache/catalina/realm/MemoryRealm.java
@@ -23,10 +23,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.apache.catalina.LifecycleException;
 import org.apache.juli.logging.Log;
 import org.apache.juli.logging.LogFactory;
@@ -55,13 +53,12 @@ public class MemoryRealm  extends RealmBase {
      * Contains the names of all user attributes available for this Realm.
      */
     private static final List<String> USER_ATTRIBUTES_AVAILABLE =
-            new ArrayList<>(Arrays.asList("username", "fullname", "roles"));
+            Arrays.asList("username", "fullname", "roles");
 
     /**
      * Contains the names of user attributes for which access is denied.
      */
-    private static final List<String> USER_ATTRIBUTES_ACCESS_DENIED =
-            new ArrayList<>(Arrays.asList("password"));
+    private static final List<String> USER_ATTRIBUTES_ACCESS_DENIED = Arrays.asList("password");
 
     // ----------------------------------------------------- Instance Variables
 
@@ -249,7 +246,7 @@ public class MemoryRealm  extends RealmBase {
     void addUser(String username, String password, String roles, String fullname) {
 
         // Accumulate the list of roles for this user
-        Set<String> roleSet = new LinkedHashSet<>();
+        List<String> list = new ArrayList<>();
         roles += ",";
         while (true) {
             int comma = roles.indexOf(',');
@@ -257,7 +254,7 @@ public class MemoryRealm  extends RealmBase {
                 break;
             }
             String role = roles.substring(0, comma).trim();
-            roleSet.add(role);
+            list.add(role);
             roles = roles.substring(comma + 1);
         }
 
@@ -269,23 +266,23 @@ public class MemoryRealm  extends RealmBase {
                 switch (name) {
                 case "username":
                 case "name":
-                    attributes.put(name, new String(username));
+                    attributes.put(name, username);
                     break;
 
                 case "fullname":
-                    attributes.put(name, new String(fullname));
+                    attributes.put(name, fullname);
                     break;
 
                 case "roles":
-                    attributes.put(name, StringUtils.join(roleSet));
+                    attributes.put(name, StringUtils.join(list));
                     break;
                 }
             }
         }
 
         // Construct and cache the Principal for this user
-        GenericPrincipal principal = new GenericPrincipal(username, new ArrayList<String>(roleSet),
-                null, null, null, attributes);
+        GenericPrincipal principal =
+                new GenericPrincipal(username, list, null, null, null, attributes);
         principals.put(username, principal);
         credentials.put(username, password);
 

--- a/java/org/apache/catalina/realm/MemoryRuleSet.java
+++ b/java/org/apache/catalina/realm/MemoryRuleSet.java
@@ -113,10 +113,11 @@ final class MemoryUserRule extends Rule {
         }
         String password = attributes.getValue("password");
         String roles = attributes.getValue("roles");
+        String fullname = attributes.getValue("fullname");
 
         MemoryRealm realm =
             (MemoryRealm) digester.peek(digester.getCount() - 1);
-        realm.addUser(username, password, roles);
+        realm.addUser(username, password, roles, fullname);
 
     }
 

--- a/java/org/apache/catalina/realm/MemoryRuleSet.java
+++ b/java/org/apache/catalina/realm/MemoryRuleSet.java
@@ -113,11 +113,14 @@ final class MemoryUserRule extends Rule {
         }
         String password = attributes.getValue("password");
         String roles = attributes.getValue("roles");
-        String fullname = attributes.getValue("fullname");
+        String fullName = attributes.getValue("fullName");
+        if (fullName == null) {
+            fullName = attributes.getValue("fullname");
+        }
 
         MemoryRealm realm =
             (MemoryRealm) digester.peek(digester.getCount() - 1);
-        realm.addUser(username, password, roles, fullname);
+        realm.addUser(username, password, roles, fullName);
 
     }
 

--- a/java/org/apache/catalina/realm/RealmBase.java
+++ b/java/org/apache/catalina/realm/RealmBase.java
@@ -29,8 +29,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.regex.Pattern;
-
 import jakarta.servlet.annotation.ServletSecurity.TransportGuarantee;
 import jakarta.servlet.http.HttpServletResponse;
 

--- a/java/org/apache/catalina/realm/RealmBase.java
+++ b/java/org/apache/catalina/realm/RealmBase.java
@@ -1307,64 +1307,6 @@ public abstract class RealmBase extends LifecycleMBeanBase implements Realm {
         return null;
     }
 
-    /**
-     * Parse the specified delimiter separated names of attributes and return a list
-     * of that names or <code>null</code>, if no attributes have been specified.
-     * Resolve wildcard characters (if any), remove duplicate names and optionally
-     * skip invalid attributes or attributes for which access is denied.
-     * <p>
-     * If a wildcard character is found, return <code>availableAttributes</code> or,
-     * in case the latter is <code>null</code> (that is, we don't know which
-     * attributes are available in advance) or <code>resolveWildcard</code> is
-     * <code>false</code>, a list consisting of a single wildcard character only
-     * (that is, we want the <i>raw</i> wildcard character unresolved).
-     * <p>
-     * If <code>deniedAttributes</code> is not <code>null</code>, log an
-     * <i>userAttributeAccessDenied</i> message for each specified attribute
-     * <b>contained</b> in that list.
-     * <p>
-     * If <code>availableAttributes</code> is not <code>null</code>, log an
-     * <i>userAttributeNotFound</i> message for each specified attribute <b>not
-     * contained</b> in that list.
-     * 
-     * @param userAttributes comma separated names of attributes to parse
-     * @param deniedAttributes list of attribute names for which access is denied
-     * @param availableAttributes list of available (aka valid) attribute names
-     * @param resolveWildcard if <code>true</code>, return <code>availableAttributes</code>
-     *            if a wildcard character was found and <code>availableAttributes</code>
-     *            is not <code>null</code>; otherwise return a list consisting of a
-     *            single wildcard character only
-     * @return a list containing the parsed attribute names or <code>null</code>, if
-     *         no attributes have been specified
-     */
-    protected List<String> parseUserAttributes(String userAttributes,
-            List<String> deniedAttributes, List<String> availableAttributes,
-            boolean resolveWildcard) {
-        if (userAttributes == null) {
-            return null;
-        }
-        List<String> attrs = new ArrayList<>();
-        for (String name : userAttributes.split(USER_ATTRIBUTES_DELIMITER)) {
-            name = name.trim();
-            if (name.length() == 0) {
-                continue;
-            }
-            if (name.equals(USER_ATTRIBUTES_WILDCARD)) {
-                return (availableAttributes != null && resolveWildcard) ? availableAttributes
-                        : Collections.singletonList(USER_ATTRIBUTES_WILDCARD);
-            }
-            if (attrs.contains(name)) {
-                // skip duplicates
-                continue;
-            }
-            attrs.add(name);
-        }
-        if (deniedAttributes != null || availableAttributes != null) {
-            return validateUserAttributes(attrs, deniedAttributes, availableAttributes);
-        }
-        return attrs.size() > 0 ? attrs : null;
-    }
-
 
     /**
      * Parse the specified delimiter separated attribute names and return a list of
@@ -1378,7 +1320,25 @@ public abstract class RealmBase extends LifecycleMBeanBase implements Realm {
      *         no attributes have been specified
      */
     protected List<String> parseUserAttributes(String userAttributes) {
-        return parseUserAttributes(userAttributes, null, null, false);
+        if (userAttributes == null) {
+            return null;
+        }
+        List<String> attrs = new ArrayList<>();
+        for (String name : userAttributes.split(USER_ATTRIBUTES_DELIMITER)) {
+            name = name.trim();
+            if (name.length() == 0) {
+                continue;
+            }
+            if (name.equals(USER_ATTRIBUTES_WILDCARD)) {
+                return Collections.singletonList(USER_ATTRIBUTES_WILDCARD);
+            }
+            if (attrs.contains(name)) {
+                // skip duplicates
+                continue;
+            }
+            attrs.add(name);
+        }
+        return attrs.size() > 0 ? attrs : null;
     }
 
 
@@ -1394,13 +1354,14 @@ public abstract class RealmBase extends LifecycleMBeanBase implements Realm {
      * <i>userAttributeAccessDenied</i> message for each specified attribute
      * <b>contained</b> in that list.
      * 
+     * @param log the logger used for logging invalid attributes names
      * @param userAttributes list of attribute names to validate
      * @param deniedAttributes list of attribute names for which access is denied
      * @param availableAttributes list of available (aka valid) attribute names
      * @return the validated attribute names as a list or <code>null</code>, if
      *         there are no valid attributes
      */
-    protected List<String> validateUserAttributes(List<String> userAttributes,
+    protected List<String> validateUserAttributes(Log log, List<String> userAttributes,
             List<String> deniedAttributes, List<String> availableAttributes) {
         if (userAttributes == null || userAttributes.size() == 0) {
             return null;
@@ -1411,13 +1372,13 @@ public abstract class RealmBase extends LifecycleMBeanBase implements Realm {
         List<String> attrs = new ArrayList<>();
         for (String name : userAttributes) {
             if (deniedAttributes != null && deniedAttributes.contains(name)) {
-                if (containerLog != null && containerLog.isWarnEnabled()) {
-                    containerLog.warn(sm.getString("realmBase.userAttributeAccessDenied", name));
+                if (log != null && log.isWarnEnabled()) {
+                    log.warn(sm.getString("realmBase.userAttributeAccessDenied", name));
                 }
                 continue;
             } else if (availableAttributes != null && !availableAttributes.contains(name)) {
-                if (containerLog != null && containerLog.isWarnEnabled()) {
-                    containerLog.warn(sm.getString("realmBase.userAttributeNotFound", name));
+                if (log != null && log.isWarnEnabled()) {
+                    log.warn(sm.getString("realmBase.userAttributeNotFound", name));
                 }
                 continue;
             } else if (name.equals(USER_ATTRIBUTES_WILDCARD)) {

--- a/java/org/apache/catalina/realm/RealmBase.java
+++ b/java/org/apache/catalina/realm/RealmBase.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+
 import jakarta.servlet.annotation.ServletSecurity.TransportGuarantee;
 import jakarta.servlet.http.HttpServletResponse;
 

--- a/java/org/apache/catalina/realm/UserDatabaseRealm.java
+++ b/java/org/apache/catalina/realm/UserDatabaseRealm.java
@@ -492,10 +492,10 @@ public class UserDatabaseRealm extends RealmBase {
             switch (name) {
             case "username":
             case "name":
-                return new String(user.getUsername());
+                return user.getUsername();
 
             case "fullname":
-                return new String(user.getFullName());
+                return user.getFullName();
 
             case "groups":
                 sb = new StringBuilder();

--- a/java/org/apache/catalina/realm/UserDatabaseRealm.java
+++ b/java/org/apache/catalina/realm/UserDatabaseRealm.java
@@ -18,7 +18,6 @@ package org.apache.catalina.realm;
 
 import java.io.ObjectStreamException;
 import java.security.Principal;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -56,14 +55,12 @@ public class UserDatabaseRealm extends RealmBase {
      * Contains the names of all user attributes available for this Realm.
      */
     private static final List<String> USER_ATTRIBUTES_AVAILABLE =
-            new ArrayList<>(Arrays.asList("username", "fullname", "groups",
-                    "roles", "effectiveRoles"));
+            Arrays.asList("username", "fullname", "groups", "roles", "effectiveRoles");
 
     /**
      * Contains the names of user attributes for which access is denied.
      */
-    private static final List<String> USER_ATTRIBUTES_ACCESS_DENIED =
-            new ArrayList<>(Arrays.asList("password"));
+    private static final List<String> USER_ATTRIBUTES_ACCESS_DENIED = Arrays.asList("password");
 
 
     // ----------------------------------------------------- Instance Variables

--- a/java/org/apache/catalina/realm/UserDatabaseRealm.java
+++ b/java/org/apache/catalina/realm/UserDatabaseRealm.java
@@ -291,11 +291,15 @@ public class UserDatabaseRealm extends RealmBase {
         if (user == null) {
             return null;
         } else {
+<<<<<<< Upstream, based on origin/main
             if (useStaticPrincipal) {
                 return new GenericPrincipal(username, Arrays.asList(getRoles(user)));
             } else {
                 return new UserDatabasePrincipal(user, database);
             }
+=======
+            return new UserDatabasePrincipal(user);
+>>>>>>> 5aac520 Adjust to latest version in main branch
         }
     }
 
@@ -391,17 +395,28 @@ public class UserDatabaseRealm extends RealmBase {
 
     public static final class UserDatabasePrincipal extends GenericPrincipal {
         private static final long serialVersionUID = 1L;
+<<<<<<< Upstream, based on origin/main
         private final transient UserDatabase database;
         private final List<String> userAttributesList;
+=======
+        private final User user;
+>>>>>>> 5aac520 Adjust to latest version in main branch
 
+<<<<<<< Upstream, based on origin/main
         public UserDatabasePrincipal(User user, UserDatabase database) {
             super(user.getName());
             this.database = database;
             userAttributesList = UserDatabaseRealm.this.getUserAttributesList();
+=======
+        public UserDatabasePrincipal(User user) {
+            super(user.getName());
+            this.user = user;
+>>>>>>> 5aac520 Adjust to latest version in main branch
         }
 
         @Override
         public String[] getRoles() {
+<<<<<<< Upstream, based on origin/main
             if (database == null) {
                 return new String[0];
             }
@@ -409,6 +424,8 @@ public class UserDatabaseRealm extends RealmBase {
             if (user == null) {
                 return new String[0];
             }
+=======
+>>>>>>> 5aac520 Adjust to latest version in main branch
             Set<String> roles = new HashSet<>();
             Iterator<Role> uroles = user.getRoles();
             while (uroles.hasNext()) {
@@ -434,6 +451,10 @@ public class UserDatabaseRealm extends RealmBase {
             } else if (role == null) {
                 return false;
             }
+<<<<<<< Upstream, based on origin/main
+=======
+            UserDatabase database = getUserDatabase();
+>>>>>>> 5aac520 Adjust to latest version in main branch
             if (database == null) {
                 return super.hasRole(role);
             }
@@ -460,6 +481,7 @@ public class UserDatabaseRealm extends RealmBase {
 
         @Override
         public Object getAttribute(String name) {
+            List<String> userAttributesList = getUserAttributesList();
             if (userAttributesList == null || !userAttributesList.contains(name)) {
                 // Return only requested attributes 
                 return null;
@@ -514,7 +536,7 @@ public class UserDatabaseRealm extends RealmBase {
 
         @Override
         public Enumeration<String> getAttributeNames() {
-            return Collections.enumeration(userAttributesList);
+            return Collections.enumeration(getUserAttributesList());
         }
 
         /**
@@ -531,6 +553,7 @@ public class UserDatabaseRealm extends RealmBase {
         }
 
         private Map<String, Object> getUserAttributesMap() {
+            List<String> userAttributesList = getUserAttributesList();
             if (userAttributesList == null) {
                 return null;
             }

--- a/java/org/apache/catalina/realm/UserDatabaseRealm.java
+++ b/java/org/apache/catalina/realm/UserDatabaseRealm.java
@@ -296,12 +296,15 @@ public class UserDatabaseRealm extends RealmBase {
         if (user == null) {
             return null;
         } else {
-            UserDatabasePrincipal principal =
-                    new UserDatabasePrincipal(user, database, getUserAttributesList(user));
+            List<String> userAttrs = getUserAttributesList(user);
             if (useStaticPrincipal) {
-                return principal.getStaticPrincipal();
+                if (userAttrs == null) {
+                    return new GenericPrincipal(username, Arrays.asList(getRoles(user)));
+                } else {
+                    return new UserDatabasePrincipal(user, database, userAttrs).getStaticPrincipal();
+                }
             } else {
-                return principal;
+                return new UserDatabasePrincipal(user, database, userAttrs);
             }
         }
     }
@@ -418,7 +421,7 @@ public class UserDatabaseRealm extends RealmBase {
     public static final class UserDatabasePrincipal extends GenericPrincipal {
         private static final long serialVersionUID = 1L;
         private final transient UserDatabase database;
-        private final List<String> userAttributesList;
+        private final transient List<String> userAttributesList;
 
         public UserDatabasePrincipal(User user, UserDatabase database, List<String> userAttributesList) {
             super(user.getName());
@@ -493,7 +496,7 @@ public class UserDatabaseRealm extends RealmBase {
             if (database == null) {
                 return super.getAttribute(name);
             }
-            User user = database.findUser(name);
+            User user = database.findUser(this.name);
             if (user == null) {
                 return null;
             }

--- a/java/org/apache/catalina/realm/mbeans-descriptors.xml
+++ b/java/org/apache/catalina/realm/mbeans-descriptors.xml
@@ -57,6 +57,10 @@
                  type="java.lang.String"
                  writeable="false"/>
 
+    <attribute   name="userAttributes"
+          description="Comma separated list of user attributes (fields) to additionally query from the user table"
+                 type="java.lang.String"/>
+
     <attribute   name="userCredCol"
           description="The column in the user table that holds the user's credentials"
                  type="java.lang.String"/>
@@ -231,6 +235,10 @@
                  type="java.lang.String"
                  writeable="false"/>
 
+    <attribute   name="userAttributes"
+          description="Comma separated list of user attributes to additionally query from the user's directory entry"
+                 type="java.lang.String"/>
+
     <attribute   name="userBase"
           description="The base element for user searches"
                  type="java.lang.String"/>
@@ -299,6 +307,11 @@
                  type="java.lang.String"
                  writeable="false"/>
 
+    <attribute   name="userAttributes"
+          description="Comma separated list of user attributes to additionally query from the read XML file"
+                 type="java.lang.String"
+            writeable="false"/>
+
     <attribute   name="validate"
           description="The 'validate certificate chains' flag."
                  type="boolean"/>
@@ -341,6 +354,10 @@
           description="The name of the LifecycleState that this component is currently in"
                  type="java.lang.String"
                  writeable="false"/>
+
+    <attribute   name="userAttributes"
+          description="Comma separated list of user attributes to additionally query from the underlying user database"
+                 type="java.lang.String"/>
 
     <attribute   name="validate"
           description="The 'validate certificate chains' flag."

--- a/java/org/apache/catalina/users/AbstractUser.java
+++ b/java/org/apache/catalina/users/AbstractUser.java
@@ -16,8 +16,8 @@
  */
 package org.apache.catalina.users;
 
-
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -34,6 +34,12 @@ import org.apache.catalina.User;
  * @since 4.1
  */
 public abstract class AbstractUser implements User {
+
+
+    /**
+     * Reserved attribute names (none by default).
+     */
+    private static final Set<String> RESERVED_ATTRIBUTE_NAMES = new HashSet<>();
 
 
     // ----------------------------------------------------- Instance Variables
@@ -278,7 +284,9 @@ public abstract class AbstractUser implements User {
      * Return a set of reserved names that cannot be used as attribute names.
      */
     @Override
-    public abstract Set<String> getReservedAttributeNames();
+    public Set<String> getReservedAttributeNames() {
+        return RESERVED_ATTRIBUTE_NAMES;
+    };
 
 
     // ------------------------------------------------------ Principal Methods

--- a/java/org/apache/catalina/users/AbstractUser.java
+++ b/java/org/apache/catalina/users/AbstractUser.java
@@ -17,7 +17,10 @@
 package org.apache.catalina.users;
 
 
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
 
 import org.apache.catalina.Group;
 import org.apache.catalina.Role;
@@ -52,6 +55,12 @@ public abstract class AbstractUser implements User {
      * The logon username of this user.
      */
     protected String username = null;
+
+
+    /**
+     * Additional attributes of this user. 
+     */
+    protected Map<String, String> attributes = new HashMap<>(); 
 
 
     // ------------------------------------------------------------- Properties
@@ -208,6 +217,68 @@ public abstract class AbstractUser implements User {
      */
     @Override
     public abstract void removeRoles();
+
+
+    /**
+     * Return the value of the attribute identified by the specified name or
+     * <code>null</code>, if the specified attribute does not exist.
+     * 
+     * @param name the name of the attribute for which to return its value
+     */
+    @Override
+    public String getAttribute(String name) {
+        return attributes.get(name);
+    }
+
+
+    /**
+     * Set the value of the attribute identified by the specified name. Return the
+     * value previously assigned to the attribute identified by the specified name
+     * or <code>null</code>, if no such attribute exists.
+     * <p>
+     * If the specified name is a <i>reserved name</i>, according to the set
+     * returned by {@link #getReservedAttributeNames()}, this method does nothing
+     * and returns <code>null</code>. Reserved named are those used to store the
+     * user's well-defined basic properties <code>username</code>,
+     * <code>password</code>, <code>fullname</code>, <code>groups</code> and
+     * <code>roles</code> as well as alias property names <code>name</code> and
+     * <code>fullName</code>.
+     * 
+     * @param name the name of the attribute to set the value for
+     * @param value the new value to set
+     */
+    @Override
+    public String setAttribute(String name, String value) {
+        if (getReservedAttributeNames().contains(name)) {
+            return null;
+        }
+        return attributes.put(name, value);
+    }
+
+
+    /**
+     * Remove all attributes from this user. 
+     */
+    @Override
+    public void removeAttributes() {
+        attributes.clear();
+    }
+
+
+    /**
+     * Return the set of attributes names assigned to this user.
+     */
+    @Override
+    public Iterator<String> getAttributesNames() {
+        return attributes.keySet().iterator();
+    }
+
+
+    /**
+     * Return a set of reserved names that cannot be used as attribute names.
+     */
+    @Override
+    public abstract Set<String> getReservedAttributeNames();
 
 
     // ------------------------------------------------------ Principal Methods

--- a/java/org/apache/catalina/users/MemoryUser.java
+++ b/java/org/apache/catalina/users/MemoryUser.java
@@ -17,6 +17,16 @@
 package org.apache.catalina.users;
 
 
+import java.util.Arrays;
+import java.util.HashSet;
+
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.apache.catalina.Group;
+import org.apache.catalina.Role;
 import org.apache.catalina.UserDatabase;
 import org.apache.tomcat.util.buf.StringUtils;
 import org.apache.tomcat.util.security.Escape;
@@ -30,6 +40,9 @@ import org.apache.tomcat.util.security.Escape;
  */
 public class MemoryUser extends GenericUser<MemoryUserDatabase> {
 
+
+    private static final Set<String> RESERVED_ATTRIBUTE_NAMES = new HashSet<>(Arrays
+            .asList("username", "name", "password", "fullname", "fullName", "groups", "roles"));
 
     /**
      * Package-private constructor used by the factory method in
@@ -73,6 +86,13 @@ public class MemoryUser extends GenericUser<MemoryUserDatabase> {
         sb.append(" roles=\"");
         StringUtils.join(roles, ',', (x) -> Escape.xml(x.getRolename()), sb);
         sb.append("\"");
+        for (Entry<String, String> attr : attributes.entrySet()) {
+            sb.append(" ");
+            sb.append(Escape.xml(attr.getKey()));
+            sb.append("=\"");
+            sb.append(Escape.xml(attr.getValue()));
+            sb.append("\"");
+        }
         sb.append("/>");
         return sb.toString();
     }
@@ -98,6 +118,19 @@ public class MemoryUser extends GenericUser<MemoryUserDatabase> {
         sb.append(", roles=\"");
         StringUtils.join(roles, ',', (x) -> Escape.xml(x.getRolename()), sb);
         sb.append("\"");
+        for (Entry<String, String> attr : attributes.entrySet()) {
+            sb.append(", ");
+            sb.append(Escape.xml(attr.getKey()));
+            sb.append("=\"");
+            sb.append(Escape.xml(attr.getValue()));
+            sb.append("\"");
+        }
         return sb.toString();
+    }
+
+
+    @Override
+    public Set<String> getReservedAttributeNames() {
+        return RESERVED_ATTRIBUTE_NAMES;
     }
 }

--- a/java/org/apache/catalina/users/MemoryUser.java
+++ b/java/org/apache/catalina/users/MemoryUser.java
@@ -20,13 +20,9 @@ package org.apache.catalina.users;
 import java.util.Arrays;
 import java.util.HashSet;
 
-import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
 
-import org.apache.catalina.Group;
-import org.apache.catalina.Role;
 import org.apache.catalina.UserDatabase;
 import org.apache.tomcat.util.buf.StringUtils;
 import org.apache.tomcat.util.security.Escape;

--- a/java/org/apache/catalina/users/MemoryUserDatabase.java
+++ b/java/org/apache/catalina/users/MemoryUserDatabase.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -864,6 +865,13 @@ class MemoryUserCreationFactory extends AbstractObjectCreationFactory {
                     }
                     user.addRole(role);
                 }
+            }
+        }
+        Set<String> reservedNames = user.getReservedAttributeNames();
+        for (int i = 0; i < attributes.getLength(); i++) {
+            String attrName = attributes.getLocalName(i);
+            if (!reservedNames.contains(attrName)) {
+                user.setAttribute(attrName, attributes.getValue(i));
             }
         }
         return user;

--- a/java/org/apache/tomcat/util/collections/CaseInsensitiveKeyLinkedMap.java
+++ b/java/org/apache/tomcat/util/collections/CaseInsensitiveKeyLinkedMap.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tomcat.util.collections;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+
+/**
+ * A Map implementation that uses case-insensitive (using
+ * {@link Locale#ENGLISH}) strings as keys. This class uses a
+ * <code>LinkedHashMap</code> as backing store. So this Map's behavior, except
+ * for case-insensitive key handling, is comparable with
+ * <code>LinkedHashMap</code>. Most notably is its predictable iteration order.
+ * <p>
+ * Keys must be instances of {@link String}. Note that this means that
+ * <code>null</code> keys are not permitted.
+ * <p>
+ * This implementation is not thread-safe.
+ *
+ * @param <V> Type of values placed in this Map.
+ * @see LinkedHashMap
+ */
+public class CaseInsensitiveKeyLinkedMap<V> extends CaseInsensitiveKeyMap<V> {
+
+    /**
+     * Constructs an empty insertion-ordered
+     * <code>CaseInsensitiveKeyLinkedMap</code> instance with the default initial
+     * capacity (16) and load factor (0.75).
+     */
+    public CaseInsensitiveKeyLinkedMap() {
+        this(false);
+    }
+    
+    /**
+     * Constructs an empty <code>CaseInsensitiveKeyLinkedMap</code> instance with
+     * the specified ordering mode.
+     *
+     * @param accessOrder the ordering mode - <code>true</code> for access-order,
+     *            <code>false</code> for insertion-order
+     */
+    public CaseInsensitiveKeyLinkedMap(boolean accessOrder) {
+        super(new LinkedHashMap<>(16, 0.75f, accessOrder));
+    }
+}

--- a/java/org/apache/tomcat/util/collections/CaseInsensitiveKeyMap.java
+++ b/java/org/apache/tomcat/util/collections/CaseInsensitiveKeyMap.java
@@ -27,8 +27,10 @@ import java.util.Set;
 import org.apache.tomcat.util.res.StringManager;
 
 /**
- * A Map implementation that uses case-insensitive (using {@link
- * Locale#ENGLISH}) strings as keys.
+ * A Map implementation that uses case-insensitive (using
+ * {@link Locale#ENGLISH}) strings as keys. This class uses a
+ * <code>HashMap</code> as backing store. So this Map's behavior, except for
+ * case-insensitive key handling, is comparable with <code>HashMap</code>.
  * <p>
  * Keys must be instances of {@link String}. Note that this means that
  * <code>null</code> keys are not permitted.
@@ -36,14 +38,31 @@ import org.apache.tomcat.util.res.StringManager;
  * This implementation is not thread-safe.
  *
  * @param <V> Type of values placed in this Map.
+ * @see HashMap
  */
 public class CaseInsensitiveKeyMap<V> extends AbstractMap<String,V> {
 
     private static final StringManager sm =
             StringManager.getManager(CaseInsensitiveKeyMap.class);
 
-    private final Map<Key,V> map = new HashMap<>();
+    private final Map<Key,V> map;
 
+    /**
+     * Constructs an empty CaseInsensitiveKeyMap with the default initial capacity
+     * (16) and the default load factor (0.75).
+     */
+    public CaseInsensitiveKeyMap() {
+        this(new HashMap<>());
+    }
+    
+    /**
+     * Allow initializing the backing store Map from subclasses.
+     * 
+     * @param map the map used as backing store  
+     */
+    protected CaseInsensitiveKeyMap(Map<Key,V> map) {
+        this.map = map;
+    }
 
     @Override
     public V get(Object key) {
@@ -164,7 +183,7 @@ public class CaseInsensitiveKeyMap<V> extends AbstractMap<String,V> {
         }
     }
 
-    private static class Key {
+    protected static class Key {
 
         private final String key;
         private final String lcKey;

--- a/test/org/apache/catalina/users/MemoryUserDatabaseTests.java
+++ b/test/org/apache/catalina/users/MemoryUserDatabaseTests.java
@@ -190,7 +190,7 @@ public class MemoryUserDatabaseTests {
     public void testSerializePrincipal()
         throws Exception {
         User user = db.findUser("admin");
-        GenericPrincipal gpIn = new UserDatabaseRealm.UserDatabasePrincipal(user, db);
+        GenericPrincipal gpIn = new UserDatabaseRealm.UserDatabasePrincipal(user, db, null);
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(bos);
         oos.writeObject(gpIn);

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -120,6 +120,15 @@
         Add recycling check in the input and output stream isReady to try to
         give a more informative ISE when the facade has been recycled. (remm)
       </fix>
+      <add>
+        <!--  please, add this to the latest "in development" section ("Tomcat 10.1.0-M6 (markt)")
+              I just didn't want to merge my branch with your latest upstream :-) 
+        -->
+        Add support for querying configured additional user attributes to  
+        <code>DataSourceRealm</code>, <code>JNDIRealm</code>,
+        <code>MemoryRelam</code> and <code>UserDatabaseRealm</code>. Patch
+        provided by Carsten Klein. (friendlycommitter)
+      </add>
     </changelog>
   </subsection>
   <subsection name="Coyote">

--- a/webapps/docs/config/realm.xml
+++ b/webapps/docs/config/realm.xml
@@ -166,6 +166,34 @@
         name. If not specified, the default is <code>true</code>.</p>
       </attribute>
 
+      <attribute name="userAttributes" required="false">
+        <p>Comma separated list of names of columns to additionally query from
+        the "users" table named by the <code>userTable</code> attribute. These
+        are provided to the application as <i>Additional User Attributes</i>
+        through the Principal's attributes map (with configured column names
+        used as the keys). This attribute also supports the wildcard character
+        <code>*</code>, which means to query <i>all</i> columns (except, for
+        security reasons, the column containing the user's credentials).</p>
+        <p>Any of the "users" table's columns can be specified, except the
+        column containing the user's credentials (i.e. password) named by the
+        <code>userCredCol</code> attribute. If the credentials column is
+        explicitly specified, it will be ignored and a warning will be logged.
+        </p>
+        <p>Specified columns that are not present in the "users" table are
+        dropped from the list and a warning is logged, one for each missing
+        column. However, these checks are performed only once while the Realm
+        processes its first login attempt. If the structure of the "users"
+        table significantly changes after that point in time (i.e. a specified
+        column gets removed), an exception is likely the result for each
+        subsequent login attempt until the Realm gets restarted. Even so,
+        exceptions caused by user attribute queries do not prevent the user
+        from loggin in, but only cause the associated Principal's attributes
+        map being empty.</p>
+        <p>See the <a href="../realm-howto.html#Additional_User_Attributes">
+        Additional User Attributes How-To</a> for more information on how
+        additional user attributes can be access from your application.</p>
+      </attribute>
+
       <attribute name="userCredCol" required="true">
         <p>Name of the column, in the "users" table, which contains
         the user's credentials (i.e. password).  If a
@@ -173,6 +201,8 @@
         will assume that the passwords have been encoded with the
         specified algorithm.  Otherwise, they will be assumed to be
         in clear text.</p>
+        <p>For security reasons, the column named by this attribute cannot
+        be used as an <i>Additional User Attribute</i>.</p>
       </attribute>
 
       <attribute name="userNameCol" required="true">
@@ -192,7 +222,10 @@
       <attribute name="userTable" required="true">
         <p>Name of the "users" table, which must contain columns named
         by the <code>userNameCol</code> and <code>userCredCol</code>
-        attributes.</p>
+        attributes. More columns containing needful user information could
+        freely be added. These can be provided to the application as
+        <i>Additional User Attributes</i> configured by the
+        <code>userAttributes</code> attribute.</p>
       </attribute>
 
       <attribute name="X509UsernameRetrieverClassName" required="false">
@@ -523,6 +556,37 @@
         <code>true</code> is used.</p>
       </attribute>
 
+      <attribute name="userAttributes" required="false">
+        <p>Comma separated list of names of attributes to additionally query
+        from the user's directory entry. These are provided to the application
+        as <i>Additional User Attributes</i> through the Principal's attributes
+        map (with configured attributes names used as the keys). This attribute
+        also supports the wildcard character <code>*</code>, which means to
+        query <i>all</i> attributes (except, for security reasons, the
+        attribute containing the user's password, if it's specified).</p>
+        <p>Any of the attributes in the user's entry can be specified, except
+        the attribute containing the user's password named by the
+        <code>userPassword</code> attribute (if present). If the password
+        attribute is explicitly specified, it will be ignored and a warning
+        will be logged.</p>
+        <p>The LDAP v3 allows <i>options</i> to be appended to an attribute
+        name (i.e. ";binary" to force an attribute to be returned as 
+        <code>byte[]</code> instead of <code>String</code>). If such an option
+        is present in a requested attribute's name, it will also be part of the
+        attribute's key in the Principal's attributes map. Since attribute
+        names in LDAP are always case-insensitive, the attributes map provided
+        through the user's Principal is also case-insensitive. That is, its
+        keys are comparared ignoring case.</p>
+        <p>Specified attributes that are not present in the user's directory
+        entry are ignored and a warning is logged, one for each missing
+        attribute. However, since in a directory, every user entry could have
+        its own set of attributes, invalid attributes (if any) are logged on
+        every login attempt.</p>
+        <p>See the <a href="../realm-howto.html#Additional_User_Attributes">
+        Additional User Attributes How-To</a> for more information on how
+        additional user attributes can be access from your application.</p>
+      </attribute>
+
       <attribute name="userBase" required="false">
         <p>The base element for user searches performed using the
         <code>userSearch</code> expression.  Not used if you are using
@@ -684,6 +748,38 @@
            specified, the default value of <code>302</code> is used.</p>
       </attribute>
 
+      <attribute name="userAttributes" required="false">
+        <p>Comma separated list of names of attributes to additionally query
+        from the user's entry in the UserDatabase. These are provided to the
+        application as <i>Additional User Attributes</i> through the
+        Principal's attributes map (with configured attributes names used as
+        the keys). This attribute also supports the wildcard character
+        <code>*</code>, which means to query <i>all</i> attributes (except, for
+        security reasons, the <code>password</code> attribute).</p>
+        <p>Except the <code>password</code> attribute, any of the user entry's
+        attributes that are defined by and used by the UserDatabase can be
+        specified: <code>username</code> (or its alias <code>name</code>),
+        <code>fullName</code> (or its alias <code>fullname</code>),
+        <code>groups</code> and <code>roles</code>, as well as extra attribute
+        <code>effectiveRoles</code>, which contains a comma separated list of
+        the user's effective roles. All these are also referred to as
+        <i>core attributes</i>, which are always available (thought they could
+        be <code>null</code> or empty).</p>
+        <p>Additionally, and in contrast to <i>core attributes</i>, more
+        arbitrary XML attributes could be added to the users' entries
+        <code>&lt;user ...</code>, like <code>room</code>, <code>email</code>
+        and <code>phone</code>. The only purpose of these <i>non-core</i>
+        attributes is to be queried as user attributes. Specified
+        <i>non-core</i> attributes that are not present in the user's entry in
+        the UserDatabase are ignored and a warning is logged, one for each
+        missing attribute. However, since in the UserDatabase, every user entry
+        could have its own set of attributes, invalid attributes (if any) are
+        logged on every login attempt.</p>
+        <p>See the <a href="../realm-howto.html#Additional_User_Attributes">
+        Additional User Attributes How-To</a> for more information on how
+        additional user attributes can be access from your application.</p>
+      </attribute>
+
       <attribute name="X509UsernameRetrieverClassName" required="false">
         <p>When using X509 client certificates, this specifies the class name
         that will be used to retrieve the user name from the certificate.
@@ -752,6 +848,24 @@
            specified, the default value of <code>302</code> is used.</p>
       </attribute>
 
+      <attribute name="userAttributes" required="false">
+        <p>Comma separated list of names of attributes to additionally query
+        from the user's entry in the XML file specified by the
+        <code>pathname</code> attribute. These are provided to the application
+        as <i>Additional User Attributes</i> through the Principal's attributes
+        map (with configured attributes names used as the keys). This attribute
+        also supports the wildcard character <code>*</code>, which means to
+        query <i>all</i> attributes (except, for security reasons, the
+        <code>password</code> attribute).</p>
+        <p>In contrast to other Realms, this Realm only supports a fixed and
+        quite limited set of queryable user attributes: <code>username</code>
+        (or its alias <code>name</code>), <code>fullName</code> (or its alias
+        <code>fullname</code>) and  <code>roles</code>.</p>
+        <p>See the <a href="../realm-howto.html#Additional_User_Attributes">
+        Additional User Attributes How-To</a> for more information on how
+        additional user attributes can be access from your application.</p>
+      </attribute>
+
       <attribute name="X509UsernameRetrieverClassName" required="false">
         <p>When using X509 client certificates, this specifies the class name
         that will be used to retrieve the user name from the certificate.
@@ -780,6 +894,14 @@
             clear text).</li>
         <li><strong>roles</strong> - Comma-delimited list of the role names
             assigned to this user.</li>
+        </ul></li>
+    <li>Each <code>&lt;user&gt;</code> element may have the following
+        attribute:
+        <ul>
+        <li><strong>fullName</strong> - User-friendly name of this user (aka
+            display name).<br/>
+            For compatibility, it is allowed to use <strong>fullname</strong>
+            as an alternative name for this attribute.</li>
         </ul></li>
     </ul>
 

--- a/webapps/docs/config/realm.xml
+++ b/webapps/docs/config/realm.xml
@@ -606,6 +606,8 @@
         user's entry and the password presented by the user, with a
         successful bind being interpreted as an authenticated
         user.</p>
+        <p>For security reasons, the attribute named by this attribute
+        cannot be used as an <i>Additional User Attribute</i>.</p>
       </attribute>
 
       <attribute name="userPattern" required="false">

--- a/webapps/docs/realm-howto.xml
+++ b/webapps/docs/realm-howto.xml
@@ -254,6 +254,81 @@ simplified to <code>{digest}</code>.</p>
 
 
 
+<subsection name="Additional User Attributes">
+<p>Some of the Realm implementations, namely <code>DataSourceRealm</code>,
+<code>JNDIRealn</code>, <code>MemoryRealm</code> and
+<code>UserDatabaseRealm</code>, support a feature called
+<i>Additional User Attributes</i>. With that, the Realm additionally queries a
+configurable list of attributes from the user's entry in the associated user
+database. Depending on the Realm, the latter is either a JDBC database, a
+JDNI directory, an XML file or a Tomcat UserDatabase resource. The purpose of
+this feature is to provide extra user-related information, like e-mail address,
+department, room number, phone number etc., to the application with only a
+configured list of attribute names (like the SELECT clause of an SQL
+statement).</p>
+
+<p>Additional user attributes are provided to the application through the
+<code>Principal</code> instance, which is associated with each authenticated
+request. Principals created by the Realms noted above all maintain a set of
+read-only <i>named attributes</i>, accessible by these well-known methods:
+
+<source>java.lang.Object getAttribute(java.lang.String name);
+
+java.util.Enumeration&lt;java.lang.String&gt; getAttributeNames();
+</source>
+
+This set of attributes is populated by the Realm with the queried additional
+user attributes. The configured names of the attributes to query additionally
+also serve as the names of the attributes. These are the real names of the user
+table's columns in the JDBC database (when using <code>DataSourceRealm</code>)
+or the real names of the user entry's attributes in either the JNDI directory
+(when using <code>JNDIRealm</code>) or the <code>tomcat-users.xml</code> file
+(when using <code>MemoryRealm</code> or <code>UserDatabaseRealm</code>).</p>
+
+<p>The Principal returned for a request by method
+<code>HttpServletRequest.getUserPrincipal()</code> is of type
+<code>java.security.Principal</code>. The methods to access the Principal's
+attributes, however, are actually declared in the
+<code>org.apache.catalina.TomcatPrincipal</code> interface, which extends
+<code>java.security.Principal</code> and is the base type for all Principal
+classes used in Tomcat. So, in order to actually access the Principal's
+attributes, an <code>instanceof</code> check and casting is required. Have a
+look at this simple example, which dumps all available additional user
+attributes:
+
+<source>Principal p = request.getUserPrincipal();
+if (p instanceof TomcatPrincipal) {
+
+    TomcatPrincipal principal = (TomcatPrincipal) p;
+  
+    out.writeln("Principal contains these attributes:");
+  
+    Enumeration&lt;String&gt; names = principal.getAttributeNames();
+    while (names.hasMoreElements()) {
+        String name = names.nextElement();
+        Object value = principal.getAttribute(name);
+    
+        out.writeln(name + ": " + value.toString());
+    }
+} else {
+    out.writeln("Principal does not support attributes.")
+}
+</source>
+
+The JSP example application referred to in the next section also lists the
+Principal's attributes. However, ensure that the <code>userAttributes</code>
+attribute of the default
+<a href="config/realm.html#UserDatabase_Realm_-_org.apache.catalina.realm.UserDatabaseRealm">UserDatabaseRealm</a>
+is configured to query some additional user attributes.</p>
+
+<p><strong>Security alert:</strong> Please note, that this feature, when
+configured inappropriately and, depending on the user related data available in
+ the Realm's user database, could leak sensitive user data. 
+</p>
+</subsection>
+
+
+
 <subsection name="Example Application">
 
 <p>The example application shipped with Tomcat includes an area that is

--- a/webapps/examples/jsp/security/protected/index.jsp
+++ b/webapps/examples/jsp/security/protected/index.jsp
@@ -100,7 +100,7 @@ enter it here:
     	  for (int i = 0; i < values.length; i++) {
     		  value += values[i] + "<br/>";
     	  }
-    	  type = values[0].getClass().getName();
+    	  type = values[0].getClass().getName() + "[]";
       }
       type = type.replaceFirst("^java\\.lang\\.", "");
 %>

--- a/webapps/examples/jsp/security/protected/index.jsp
+++ b/webapps/examples/jsp/security/protected/index.jsp
@@ -83,24 +83,27 @@ enter it here:
 <%
   } else {
     TomcatPrincipal principal = (TomcatPrincipal) p;
-    boolean ignoreCase = principal.isAttributesCaseIgnored();
 %>
 <p>The principal contains the following attributes:</p>
 <table>
-<tr><th>Name <small>(case-<%= ignoreCase ? "in": "" %>sensitive)</small></th><th>Value</th><th>Type</th></tr>
+<tr><th>Name</th><th>Value</th><th>Type</th></tr>
 <%
     Enumeration<String> names = principal.getAttributeNames();
     while (names.hasMoreElements()) {
       String name = names.nextElement();
       Object value = principal.getAttribute(name);
-      String type = value != null ? value.getClass().getName() : "null";
+      String type = value != null ? value.getClass().getName() : "unknown";
       if (value instanceof Object[]) {
-    	  Object[] values = (Object[]) value;
-    	  value = "";
-    	  for (int i = 0; i < values.length; i++) {
-    		  value += values[i] + "<br/>";
-    	  }
-    	  type = values[0].getClass().getName() + "[]";
+        Object[] values = (Object[]) value;
+        value = "";
+        for (int i = 0; i < values.length; i++) {
+          value += values[i] + "<br/>";
+        }
+        if (values.length > 0) {
+          type = values[0].getClass().getName() + "[]";
+        } else {
+          type = "unknown";
+        }
       }
       type = type.replaceFirst("^java\\.lang\\.", "");
 %>

--- a/webapps/examples/jsp/security/protected/index.jsp
+++ b/webapps/examples/jsp/security/protected/index.jsp
@@ -15,6 +15,8 @@
   limitations under the License.
 --%>
 <%@ page import="java.util.Enumeration" %>
+<%@ page import="java.security.Principal" %>
+<%@ page import="org.apache.catalina.TomcatPrincipal" %>
 <%
   if (request.getParameter("logoff") != null) {
     session.invalidate();
@@ -71,6 +73,45 @@ enter it here:
 <input type="text" name="role" value="<%= util.HTMLFilter.filter(role) %>">
 <input type="submit" >
 </form>
+<br><br>
+
+<%
+  Principal p = request.getUserPrincipal();
+  if (!(p instanceof TomcatPrincipal)) {
+%>
+<p>The principal does not support attributes.</p>
+<%
+  } else {
+    TomcatPrincipal principal = (TomcatPrincipal) p;
+    boolean ignoreCase = principal.isAttributesCaseIgnored();
+%>
+<p>The principal contains the following attributes:</p>
+<table>
+<tr><th>Name <small>(case-<%= ignoreCase ? "in": "" %>sensitive)</small></th><th>Value</th><th>Type</th></tr>
+<%
+    Enumeration<String> names = principal.getAttributeNames();
+    while (names.hasMoreElements()) {
+      String name = names.nextElement();
+      Object value = principal.getAttribute(name);
+      String type = value != null ? value.getClass().getName() : "null";
+      if (value instanceof Object[]) {
+    	  Object[] values = (Object[]) value;
+    	  value = "";
+    	  for (int i = 0; i < values.length; i++) {
+    		  value += values[i] + "<br/>";
+    	  }
+    	  type = values[0].getClass().getName();
+      }
+      type = type.replaceFirst("^java\\.lang\\.", "");
+%>
+<tr><td><%= name %></td><td><%= value %></td><td><%= type %></td>
+<%
+    }
+%>
+</table>
+<%
+  }
+%>
 <br><br>
 
 To add some data to the authenticated session, enter it here:


### PR DESCRIPTION
This enhancement adds support for additional user attributes to be queried by MemoryRealm, UserDatabaseRealm, DataSourceRealm and JNDIRealm. That has already been discussed here

http://tomcat.10.x6.nabble.com/Getting-additional-attributes-for-logged-on-users-tt5110316.html

and here

http://tomcat.10.x6.nabble.com/Enhancement-Additional-user-attributes-queried-by-some-realms-td5111884.html

Bold sentences require your special attention (like questions, decisions, changes not related to the enhancement, etc).

**That's still work in progress. There's no documentation and change log entries yet. Let's agree on the code first.**

**Have a look at example at `/examples/jsp/security/protected/`. It has been modified to list all the Principal's attributes.**

### General implementation notes:

- Interface `TomcatPrincipal` now supports an attributes map, accessible by methods

  `Object getAttribute(String name);`
  `Enumeration<String> getAttributeNames();`
  ~~`boolean isAttributesIgnoreCase();`~~ (removed)

  Have a look at these method's Javadoc comments.

  Note, that it's not named _userAttributes_, but simply _attributes_. It uses that more generic name, since the Principal _IS_ (or at least represents) the user.

  With JNDIRealm, and, depending on the directory server used, attribute names may be _case-insensitive_ (if `
javax.naming.directory.Attributes.isCaseIgnored()` returns `true`). If so, the Principal's attributes map uses case-insensitive names as well.

- Class `GenericPrincipal`, which implements that interface, also adds serialization support for the attributes map.

- Realm classes `MemoryRealm`, `UserDatabaseRealm`, `DataSourceRealm` and `JNDIRealm` now have a new configuration option `userAttributes`. It takes a delimiter separated list of attribute/field names to query from the _user table/entry_. These additional attributes are then provided through the Principal's attributes map.

  That option supports a wildcard character (*), which indicates to retrieve all available attributes/fields (except the _password_ field). Both the delimiter and the wildcard character are defined by a constant in class `RealmBase`.

- Using the `userAttributes` option requires some preprocessing, depending on the Realm implementation (parsing, validating etc.). Its result is then cached in a Realm's private field.

  The preprocessing  may be quite expensive for some Realms. For example, DataSourceRealm must retrieve all the user table's field names to determine, which requested attributes are valid (if no wildcard character was specified).

  I decided not to use any JDBC- or JNDI connections prior to the first authentication attempt so, preprocessing is done lazily for some Realms. As Realms are used by concurrent threads, it uses _double-checked locking, DCL_ in order to be thread-safe (like in `UserDatabaseRealm.getDatabase()`). That, in particular, applies to `DataSourceRealm`.

  Since JNDI simply ignores requested non-existing attributes, it's much easier to use than JDBC and SQL. Together with the fact, that JNDIRealm anyway logs missing or invalid fields for every login attempt (in contrast to while preprocessing only), lazy initialization and the DCL is not needed with that Realm.

- Preprocessing logs a warning to the container log for every unknown or invalid attribute requested. Except for `MemoryRealm`, warnings are logged on the first authentication attempt. `JNDIRealm` even logs warnings on every authentication attempt, since in a directory users may have different sets of attributes.

  - All Realms emit warning messages
    - `realmBase.userAttributeAccessDenied`, if an attribute containing the user's password is requested.
    - `realmBase.userAttributeNotFound`, if the attribute could not be found.
  - JNDIRealm emits warning messages
    - `jndiRealm.userAttributeAccessDenied`, if an attribute containing the user's password is requested.
    - `jndiRealm.userAttributeNotFound`, if the attribute could not be found.
  - JNDIRealm emits debug message
    - `jndiRealm.userAttributeNotRequested`, if a _related_ attribute was sent by the directory server, but was not explicitly requested

  **We may still agree on the log levels used.**

- Realms (are encouraged to) use a LinkedHashMap to store user attributes, so insertion order is preserved. That is, `getAttributeNames()` returns names in the order specified in the `userAttributes` option (with invalid attributes removed).

### Realm-specific notes

- `MemoryRealm`
  - Uses a fixed set of available user attributes, determined by its implementation:
    `username`
    `fullname`
    `roles`    (comma separated list of roles like in the XML attribute)
  - Emits an _AccessDenied_ warning when requesting the `password` attribute.
  - Does not perform _lazy_ preprocessing and logging, as all Principals are created in `startInternal()`.
  - (Removed from this PR) ~~**Refactored role accumulation using a `LinkedHashSet` to remove duplicate roles.** Uses a **Linked**HashSet to preserve order for user attribute `roles`.~~

- `UserDatabaseRealm`
  - Uses a fixed set of available user attributes, determined by its implementation:
    `username`
    `fullname`
    `groups`   (comma sep. list of groups like in the XML attribute)
    `roles`    (comma sep. list of roles like in the XML attribute)
    `effectiveRoles`    (comma sep. list of effective roles w/ group-based roles resolved)
  - Emits an _AccessDenied_ warning when requesting the `password` attribute.
  - Performs _lazy_ preprocessing and logging in order to be consistent with the other Realms intended for production use (`MemoryRealm` is not).
    **However, that could easily be changed if you like.**
  - User attribute values are not cached in a map. They are retrieved from the user's `User` object for every invocation of method `getAttribute` so, changes applied to the `UserDatabase` are reflected immediately.

- `DataSourceRealm`
  - Performs an extra SQL query to retrieve user attributes.
  - Emits an _AccessDenied_ warning when requesting the attribute specified in `userCredCol`.
  - Performs _lazy_ preprocessing and logging.
  - (Removed from this PR) ~~**Refactored role accumulation using a `HashSet` to remove duplicate roles.**~~

- `JDNIRealm`
  - There is no extra LDAP query required to retrieve additional user attributes. Requested user attributes are merged with the attributes list created in method `getUser(JNDIConnection, String, String, int)` (now uses a `Set` to remove duplicates).
  - Emits an _AccessDenied_ warning when requesting the `userPassword` attribute (if specified).
  - Needs no _lazy_ preprocessing and logging.
  - Logs messages for non-existing and denied attributes (WARNING level) as well as for attributes, not explicitly requested (DEBUG Level), on every authentication attempt (users may have different sets of attributes).
  - With `userAttributes` containing the wildcard character, it is now legal to query _ALL_ attributes from the user's directory entry. The current implementation of JNDIRealm denied that explicitly. **That has been changed and marked with a TODO comment.**
  - A directory's attribute names may be case-insensitive, that is `Attributes.isIgnoreCase()` returns `true`. In that case, the keys of the _attributes map_ provided through the user's Principal are case-insensitive as well.
  - Provides all available values for multiple value (ordered) attributes as an Object[] array.
  - Supports the Sun LDAP provider's ";binary" option to be appended to an attribute in order to get the value as an array of bytes. However, the ";binary" suffix is then also part of the attribute's name in the Principal's attributes map.

    See _Attribute Values_ at https://docs.oracle.com/javase/jndi/tutorial/ldap/misc/attrs.html
  - I only have access to a single Active Directory Server and did not manage to make it work with the `userPattern` option. **So, the _user attributes_ implementation in method `getUserByPattern(DirContext, String, String[], String)` is not yet completely tested!** Although I believe it should work as expected, **could someone with another directory server around test this case?**

### Defensive copies of attribute values

As already discussed, the implementers of method `TomcatPrincipal.getAttribute(String)` always return a _defensive copy_ of the attribute's value. That is done by a couple of `instanceof`checks, implementing a _fastpath_ copy for well-known and commonly used types, like String, Integer, Date etc.

For all other types, creating a copy through serialization/deserialization to/from a memory byte buffer is tried. That only works if all classes involved are serializable. Otherwise, the attribute value's string representation returned from its `toString()` method is returned.

The _fastpath_ copy process used copy constructors where possible. However, as recently pointed out by Adam Rauch, many of those are deprecated as of Java 9 and will be removed in the future:

https://www.oracle.com/java/technologies/javase/9-deprecated-features.html#JDK-8065614

So, I now use `valueOf()` for those as recommended by Oracle. Since for numbers there is a _number cache_, providing singletons for values smaller than 256, the whole defensive copying is quite pointless. Also, the _number cache_ is pointless or even dangerous, if someone could ever change the _native_ value of such an instance.

**How shall we deal with the _immutable attributes problem_? Is the proposed solution over-secured or even paranoid?**

### Final notes

- (Removed from this PR) ~~**Class `GenericPrincipal`: removed trailing comma from roles list in `toString()`method.**~~
- Added new class `CaseInsensitiveKeyLinkedMap`: Extends class `CaseInsensitiveKeyMap` and uses a `LinkedHashMap` instance as its backing store.
- Slightly modified class `CaseInsensitiveKeyMap` in order to be extendable easily. Also enhanced Javadoc comments to better distinguish between `...Map` and `...LinkedMap` versions.
- **What about proposing to add these new _attributes methods_ in interface `TomcatPrincipal` to a new _official_ interface 'jakarta.servlet.Principal' (or 'jakarta.servlet.ServletPrincipal')?**