### PR TITLE
Bug 65426 - HTTP2 Request is Stalled due to Exception on Tomcat. (PING FRAME)

### DIFF
--- a/java/org/apache/coyote/http2/Http2UpgradeHandler.java
+++ b/java/org/apache/coyote/http2/Http2UpgradeHandler.java
@@ -1294,7 +1294,7 @@ class Http2UpgradeHandler extends AbstractStream implements InternalHttpUpgradeH
                     // Don't try and remove Stream 0 as that is the connection
                     // Don't try and remove 'newer' streams. We'll get to them as we
                     // work through the ordered list of streams.
-                    while (toClose > 0 && parent.getIdAsInt() > 0 && parent.getIdAsInt() < stream.getIdAsInt() &&
+                    while (toClose > 0 && parent != null && parent.getIdAsInt() > 0 && parent.getIdAsInt() < stream.getIdAsInt() &&
                             parent.getChildStreams().isEmpty()) {
                         // This cast is safe since we know parent ID > 0 therefore
                         // this isn't the connection


### PR DESCRIPTION
Hello Tomcat Team,

I am getting STALLED requests for PING FRAME occasionally and the chrome browser gets stuck for a long period of time.  It was due to the parent stream being null.  Since PING request is stream-id 0.  The parent is NULL. I was getting NPE.

Here is Bug: https://bz.apache.org/bugzilla/show_bug.cgi?id=65426