### PR TITLE
Delegate check for preemptive authentication from AuthenticatorBase to affected Authenticators

### DIFF
--- a/java/org/apache/catalina/authenticator/AuthenticatorBase.java
+++ b/java/org/apache/catalina/authenticator/AuthenticatorBase.java
@@ -18,7 +18,6 @@ package org.apache.catalina.authenticator;
 
 import java.io.IOException;
 import java.security.Principal;
-import java.security.cert.X509Certificate;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -62,7 +61,6 @@ import org.apache.catalina.util.SessionIdGeneratorBase;
 import org.apache.catalina.util.StandardSessionIdGenerator;
 import org.apache.catalina.valves.RemoteIpValve;
 import org.apache.catalina.valves.ValveBase;
-import org.apache.coyote.ActionCode;
 import org.apache.juli.logging.Log;
 import org.apache.juli.logging.LogFactory;
 import org.apache.tomcat.util.ExceptionUtils;
@@ -597,15 +595,9 @@ public abstract class AuthenticatorBase extends ValveBase
             authRequired = true;
         }
 
-        if (!authRequired && context.getPreemptiveAuthentication()) {
-            authRequired =
-                    request.getCoyoteRequest().getMimeHeaders().getValue("authorization") != null;
-        }
-
         if (!authRequired && context.getPreemptiveAuthentication() &&
-                HttpServletRequest.CLIENT_CERT_AUTH.equals(getAuthMethod())) {
-            X509Certificate[] certs = getRequestCertificates(request);
-            authRequired = certs != null && certs.length > 0;
+                isPreemptiveAuthRequest(request)) {
+            authRequired = true;
         }
 
         JaspicState jaspicState = null;
@@ -861,35 +853,6 @@ public abstract class AuthenticatorBase extends ValveBase
         return false;
     }
 
-
-    /**
-     * Look for the X509 certificate chain in the Request under the key
-     * <code>jakarta.servlet.request.X509Certificate</code>. If not found, trigger
-     * extracting the certificate chain from the Coyote request.
-     *
-     * @param request
-     *            Request to be processed
-     *
-     * @return The X509 certificate chain if found, <code>null</code> otherwise.
-     */
-    protected X509Certificate[] getRequestCertificates(final Request request)
-            throws IllegalStateException {
-
-        X509Certificate certs[] =
-                (X509Certificate[]) request.getAttribute(Globals.CERTIFICATES_ATTR);
-
-        if ((certs == null) || (certs.length < 1)) {
-            try {
-                request.getCoyoteRequest().action(ActionCode.REQ_SSL_CERTIFICATE, null);
-                certs = (X509Certificate[]) request.getAttribute(Globals.CERTIFICATES_ATTR);
-            } catch (IllegalStateException ise) {
-                // Request body was too large for save buffer
-                // Return null which will trigger an auth failure
-            }
-        }
-
-        return certs;
-    }
 
     /**
      * Associate the specified single sign on identifier with the specified
@@ -1403,6 +1366,9 @@ public abstract class AuthenticatorBase extends ValveBase
         sso = null;
     }
 
+    protected boolean isPreemptiveAuthRequest(Request request) {
+        return false;
+    }
 
     private AuthConfigProvider getJaspicProvider() {
         Optional<AuthConfigProvider> provider = jaspicProvider;

--- a/java/org/apache/catalina/authenticator/AuthenticatorBase.java
+++ b/java/org/apache/catalina/authenticator/AuthenticatorBase.java
@@ -596,7 +596,7 @@ public abstract class AuthenticatorBase extends ValveBase
         }
 
         if (!authRequired && context.getPreemptiveAuthentication() &&
-                isPreemptiveAuthRequest(request)) {
+                isPreemptiveAuthPossible(request)) {
             authRequired = true;
         }
 
@@ -1366,7 +1366,7 @@ public abstract class AuthenticatorBase extends ValveBase
         sso = null;
     }
 
-    protected boolean isPreemptiveAuthRequest(Request request) {
+    protected boolean isPreemptiveAuthPossible(Request request) {
         return false;
     }
 

--- a/java/org/apache/catalina/authenticator/BasicAuthenticator.java
+++ b/java/org/apache/catalina/authenticator/BasicAuthenticator.java
@@ -133,7 +133,7 @@ public class BasicAuthenticator extends AuthenticatorBase {
     }
 
     @Override
-    protected boolean isPreemptiveAuthRequest(Request request) {
+    protected boolean isPreemptiveAuthPossible(Request request) {
         return request.getCoyoteRequest().getMimeHeaders().getValue("authorization") != null;
     }
 

--- a/java/org/apache/catalina/authenticator/BasicAuthenticator.java
+++ b/java/org/apache/catalina/authenticator/BasicAuthenticator.java
@@ -134,7 +134,8 @@ public class BasicAuthenticator extends AuthenticatorBase {
 
     @Override
     protected boolean isPreemptiveAuthPossible(Request request) {
-        return request.getCoyoteRequest().getMimeHeaders().getValue("authorization") != null;
+        MessageBytes authorizationHeader = request.getCoyoteRequest().getMimeHeaders().getValue("authorization");
+        return authorizationHeader != null && authorizationHeader.startsWithIgnoreCase("basic ", 0);
     }
 
     /**

--- a/java/org/apache/catalina/authenticator/BasicAuthenticator.java
+++ b/java/org/apache/catalina/authenticator/BasicAuthenticator.java
@@ -132,6 +132,10 @@ public class BasicAuthenticator extends AuthenticatorBase {
         return HttpServletRequest.BASIC_AUTH;
     }
 
+    @Override
+    protected boolean isPreemptiveAuthRequest(Request request) {
+        return request.getCoyoteRequest().getMimeHeaders().getValue("authorization") != null;
+    }
 
     /**
      * Parser for an HTTP Authorization header for BASIC authentication

--- a/java/org/apache/catalina/authenticator/DigestAuthenticator.java
+++ b/java/org/apache/catalina/authenticator/DigestAuthenticator.java
@@ -31,6 +31,7 @@ import org.apache.catalina.Realm;
 import org.apache.catalina.connector.Request;
 import org.apache.juli.logging.Log;
 import org.apache.juli.logging.LogFactory;
+import org.apache.tomcat.util.buf.MessageBytes;
 import org.apache.tomcat.util.http.parser.Authorization;
 import org.apache.tomcat.util.security.ConcurrentMessageDigest;
 import org.apache.tomcat.util.security.MD5Encoder;
@@ -368,7 +369,8 @@ public class DigestAuthenticator extends AuthenticatorBase {
 
     @Override
     protected boolean isPreemptiveAuthPossible(Request request) {
-        return request.getCoyoteRequest().getMimeHeaders().getValue("authorization") != null;
+        MessageBytes authorizationHeader = request.getCoyoteRequest().getMimeHeaders().getValue("authorization");
+        return authorizationHeader != null && authorizationHeader.startsWithIgnoreCase("digest ", 0);
     }
 
     // ------------------------------------------------------- Lifecycle Methods

--- a/java/org/apache/catalina/authenticator/DigestAuthenticator.java
+++ b/java/org/apache/catalina/authenticator/DigestAuthenticator.java
@@ -366,6 +366,10 @@ public class DigestAuthenticator extends AuthenticatorBase {
 
     }
 
+    @Override
+    protected boolean isPreemptiveAuthRequest(Request request) {
+        return request.getCoyoteRequest().getMimeHeaders().getValue("authorization") != null;
+    }
 
     // ------------------------------------------------------- Lifecycle Methods
 

--- a/java/org/apache/catalina/authenticator/DigestAuthenticator.java
+++ b/java/org/apache/catalina/authenticator/DigestAuthenticator.java
@@ -367,7 +367,7 @@ public class DigestAuthenticator extends AuthenticatorBase {
     }
 
     @Override
-    protected boolean isPreemptiveAuthRequest(Request request) {
+    protected boolean isPreemptiveAuthPossible(Request request) {
         return request.getCoyoteRequest().getMimeHeaders().getValue("authorization") != null;
     }
 

--- a/java/org/apache/catalina/authenticator/SSLAuthenticator.java
+++ b/java/org/apache/catalina/authenticator/SSLAuthenticator.java
@@ -20,12 +20,12 @@ import java.io.IOException;
 import java.security.Principal;
 import java.security.cert.X509Certificate;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-
 import org.apache.catalina.Globals;
 import org.apache.catalina.connector.Request;
 import org.apache.coyote.ActionCode;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * An <b>Authenticator</b> and <b>Valve</b> implementation of authentication
@@ -103,12 +103,6 @@ public class SSLAuthenticator extends AuthenticatorBase {
         return HttpServletRequest.CLIENT_CERT_AUTH;
     }
 
-    @Override
-    protected boolean isPreemptiveAuthPossible(Request request) {
-        X509Certificate[] certs = getRequestCertificates(request);
-        return certs != null && certs.length > 0;
-    }
-    
     /**
      * Look for the X509 certificate chain in the Request under the key
      * <code>jakarta.servlet.request.X509Certificate</code>. If not found, trigger

--- a/java/org/apache/catalina/authenticator/SSLAuthenticator.java
+++ b/java/org/apache/catalina/authenticator/SSLAuthenticator.java
@@ -104,7 +104,7 @@ public class SSLAuthenticator extends AuthenticatorBase {
     }
 
     @Override
-    protected boolean isPreemptiveAuthRequest(Request request) {
+    protected boolean isPreemptiveAuthPossible(Request request) {
         X509Certificate[] certs = getRequestCertificates(request);
         return certs != null && certs.length > 0;
     }

--- a/java/org/apache/catalina/authenticator/SSLAuthenticator.java
+++ b/java/org/apache/catalina/authenticator/SSLAuthenticator.java
@@ -23,7 +23,9 @@ import java.security.cert.X509Certificate;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import org.apache.catalina.Globals;
 import org.apache.catalina.connector.Request;
+import org.apache.coyote.ActionCode;
 
 /**
  * An <b>Authenticator</b> and <b>Valve</b> implementation of authentication
@@ -99,5 +101,40 @@ public class SSLAuthenticator extends AuthenticatorBase {
     @Override
     protected String getAuthMethod() {
         return HttpServletRequest.CLIENT_CERT_AUTH;
+    }
+
+    @Override
+    protected boolean isPreemptiveAuthRequest(Request request) {
+        X509Certificate[] certs = getRequestCertificates(request);
+        return certs != null && certs.length > 0;
+    }
+    
+    /**
+     * Look for the X509 certificate chain in the Request under the key
+     * <code>jakarta.servlet.request.X509Certificate</code>. If not found, trigger
+     * extracting the certificate chain from the Coyote request.
+     *
+     * @param request
+     *            Request to be processed
+     *
+     * @return The X509 certificate chain if found, <code>null</code> otherwise.
+     */
+    protected X509Certificate[] getRequestCertificates(final Request request)
+            throws IllegalStateException {
+
+        X509Certificate certs[] =
+                (X509Certificate[]) request.getAttribute(Globals.CERTIFICATES_ATTR);
+
+        if ((certs == null) || (certs.length < 1)) {
+            try {
+                request.getCoyoteRequest().action(ActionCode.REQ_SSL_CERTIFICATE, null);
+                certs = (X509Certificate[]) request.getAttribute(Globals.CERTIFICATES_ATTR);
+            } catch (IllegalStateException ise) {
+                // Request body was too large for save buffer
+                // Return null which will trigger an auth failure
+            }
+        }
+
+        return certs;
     }
 }

--- a/java/org/apache/catalina/authenticator/SpnegoAuthenticator.java
+++ b/java/org/apache/catalina/authenticator/SpnegoAuthenticator.java
@@ -300,7 +300,7 @@ public class SpnegoAuthenticator extends AuthenticatorBase {
     }
 
     @Override
-    protected boolean isPreemptiveAuthRequest(Request request) {
+    protected boolean isPreemptiveAuthPossible(Request request) {
         return request.getCoyoteRequest().getMimeHeaders().getValue("authorization") != null;
     }
 

--- a/java/org/apache/catalina/authenticator/SpnegoAuthenticator.java
+++ b/java/org/apache/catalina/authenticator/SpnegoAuthenticator.java
@@ -301,7 +301,8 @@ public class SpnegoAuthenticator extends AuthenticatorBase {
 
     @Override
     protected boolean isPreemptiveAuthPossible(Request request) {
-        return request.getCoyoteRequest().getMimeHeaders().getValue("authorization") != null;
+        MessageBytes authorizationHeader = request.getCoyoteRequest().getMimeHeaders().getValue("authorization");
+        return authorizationHeader != null && authorizationHeader.startsWithIgnoreCase("negotiate ", 0);
     }
 
     /**

--- a/java/org/apache/catalina/authenticator/SpnegoAuthenticator.java
+++ b/java/org/apache/catalina/authenticator/SpnegoAuthenticator.java
@@ -299,6 +299,10 @@ public class SpnegoAuthenticator extends AuthenticatorBase {
         return false;
     }
 
+    @Override
+    protected boolean isPreemptiveAuthRequest(Request request) {
+        return request.getCoyoteRequest().getMimeHeaders().getValue("authorization") != null;
+    }
 
     /**
      * This class gets a gss credential via a privileged action.


### PR DESCRIPTION
The main purpose of the proposed refactoring is to give an individual `Authenticator` the possibility to decide if preemptive authentication is possible (e.g. if a completely different header is used for authentication).

In addition it yields cleaner code as the certificate handling code and the header name for basic, digest and spnego auth can now be moved to the relevant `Authenticator`s and does not pollute the `AuthenicatorBase`. `FormAuthenticator` and `NonLoginAuthenticator` don't need to override `isPreemptiveAuthRequest()` as preemptive is not supported/needed.

Main changes:
- new protected method isPreemptiveAuthRequest() in AuthenticatorBase
which is overridden in some authenticators
- moved getRequestCertificates() from AuthenticatorBase to
SSLAuthenticator