### PR TITLE
avoid null classloader when thread context CL is null

### DIFF
--- a/java/org/apache/juli/FileHandler.java
+++ b/java/org/apache/juli/FileHandler.java
@@ -378,6 +378,9 @@ public class FileHandler extends Handler {
         String className = this.getClass().getName(); //allow classes to override
 
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        if (cl == null) {
+            cl = this.getClass().getClassLoader();
+        }
 
         // Retrieve configuration of logging file name
         if (rotatable == null) {


### PR DESCRIPTION
I've seen the config get ignored when thread context classloader is null - if the cl is left at null, the default OneLineFormatter is used instead of the configured formatter