### PR TITLE
Fix ELContext save/restore after fragment helper invoke

### DIFF
--- a/java/org/apache/jasper/runtime/JspContextWrapper.java
+++ b/java/org/apache/jasper/runtime/JspContextWrapper.java
@@ -556,7 +556,9 @@ public class JspContextWrapper extends PageContext implements VariableResolver {
 
         @Override
         public void putContext(Class<?> key, Object contextObject) {
-            wrapped.putContext(key, contextObject);
+            if (key != JspContext.class) {
+                wrapped.putContext(key, contextObject);
+            }
         }
 
         @Override


### PR DESCRIPTION
It seems that `ELContextWrapper.getContext()` and `ELContextWrapper.putContext()` are out of sync with each other. ELContextWrapper.getContext() in its current implementation always returns current page context, and in a custom tag with fragment Helper the generated code corrupts parent ELContext. The generated custom tag code results in current page context always propogated to invoker evaluation context after helper invokation. Here is custom tag code commented to illustrate the problem:

```
    public void invoke( java.io.Writer writer )
      throws javax.servlet.jsp.JspException
    {
      javax.servlet.jsp.JspWriter out = null;
      if( writer != null ) {
        out = this.jspContext.pushBody(writer);
      } else {
        out = this.jspContext.getOut();
      }
      try {
      // Does not work as suggested because ELContextWrapper always returns current page context
      try {
        Object _jspx_saved_JspContext = this.jspContext.getELContext().getContext(javax.servlet.jsp.JspContext.class);
        // Pointless with ELContextWrapper, as ELContextWrapper will return the current page context anyway
        this.jspContext.getELContext().putContext(javax.servlet.jsp.JspContext.class,this.jspContext);
        switch( this.discriminator ) {
           ....
           break;
        }
        // Here the invoker (parent) ELContext gets corrupted instead of being restored
        jspContext.getELContext().putContext(javax.servlet.jsp.JspContext.class,_jspx_saved_JspContext); 
      }
```

The propose is not to put ELContext to parent in ELContextWrapper .

```
        @Override
        public void putContext(@SuppressWarnings("rawtypes") Class key, Object contextObject) {
            if (key != JspContext.class) {
                wrapped.putContext(key, contextObject);
            }
        }
```
