### PR TITLE
Load "jakarta.annotation.*" classes from common classloader

### DIFF
--- a/java/org/apache/catalina/loader/WebappClassLoaderBase.java
+++ b/java/org/apache/catalina/loader/WebappClassLoaderBase.java
@@ -2626,7 +2626,8 @@ public abstract class WebappClassLoaderBase extends URLClassLoader
                 if (name.startsWith("servlet.jsp.jstl.", 8)) {
                     return false;
                 }
-                if (name.startsWith("el.", 8) ||
+                if (name.startsWith("annotation.", 8) ||
+                    name.startsWith("el.", 8) ||
                     name.startsWith("servlet.", 8) ||
                     name.startsWith("websocket.", 8) ||
                     name.startsWith("security.auth.message.", 8)) {
@@ -2637,7 +2638,8 @@ public abstract class WebappClassLoaderBase extends URLClassLoader
                 if (name.startsWith("servlet/jsp/jstl/", 8)) {
                     return false;
                 }
-                if (name.startsWith("el/", 8) ||
+                if (name.startsWith("annotation/", 8) ||
+                    name.startsWith("el/", 8) ||
                     name.startsWith("servlet/", 8) ||
                     name.startsWith("websocket/", 8) ||
                     name.startsWith("security/auth/message/", 8)) {

--- a/test/org/apache/catalina/loader/TestWebappClassLoader.java
+++ b/test/org/apache/catalina/loader/TestWebappClassLoader.java
@@ -99,6 +99,7 @@ public class TestWebappClassLoader extends TomcatBaseTest {
             "org.apache.juli",
             "org.apache.naming",
             "org.apache.tomcat",
+            "jakarta.annotation",
             "jakarta.el",
             "jakarta.servlet",
             "jakarta.websocket",


### PR DESCRIPTION
Some users mistakenly add `jakarta.annotation-api` to their applications, which prevents Tomcat from finding `@Resource` and similar annotations on the servlets. See [this Stack Overflow question](https://stackoverflow.com/q/69249988/11748454) for example.

To prevent this "jakarta.annotation" should also be always loaded from the common classloader.