### PR TITLE
changing HashMap to LinkedHashMap to maintain execution order of deployment

### DIFF
--- a/java/org/apache/catalina/core/ContainerBase.java
+++ b/java/org/apache/catalina/core/ContainerBase.java
@@ -159,7 +159,7 @@ public abstract class ContainerBase extends LifecycleMBeanBase implements Contai
     /**
      * The child Containers belonging to this Container, keyed by name.
      */
-    protected final HashMap<String, Container> children = new HashMap<>();
+    protected final LinkedHashMap<String, Container> children = new LinkedHashMap<>();
 
 
     /**


### PR DESCRIPTION
currently deployment order is not maintain, in order to overcome this we can change HashMap to LinkedHashMap.
So that the deployment order in <context> maintained.