### PR TITLE
MimeHeader.toString to speed up debugging in IDEs

### DIFF
--- a/java/org/apache/tomcat/util/http/MimeHeaders.java
+++ b/java/org/apache/tomcat/util/http/MimeHeaders.java
@@ -16,13 +16,13 @@
  */
 package org.apache.tomcat.util.http;
 
+import org.apache.tomcat.util.buf.MessageBytes;
+import org.apache.tomcat.util.res.StringManager;
+
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Enumeration;
-
-import org.apache.tomcat.util.buf.MessageBytes;
-import org.apache.tomcat.util.res.StringManager;
 
 /**
  * This class is used to contain standard internet message headers,
@@ -538,5 +538,10 @@ class MimeHeaderField {
 
     public MessageBytes getValue() {
         return valueB;
+    }
+
+    @Override
+    public String toString() {
+        return nameB + ": " + valueB;
     }
 }

--- a/java/org/apache/tomcat/util/http/MimeHeaders.java
+++ b/java/org/apache/tomcat/util/http/MimeHeaders.java
@@ -16,13 +16,13 @@
  */
 package org.apache.tomcat.util.http;
 
-import org.apache.tomcat.util.buf.MessageBytes;
-import org.apache.tomcat.util.res.StringManager;
-
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Enumeration;
+
+import org.apache.tomcat.util.buf.MessageBytes;
+import org.apache.tomcat.util.res.StringManager;
 
 /**
  * This class is used to contain standard internet message headers,

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -155,6 +155,10 @@
         Improve performance of Connector shutdown - primarily to reduce the time
         it takes to run the test suite. (markt)
       </scode>
+      <add>
+        <pr>457</pr>: Add a <code>toString()</code> method to
+        <code>MimeHeader</code> to aid debugging. (dblevins)
+      </add>
     </changelog>
   </subsection>
   <subsection name="Jasper">


### PR DESCRIPTION
Minor improvement to show header name/value in IDE while debugging.  Without it you get an array of object that looks like this:

![image](https://user-images.githubusercontent.com/94926/140192733-d7286b32-7b62-442b-be60-361242fceb3e.png)

Most IDEs like Intellij will show the toString value automatically beside the instance.  Most other objects in coyote Request have a toString already and show up quite nicely:

![image](https://user-images.githubusercontent.com/94926/140193088-94e00e7d-599a-44da-8836-61a49d7ad91c.png)
