### PR TITLE
Remove catalina ssi from catalina.jar.tmp.bnd file

### DIFF
--- a/res/bnd/catalina.jar.tmp.bnd
+++ b/res/bnd/catalina.jar.tmp.bnd
@@ -33,7 +33,6 @@ Export-Package: \
     org.apache.catalina.security,\
     org.apache.catalina.servlets,\
     org.apache.catalina.session,\
-    org.apache.catalina.ssi,\
     org.apache.catalina.startup,\
     org.apache.catalina.users,\
     org.apache.catalina.util,\


### PR DESCRIPTION
References to org.apache.catalina.ssi are still contained in catalina.jar after it was moved to a separate catalina-ssi.jar. It should be cleaned up.
