### PR TITLE
AsyncFileHandler: try to flush on close

### DIFF
--- a/java/org/apache/juli/AsyncFileHandler.java
+++ b/java/org/apache/juli/AsyncFileHandler.java
@@ -87,6 +87,8 @@ public class AsyncFileHandler extends FileHandler {
         if (closed) {
             return;
         }
+        // try to flush the queue
+        for (int i = 0; !queue.isEmpty() && i < 9; ++i) Thread.yield();
         closed = true;
         super.close();
     }


### PR DESCRIPTION
When shutting down Tomcat on a single core server, some log entries can be lost. (E.g. the last ones added by `contextDestroyed`.) This patch tries to prevent that. It's not very elegant, but it works for me.

(Should you want to rewrite `AsyncFileHandler` instead, you might also want to drop the `org.apache.juli.AsyncLoggerPollInterval` property, since using that doesn't make any sense to me.)