### PR TITLE
ignore output directory target after building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ nbproject
 output
 # Next line commented out, because test/webapp-virtual-library and
 # test/webapp-virtual-webapp use it:
-# target
+target
 work
 build.properties
 mvn.properties


### PR DESCRIPTION
considering that many developer may use maven to rebuild their local project and then produce the output directory 'target', so add it to .gitignore