### PR TITLE
Fix locked up connection for NamingException.

### DIFF
--- a/java/org/apache/catalina/realm/JNDIRealm.java
+++ b/java/org/apache/catalina/realm/JNDIRealm.java
@@ -2311,7 +2311,14 @@ public class JNDIRealm extends RealmBase {
             // Log the problem for posterity
             containerLog.error(sm.getString("jndiRealm.exception"), e);
 
+            close(connection);
+            closePooledConnections();
+
             // Return "not authenticated" for this request
+            if (containerLog.isDebugEnabled()) {
+                containerLog.debug("Returning null principal.");
+            }
+
             return null;
         }
     }


### PR DESCRIPTION
Related bug: https://bz.apache.org/bugzilla/show_bug.cgi?id=65411



A NamingException during JDNIRealm.getPrincipal(String username, GSSCredential gssCredential) leads to a locked up realm. Which leads to tomcat locking up.  

Similar to the fix for Bug 65033 (https://bz.apache.org/bugzilla/show_bug.cgi?id=65033), the second catching of the NamingException should also close the connection and unlock the singleConnectionLock.  

It seems that the connection used to be closed, but with 9.0.39 and this commit https://github.com/apache/tomcat/commit/95658dfd868216db0773c38aad8eebf544024b09?branch=95658dfd868216db0773c38aad8eebf544024b09 the close(connection) is not called anymore.


