### PR TITLE
Optionally inherit request parameters

### DIFF
--- a/java/org/apache/catalina/core/ApplicationHttpRequest.java
+++ b/java/org/apache/catalina/core/ApplicationHttpRequest.java
@@ -92,6 +92,15 @@ class ApplicationHttpRequest extends HttpServletRequestWrapper {
 
     private static final int SPECIALS_FIRST_FORWARD_INDEX = 6;
 
+    private static final boolean INHERIT_REQUEST_PARAMETERS;
+
+    /**
+     * Take parameters from {@link #getRequest()}.
+     */
+    static {
+        INHERIT_REQUEST_PARAMETERS = Boolean.parseBoolean(System.getProperty(
+                "org.apache.catalina.core.ApplicationHttpRequest.INHERIT_REQUEST_PARAMETERS", "true"));
+    }
 
     // ----------------------------------------------------------- Constructors
 
@@ -752,7 +761,9 @@ class ApplicationHttpRequest extends HttpServletRequestWrapper {
         }
 
         parameters = new ParameterMap<>();
-        parameters.putAll(getRequest().getParameterMap());
+        if (INHERIT_REQUEST_PARAMETERS) {
+            parameters.putAll(getRequest().getParameterMap());
+        }
         mergeParameters();
         ((ParameterMap<String,String[]>) parameters).setLocked(true);
         parsedParams = true;


### PR DESCRIPTION
Greetings to All,

the proposed fix makes optional taking requests parameters for internal requests. 
Which produced when using JSTL directives `<c:import`. 

**Explanation case** 

Processing `REQUEST1` with parameters `param1=value11` and `param2=value12`. 
Processing forwards to a JSP page, containing internal sub-request:
``` jsp
<c:import url="URL2?param2=value22&param3=value23"
```
In called `REQUEST2` will be presented:
* `param1=value11`
* `param2=value12&param2=value22`
* `param3=value23`

Such behavior is not always wanted because of collisions in similar named parameters. 

**Solution**

The proposed change has been implemented for a long time ago and successfully tested internally. Would be great to include it in main project. Kindly ask to help with passing through all the requirements for that.

 

