### PR TITLE
Allow http response date field set to older date

### DIFF
--- a/java/org/apache/tomcat/util/http/FastHttpDateFormat.java
+++ b/java/org/apache/tomcat/util/http/FastHttpDateFormat.java
@@ -94,7 +94,7 @@ public final class FastHttpDateFormat {
      */
     public static final String getCurrentDate() {
         long now = System.currentTimeMillis();
-        if ((now - currentDateGenerated) > 1000) {
+        if (Math.abs(now - currentDateGenerated) > 1000) {
             currentDate = FORMAT_RFC5322.format(new Date(now));
             currentDateGenerated = now;
         }


### PR DESCRIPTION
When you set the system time to a newer date by accident, then you reset system time to an older date, but the HTTP header response date field cannot be changed. It is still the newer date.