### PR TITLE
Change the logic for judging whether a jsp file is outdated

### DIFF
--- a/java/org/apache/jasper/compiler/Compiler.java
+++ b/java/org/apache/jasper/compiler/Compiler.java
@@ -448,7 +448,7 @@ public abstract class Compiler {
 
             if (jsw.getLastModificationTest()
                     + (ctxt.getOptions().getModificationTestInterval() * 1000) > System
-                    .currentTimeMillis()) {
+                    .currentTimeMillis() && jsw.getCompileException() == null) {
                 return false;
             }
             jsw.setLastModificationTest(System.currentTimeMillis());

--- a/java/org/apache/jasper/servlet/JspServletWrapper.java
+++ b/java/org/apache/jasper/servlet/JspServletWrapper.java
@@ -215,6 +215,10 @@ public class JspServletWrapper {
         return ctxt.getServletContext();
     }
 
+    public JasperException getCompileException() {
+        return compileException;
+    }
+
     /**
      * Sets the compilation exception for this JspServletWrapper.
      *


### PR DESCRIPTION
Bug fix: after a jsp file is accessed, modify the jsp file to make it have a syntax error, when you accessing the jsp file again, the response will report a synatx error for the first time, but if it is accessed again within 4s(tomcat default config `modificationTestInterval`), you will get the reponse of the jsp file before modification.

if a jsp file have a syntax error, its `JspServletWrapper` will carry a `compileException` which will be throw in `jspCompiler.compile()`, making `theServlet` can not reload. if you access the jsp file modified, tomcat will reset the `lastModificationTest` to the current system time. within 4s, tomcat will judge the jsp file with syntax errors as not outdated, then the request will be handled by the old jsp file's `theServlet`.

before fixing: [before](https://raw.githubusercontent.com/F4ded/blog-pic/master/iloveimg-compressed/before.gif)
afiter fixing: [after](https://raw.githubusercontent.com/F4ded/blog-pic/master/iloveimg-compressed/after.gif)