### PR TITLE
add test sub targets depend on setup-jacoco

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1841,19 +1841,19 @@
   </target>
 
   <target name="test-nio" description="Runs the JUnit test cases for NIO. Does not stop on errors."
-          depends="test-compile,deploy,test-openssl-exists" if="${execute.test.nio}">
+          depends="setup-jacoco,test-compile,deploy,test-openssl-exists" if="${execute.test.nio}">
     <runtests protocol="org.apache.coyote.http11.Http11NioProtocol"
               extension=".NIO" />
   </target>
 
   <target name="test-nio2" description="Runs the JUnit test cases for NIO2. Does not stop on errors."
-          depends="test-compile,deploy,test-openssl-exists" if="${execute.test.nio2}">
+          depends="setup-jacoco,test-compile,deploy,test-openssl-exists" if="${execute.test.nio2}">
     <runtests protocol="org.apache.coyote.http11.Http11Nio2Protocol"
               extension=".NIO2" />
   </target>
 
   <target name="test-apr" description="Runs the JUnit test cases for APR. Does not stop on errors."
-          depends="test-compile,deploy,test-apr-exists,test-openssl-exists"
+          depends="setup-jacoco,test-compile,deploy,test-apr-exists,test-openssl-exists"
           if="${apr.exists}">
     <runtests protocol="org.apache.coyote.http11.Http11AprProtocol"
               extension=".APR" />


### PR DESCRIPTION
if run test-* targets,eg ant test-nio, get errors
build.xml:1896: Problem: failed to create task or type antlib:org.jacoco.ant:coverage