### PR TITLE
replace deprecated getSubjectDN()

### DIFF
--- a/java/org/apache/catalina/realm/X509SubjectDnRetriever.java
+++ b/java/org/apache/catalina/realm/X509SubjectDnRetriever.java
@@ -26,6 +26,6 @@ public class X509SubjectDnRetriever implements X509UsernameRetriever {
 
     @Override
     public String getUsername(X509Certificate clientCert) {
-        return clientCert.getSubjectDN().getName();
+        return clientCert.getSubjectX500Principal().getName();
     }
 }


### PR DESCRIPTION
According to java spec, getSubjectDN() should not be used:
"denigrated, replaced by getSubjectX500Principal(). This method returns the subject as an implementation specific Principal object, which should not be relied upon by portable code."

Not sure if my proposed change is correct, at least it is probably not compatible for all use cases.