### PR TITLE
Load "javax.annotation.*" classes from common classloader

### DIFF
--- a/java/org/apache/catalina/loader/WebappClassLoaderBase.java
+++ b/java/org/apache/catalina/loader/WebappClassLoaderBase.java
@@ -2605,7 +2605,8 @@ public abstract class WebappClassLoaderBase extends URLClassLoader
                 if (name.startsWith("servlet.jsp.jstl.", 6)) {
                     return false;
                 }
-                if (name.startsWith("el.", 6) ||
+                if (name.startsWith("annotation.", 6) ||
+                    name.startsWith("el.", 6) ||
                     name.startsWith("servlet.", 6) ||
                     name.startsWith("websocket.", 6) ||
                     name.startsWith("security.auth.message.", 6)) {
@@ -2616,7 +2617,8 @@ public abstract class WebappClassLoaderBase extends URLClassLoader
                 if (name.startsWith("servlet/jsp/jstl/", 6)) {
                     return false;
                 }
-                if (name.startsWith("el/", 6) ||
+                if (name.startsWith("annotation/", 6) ||
+                    name.startsWith("el/", 6) ||
                     name.startsWith("servlet/", 6) ||
                     name.startsWith("websocket/", 6) ||
                     name.startsWith("security/auth/message/", 6)) {

--- a/test/org/apache/catalina/loader/TestWebappClassLoader.java
+++ b/test/org/apache/catalina/loader/TestWebappClassLoader.java
@@ -98,6 +98,7 @@ public class TestWebappClassLoader extends TomcatBaseTest {
             "org.apache.juli",
             "org.apache.naming",
             "org.apache.tomcat",
+            "javax.annotation",
             "javax.el",
             "javax.servlet",
             "javax.websocket",


### PR DESCRIPTION
This is the `javax` version of #469.

Some users mistakenly add `javax.annotation-api` to their applications, which prevents Tomcat from finding `@Resource` and similar annotations on Java 9+.

To prevent this "javax.annotation" should also be always loaded from the _common_ classloader.

On Java 8 and earlier classes from `javax.annotation` where served from the _system_ classloader, so the change should be a no-op.