### PR TITLE
Fix Response#sendRedirect() if no request context exists.

### DIFF
--- a/java/org/apache/catalina/connector/Response.java
+++ b/java/org/apache/catalina/connector/Response.java
@@ -1290,12 +1290,12 @@ public class Response implements HttpServletResponse {
             Context context = getContext();
             // If no ROOT context is defined, the context can be null.
             // In this case, the default Tomcat values are assumed, but without
-            // respect to org.apache.catalina.STRICT_SERVLET_COMPLIANCE.
+            // reference to org.apache.catalina.STRICT_SERVLET_COMPLIANCE.
             boolean reqHasContext = context == null;
             String locationUri;
             // Relative redirects require HTTP/1.1
             if (getRequest().getCoyoteRequest().getSupportsRelativeRedirects() &&
-                (!reqHasContext || context.getUseRelativeRedirects())) {
+                    (!reqHasContext || context.getUseRelativeRedirects())) {
                 locationUri = location;
             } else {
                 locationUri = toAbsolute(location);

--- a/java/org/apache/catalina/connector/Response.java
+++ b/java/org/apache/catalina/connector/Response.java
@@ -1287,17 +1287,22 @@ public class Response implements HttpServletResponse {
 
         // Generate a temporary redirect to the specified location
         try {
+            Context context = getContext();
+            // If no ROOT context is defined, the context can be null.
+            // In this case, the default Tomcat values are assumed, but without
+            // respect to org.apache.catalina.STRICT_SERVLET_COMPLIANCE.
+            boolean reqHasContext = context == null;
             String locationUri;
             // Relative redirects require HTTP/1.1
             if (getRequest().getCoyoteRequest().getSupportsRelativeRedirects() &&
-                    getContext().getUseRelativeRedirects()) {
+                (!reqHasContext || context.getUseRelativeRedirects())) {
                 locationUri = location;
             } else {
                 locationUri = toAbsolute(location);
             }
             setStatus(status);
             setHeader("Location", locationUri);
-            if (getContext().getSendRedirectBody()) {
+            if (reqHasContext && context.getSendRedirectBody()) {
                 PrintWriter writer = getWriter();
                 writer.print(sm.getString("coyoteResponse.sendRedirect.note",
                         Escape.htmlElementContent(locationUri)));


### PR DESCRIPTION
If no ROOT context is defined, the context may be null in special cases, e.g. RewriteValve may use Response#sendRedirect() without any application context associated.
In this case, the Tomcat behaviors for the context attributes useRelativeRedirects and sendRedirectBody are assumed, but without considering org.apache.catalina.STRICT_SERVLET_COMPLIANCE.