### PR TITLE
Differentiate log messages in KubernetesMembershipProvider with a param

### DIFF
--- a/java/org/apache/catalina/tribes/membership/cloud/KubernetesMembershipProvider.java
+++ b/java/org/apache/catalina/tribes/membership/cloud/KubernetesMembershipProvider.java
@@ -156,7 +156,7 @@ public class KubernetesMembershipProvider extends CloudMembershipProvider {
             List<Object> items = (List<Object>) itemsObject;
             for (Object podObject : items) {
                 if (!(podObject instanceof LinkedHashMap<?, ?>)) {
-                    log.warn(sm.getString("kubernetesMembershipProvider.invalidPod"));
+                    log.warn(sm.getString("kubernetesMembershipProvider.invalidPod", "item"));
                     continue;
                 }
                 LinkedHashMap<String, Object> pod = (LinkedHashMap<String, Object>) podObject;
@@ -168,26 +168,26 @@ public class KubernetesMembershipProvider extends CloudMembershipProvider {
                 // "metadata" contains "name", "uid" and "creationTimestamp"
                 Object metadataObject = pod.get("metadata");
                 if (!(metadataObject instanceof LinkedHashMap<?, ?>)) {
-                    log.warn(sm.getString("kubernetesMembershipProvider.invalidPod"));
+                    log.warn(sm.getString("kubernetesMembershipProvider.invalidPod", "metadata"));
                     continue;
                 }
                 LinkedHashMap<String, Object> metadata = (LinkedHashMap<String, Object>) metadataObject;
                 Object nameObject = metadata.get("name");
                 if (nameObject == null) {
-                    log.warn(sm.getString("kubernetesMembershipProvider.invalidPod"));
+                    log.warn(sm.getString("kubernetesMembershipProvider.invalidPod", "name"));
                     continue;
                 }
                 Object objectUid = metadata.get("uid");
                 Object creationTimestampObject = metadata.get("creationTimestamp");
                 if (creationTimestampObject == null) {
-                    log.warn(sm.getString("kubernetesMembershipProvider.invalidPod"));
+                    log.warn(sm.getString("kubernetesMembershipProvider.invalidPod", "uid"));
                     continue;
                 }
                 String creationTimestamp = creationTimestampObject.toString();
                 // "status" contains "phase" (which must be "Running") and "podIP"
                 Object statusObject = pod.get("status");
                 if (!(statusObject instanceof LinkedHashMap<?, ?>)) {
-                    log.warn(sm.getString("kubernetesMembershipProvider.invalidPod"));
+                    log.warn(sm.getString("kubernetesMembershipProvider.invalidPod", "status"));
                     continue;
                 }
                 LinkedHashMap<String, Object> status = (LinkedHashMap<String, Object>) statusObject;
@@ -196,7 +196,7 @@ public class KubernetesMembershipProvider extends CloudMembershipProvider {
                 }
                 Object podIPObject = status.get("podIP");
                 if (podIPObject == null) {
-                    log.warn(sm.getString("kubernetesMembershipProvider.invalidPod"));
+                    log.warn(sm.getString("kubernetesMembershipProvider.invalidPod", "podIP"));
                     continue;
                 }
                 String podIP = podIPObject.toString();

--- a/java/org/apache/catalina/tribes/membership/cloud/LocalStrings.properties
+++ b/java/org/apache/catalina/tribes/membership/cloud/LocalStrings.properties
@@ -23,7 +23,7 @@ cloudMembershipService.stopFail=Unable to stop the cloud membership service, lev
 
 dnsMembershipProvider.dnsError=Error getting hosts address list for namespace [{0}]
 
-kubernetesMembershipProvider.invalidPod=Pod is missing some required attributes
+kubernetesMembershipProvider.invalidPod=Pod is missing some required attributes: {0}
 kubernetesMembershipProvider.invalidPodsList=Invalid pods list: {0}
 kubernetesMembershipProvider.jsonError=JSON error
 kubernetesMembershipProvider.memberError=Error creating member

--- a/java/org/apache/catalina/tribes/membership/cloud/LocalStrings_es.properties
+++ b/java/org/apache/catalina/tribes/membership/cloud/LocalStrings_es.properties
@@ -18,4 +18,4 @@ abstractStream.trustManagerError=No se pudo crear el administrador de confianza 
 
 cloudMembershipService.stopFail=No se pudo detener el servicio de miembros estáticos, nivel: [{0}]
 
-kubernetesMembershipProvider.invalidPod=Algunos atributos requeridos faltan en el Pod
+kubernetesMembershipProvider.invalidPod=Algunos atributos requeridos faltan en el Pod: {0}

--- a/java/org/apache/catalina/tribes/membership/cloud/LocalStrings_fr.properties
+++ b/java/org/apache/catalina/tribes/membership/cloud/LocalStrings_fr.properties
@@ -23,7 +23,7 @@ cloudMembershipService.stopFail=Impossible d''arrêter le registre de membres st
 
 dnsMembershipProvider.dnsError=Erreur en obtenant la liste des adresses des hôtes pour l''espace de noms [{0}]
 
-kubernetesMembershipProvider.invalidPod=Le pod manque des attributs nécessaires
+kubernetesMembershipProvider.invalidPod=Le pod manque des attributs nécessaires: {0}
 kubernetesMembershipProvider.invalidPodsList=La liste de pods est invalide : [{0}]
 kubernetesMembershipProvider.jsonError=Erreur JSON
 kubernetesMembershipProvider.memberError=Erreur de création d'un membre

--- a/java/org/apache/catalina/tribes/membership/cloud/LocalStrings_ja.properties
+++ b/java/org/apache/catalina/tribes/membership/cloud/LocalStrings_ja.properties
@@ -23,7 +23,7 @@ cloudMembershipService.stopFail=レベル [{0}] のメンバーシップサー�
 
 dnsMembershipProvider.dnsError=名前空間 [{0}] のホストアドレスリスト取得中のエラー
 
-kubernetesMembershipProvider.invalidPod=Pod に必要な属性がありません。
+kubernetesMembershipProvider.invalidPod=Pod に必要な属性がありません。: [{0}]
 kubernetesMembershipProvider.invalidPodsList=不正な Pod リストです: [{0}]
 kubernetesMembershipProvider.jsonError=JSONエラー
 kubernetesMembershipProvider.memberError=メンバー作成中のエラー

--- a/java/org/apache/catalina/tribes/membership/cloud/LocalStrings_ko.properties
+++ b/java/org/apache/catalina/tribes/membership/cloud/LocalStrings_ko.properties
@@ -23,7 +23,7 @@ cloudMembershipService.stopFail=정적 멤버십 서비스를 중단할 수 없�
 
 dnsMembershipProvider.dnsError=네임스페이스 [{0}]을(를) 위한, 호스트들의 주소 목록을 얻는 중 오류 발생
 
-kubernetesMembershipProvider.invalidPod=Pod에 일부 필수 속성들이 없습니다.
+kubernetesMembershipProvider.invalidPod=Pod에 일부 필수 속성들이 없습니다: {0}
 kubernetesMembershipProvider.invalidPodsList=유효하지 않은 pod들의 목록: {0}
 kubernetesMembershipProvider.jsonError=JSON 오류
 kubernetesMembershipProvider.memberError=멤버 생성 중 오류 발생

--- a/java/org/apache/catalina/tribes/membership/cloud/LocalStrings_zh_CN.properties
+++ b/java/org/apache/catalina/tribes/membership/cloud/LocalStrings_zh_CN.properties
@@ -23,7 +23,7 @@ cloudMembershipService.stopFail=无法停止云成员资格服务，级别为：
 
 dnsMembershipProvider.dnsError=由于命名空间[{0}]导致的多个错误主机地址
 
-kubernetesMembershipProvider.invalidPod=Pod丢失了一些必须的属性
+kubernetesMembershipProvider.invalidPod=Pod丢失了一些必须的属性：{0}。
 kubernetesMembershipProvider.invalidPodsList=无效的播客列表：{0}。
 kubernetesMembershipProvider.jsonError=JSON错误
 kubernetesMembershipProvider.memberError=创建成员错误


### PR DESCRIPTION
The same log message is used for 6 different warning messages so this adds a parameter that can be used to tie the log message to the particular warning. 