### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ install:
 
 script:
     - ant -q clean
-    - travis_wait 120 "./.travis/antTest.sh"
+    - "./.travis/antTest.sh"
 
 after_failure:
     - tail -n 5000 ant-test.log
@@ -90,3 +90,6 @@ after_failure:
 notifications:
     email:
       - dev@tomcat.apache.org
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
