### PR TITLE
NamesEnumerator.nextElement npe fix.

### DIFF
--- a/java/org/apache/tomcat/util/http/MimeHeaders.java
+++ b/java/org/apache/tomcat/util/http/MimeHeaders.java
@@ -429,7 +429,11 @@ class NamesEnumerator implements Enumeration<String> {
     private void findNext() {
         next=null;
         for(; pos< size; pos++ ) {
-            next=headers.getName( pos ).toString();
+            MessageBytes bytes=headers.getName( pos );
+            if ( bytes == null ) {
+                break;
+            }
+            next=bytes.toString();
             for( int j=0; j<pos ; j++ ) {
                 if( headers.getName( j ).equalsIgnoreCase( next )) {
                     // duplicate.


### PR DESCRIPTION

java.lang.NullPointerException: null
        at org.apache.tomcat.util.http.NamesEnumerator.findNext(MimeHeaders.java:434)
        at org.apache.tomcat.util.http.NamesEnumerator.nextElement(MimeHeaders.java:458)
        at org.apache.tomcat.util.http.NamesEnumerator.nextElement(MimeHeaders.java:416)
        at com.ly.mdb.store.utils.CheckListLogUtil.getHeaderStr(CheckListLogUtil.java:96)
        at com.ly.mdb.store.utils.CheckListLogUtil.lambda$logSuccess$0(CheckListLogUtil.java:64)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)