### PR TITLE
Delegate check for preemptive authentication from AuthenticatorBase to affected Authenticators

### DIFF
--- a/java/org/apache/catalina/authenticator/AuthenticatorBase.java
+++ b/java/org/apache/catalina/authenticator/AuthenticatorBase.java
@@ -18,7 +18,6 @@ package org.apache.catalina.authenticator;
 
 import java.io.IOException;
 import java.security.Principal;
-import java.security.cert.X509Certificate;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -62,7 +61,6 @@ import org.apache.catalina.util.SessionIdGeneratorBase;
 import org.apache.catalina.util.StandardSessionIdGenerator;
 import org.apache.catalina.valves.RemoteIpValve;
 import org.apache.catalina.valves.ValveBase;
-import org.apache.coyote.ActionCode;
 import org.apache.juli.logging.Log;
 import org.apache.juli.logging.LogFactory;
 import org.apache.tomcat.util.ExceptionUtils;
@@ -597,15 +595,9 @@ public abstract class AuthenticatorBase extends ValveBase
             authRequired = true;
         }
 
-        if (!authRequired && context.getPreemptiveAuthentication()) {
-            authRequired =
-                    request.getCoyoteRequest().getMimeHeaders().getValue("authorization") != null;
-        }
-
         if (!authRequired && context.getPreemptiveAuthentication() &&
-                HttpServletRequest.CLIENT_CERT_AUTH.equals(getAuthMethod())) {
-            X509Certificate[] certs = getRequestCertificates(request);
-            authRequired = certs != null && certs.length > 0;
+                isPreemptiveAuthRequest(request)) {
+            authRequired = true;
         }
 
         JaspicState jaspicState = null;
@@ -861,35 +853,6 @@ public abstract class AuthenticatorBase extends ValveBase
         return false;
     }
 
-
-    /**
-     * Look for the X509 certificate chain in the Request under the key
-     * <code>jakarta.servlet.request.X509Certificate</code>. If not found, trigger
-     * extracting the certificate chain from the Coyote request.
-     *
-     * @param request
-     *            Request to be processed
-     *
-     * @return The X509 certificate chain if found, <code>null</code> otherwise.
-     */
-    protected X509Certificate[] getRequestCertificates(final Request request)
-            throws IllegalStateException {
-
-        X509Certificate certs[] =
-                (X509Certificate[]) request.getAttribute(Globals.CERTIFICATES_ATTR);
-
-        if ((certs == null) || (certs.length < 1)) {
-            try {
-                request.getCoyoteRequest().action(ActionCode.REQ_SSL_CERTIFICATE, null);
-                certs = (X509Certificate[]) request.getAttribute(Globals.CERTIFICATES_ATTR);
-            } catch (IllegalStateException ise) {
-                // Request body was too large for save buffer
-                // Return null which will trigger an auth failure
-            }
-        }
-
-        return certs;
-    }
 
     /**
      * Associate the specified single sign on identifier with the specified
@@ -1403,6 +1366,9 @@ public abstract class AuthenticatorBase extends ValveBase
         sso = null;
     }
 
+    protected boolean isPreemptiveAuthRequest(Request request) {
+        return false;
+    }
 
     private AuthConfigProvider getJaspicProvider() {
         Optional<AuthConfigProvider> provider = jaspicProvider;

--- a/java/org/apache/catalina/authenticator/BasicAuthenticator.java
+++ b/java/org/apache/catalina/authenticator/BasicAuthenticator.java
@@ -132,6 +132,10 @@ public class BasicAuthenticator extends AuthenticatorBase {
         return HttpServletRequest.BASIC_AUTH;
     }
 
+    @Override
+    protected boolean isPreemptiveAuthRequest(Request request) {
+        return request.getCoyoteRequest().getMimeHeaders().getValue("authorization") != null;
+    }
 
     /**
      * Parser for an HTTP Authorization header for BASIC authentication

--- a/java/org/apache/catalina/authenticator/DigestAuthenticator.java
+++ b/java/org/apache/catalina/authenticator/DigestAuthenticator.java
@@ -366,6 +366,10 @@ public class DigestAuthenticator extends AuthenticatorBase {
 
     }
 
+    @Override
+    protected boolean isPreemptiveAuthRequest(Request request) {
+        return request.getCoyoteRequest().getMimeHeaders().getValue("authorization") != null;
+    }
 
     // ------------------------------------------------------- Lifecycle Methods
 

--- a/java/org/apache/catalina/authenticator/SSLAuthenticator.java
+++ b/java/org/apache/catalina/authenticator/SSLAuthenticator.java
@@ -23,7 +23,9 @@ import java.security.cert.X509Certificate;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import org.apache.catalina.Globals;
 import org.apache.catalina.connector.Request;
+import org.apache.coyote.ActionCode;
 
 /**
  * An <b>Authenticator</b> and <b>Valve</b> implementation of authentication
@@ -99,5 +101,40 @@ public class SSLAuthenticator extends AuthenticatorBase {
     @Override
     protected String getAuthMethod() {
         return HttpServletRequest.CLIENT_CERT_AUTH;
+    }
+
+    @Override
+    protected boolean isPreemptiveAuthRequest(Request request) {
+        X509Certificate[] certs = getRequestCertificates(request);
+        return certs != null && certs.length > 0;
+    }
+    
+    /**
+     * Look for the X509 certificate chain in the Request under the key
+     * <code>jakarta.servlet.request.X509Certificate</code>. If not found, trigger
+     * extracting the certificate chain from the Coyote request.
+     *
+     * @param request
+     *            Request to be processed
+     *
+     * @return The X509 certificate chain if found, <code>null</code> otherwise.
+     */
+    protected X509Certificate[] getRequestCertificates(final Request request)
+            throws IllegalStateException {
+
+        X509Certificate certs[] =
+                (X509Certificate[]) request.getAttribute(Globals.CERTIFICATES_ATTR);
+
+        if ((certs == null) || (certs.length < 1)) {
+            try {
+                request.getCoyoteRequest().action(ActionCode.REQ_SSL_CERTIFICATE, null);
+                certs = (X509Certificate[]) request.getAttribute(Globals.CERTIFICATES_ATTR);
+            } catch (IllegalStateException ise) {
+                // Request body was too large for save buffer
+                // Return null which will trigger an auth failure
+            }
+        }
+
+        return certs;
     }
 }

--- a/java/org/apache/catalina/authenticator/SpnegoAuthenticator.java
+++ b/java/org/apache/catalina/authenticator/SpnegoAuthenticator.java
@@ -299,6 +299,10 @@ public class SpnegoAuthenticator extends AuthenticatorBase {
         return false;
     }
 
+    @Override
+    protected boolean isPreemptiveAuthRequest(Request request) {
+        return request.getCoyoteRequest().getMimeHeaders().getValue("authorization") != null;
+    }
 
     /**
      * This class gets a gss credential via a privileged action.

--- a/java/org/apache/catalina/authenticator/jaspic/CallbackHandlerImpl.java
+++ b/java/org/apache/catalina/authenticator/jaspic/CallbackHandlerImpl.java
@@ -80,6 +80,7 @@ public class CallbackHandlerImpl implements CallbackHandler, Contained {
                         PasswordValidationCallback pvc = (PasswordValidationCallback) callback;
                         principal = container.getRealm().authenticate(pvc.getUsername(),
                                 String.valueOf(pvc.getPassword()));
+                        pvc.setResult(principal != null);
                         subject = pvc.getSubject();
                     }
                 } else {

--- a/test/org/apache/catalina/authenticator/TestJaspicCallbackHandlerInAuthenticator.java
+++ b/test/org/apache/catalina/authenticator/TestJaspicCallbackHandlerInAuthenticator.java
@@ -116,9 +116,11 @@ public class TestJaspicCallbackHandlerInAuthenticator {
         PasswordValidationCallback pvc1 = new PasswordValidationCallback(clientSubject, "name1",
                 "password".toCharArray());
         callbackHandler.handle(new Callback[] { pvc1 });
+        Assert.assertTrue(pvc1.getResult());
         PasswordValidationCallback pvc2 = new PasswordValidationCallback(clientSubject, "name2",
                 "invalid".toCharArray());
         callbackHandler.handle(new Callback[] { pvc2 });
+        Assert.assertFalse(pvc2.getResult());
         Set<Object> credentials = clientSubject.getPrivateCredentials();
         Assert.assertTrue(credentials.size() == 1);
         GenericPrincipal gp = (GenericPrincipal) credentials.iterator().next();


### PR DESCRIPTION
The main purpose of the proposed refactoring is to give an individual `Authenticator` the possibility to decide if preemptive authentication is possible (e.g. if a completely different header is used for authentication).

In addition it yields cleaner code as the certificate handling code and the header name for basic, digest and spnego auth can now be moved to the relevant `Authenticator`s and does not pollute the `AuthenicatorBase`. `FormAuthenticator` and `NonLoginAuthenticator` don't need to override `isPreemptiveAuthRequest()` as preemptive is not supported/needed.