### PR TITLE
Improved logging of unknown http2 settings

### DIFF
--- a/build.properties.default
+++ b/build.properties.default
@@ -151,19 +151,19 @@ jdt.loc.1=http://archive.eclipse.org/eclipse/downloads/drops4/${jdt.release}/ecj
 jdt.loc.2=http://download.eclipse.org/eclipse/downloads/drops4/${jdt.release}/ecj-${jdt.version}.jar
 
 # ----- Tomcat native library -----
-tomcat-native.version=1.2.31
+tomcat-native.version=1.2.32
 tomcat-native.src.checksum.enabled=true
 tomcat-native.src.checksum.algorithm=SHA-512
-tomcat-native.src.checksum.value=2aaa93f0acf3eb780d39faeda3ece3cf053d3b6e2918462f7183070e8ab32232e035e9062f7c07ceb621006d727d3596d9b4b948f4432b4f625327b72fdb0e49
+tomcat-native.src.checksum.value=97587fdec8f12550003db44ae41cb864a16c08fc9362ca4c709b8090ead178d4f9d841436699b29496004b412a097ed5f56655f4fddfc5f4b6e333cbf890423e
 tomcat-native.win.checksum.enabled=true
 tomcat-native.win.checksum.algorithm=SHA-512
-tomcat-native.win.checksum.value=c88aad31f4e3c860e73a28903de0b4bb2c1d46851e48711ae9a86e6da98fe20db03c6e44957e97bbf1916decc1aba048e907b2072539b1b5da4aea2b88d8a39d
+tomcat-native.win.checksum.value=1b624d2eb33450bcfbf051088749be7884ecd1c406d54ac66171d93f1f93cb7253f8f3714e1accee2434072ab792d5178ceb35eed41a197a32e32c018e691cce
 tomcat-native.home=${base.path}/tomcat-native-${tomcat-native.version}
 tomcat-native.tar.gz=${tomcat-native.home}/tomcat-native.tar.gz
 tomcat-native.loc.1=${base-tomcat.loc.1}/tomcat-connectors/native/${tomcat-native.version}/source/tomcat-native-${tomcat-native.version}-src.tar.gz
 tomcat-native.loc.2=${base-tomcat.loc.2}/tomcat-connectors/native/${tomcat-native.version}/source/tomcat-native-${tomcat-native.version}-src.tar.gz
-tomcat-native.win.1=${base-tomcat.loc.1}/tomcat-connectors/native/${tomcat-native.version}/binaries/tomcat-native-${tomcat-native.version}-openssl-1.1.1l-win32-bin.zip
-tomcat-native.win.2=${base-tomcat.loc.2}/tomcat-connectors/native/${tomcat-native.version}/binaries/tomcat-native-${tomcat-native.version}-openssl-1.1.1l-win32-bin.zip
+tomcat-native.win.1=${base-tomcat.loc.1}/tomcat-connectors/native/${tomcat-native.version}/binaries/tomcat-native-${tomcat-native.version}-openssl-1.1.1n-win32-bin.zip
+tomcat-native.win.2=${base-tomcat.loc.2}/tomcat-connectors/native/${tomcat-native.version}/binaries/tomcat-native-${tomcat-native.version}-openssl-1.1.1n-win32-bin.zip
 
 # ----- NSIS, version 3.0 or later -----
 nsis.version=3.08

--- a/java/org/apache/coyote/http2/ConnectionSettingsBase.java
+++ b/java/org/apache/coyote/http2/ConnectionSettingsBase.java
@@ -88,8 +88,6 @@ abstract class ConnectionSettingsBase<T extends Throwable> {
             break;
         case UNKNOWN:
             // Unrecognised. Ignore it.
-            log.warn(sm.getString("connectionSettings.unknown",
-                    connectionId, setting, Long.toString(value)));
             return;
         }
 

--- a/java/org/apache/coyote/http2/Http2Parser.java
+++ b/java/org/apache/coyote/http2/Http2Parser.java
@@ -337,7 +337,12 @@ class Http2Parser {
                 }
                 int id = ByteUtil.getTwoBytes(setting, 0);
                 long value = ByteUtil.getFourBytes(setting, 2);
-                output.setting(Setting.valueOf(id), value);
+                Setting key = Setting.valueOf(id);
+                if (log.isDebugEnabled() && key == Setting.UNKNOWN) {
+                    log.warn(sm.getString("connectionSettings.unknown",
+                        connectionId, key, Long.toString(value))); 
+                }
+                output.setting(key, value);
             }
         }
         output.settingsEnd(ack);

--- a/java/org/apache/coyote/http2/Http2Parser.java
+++ b/java/org/apache/coyote/http2/Http2Parser.java
@@ -340,7 +340,7 @@ class Http2Parser {
                 Setting key = Setting.valueOf(id);
                 if (log.isDebugEnabled() && key == Setting.UNKNOWN) {
                     log.warn(sm.getString("connectionSettings.unknown",
-                        connectionId, key, Long.toString(value))); 
+                        connectionId, id, Long.toString(value))); 
                 }
                 output.setting(key, value);
             }

--- a/java/org/apache/coyote/http2/Http2UpgradeHandler.java
+++ b/java/org/apache/coyote/http2/Http2UpgradeHandler.java
@@ -236,7 +236,7 @@ class Http2UpgradeHandler extends AbstractStream implements InternalHttpUpgradeH
                     Setting key = Setting.valueOf(id);
                     if (log.isDebugEnabled() && key == Setting.UNKNOWN) {
                         log.warn(sm.getString("connectionSettings.unknown",
-                            connectionId, key, Long.toString(value))); 
+                            connectionId, id, Long.toString(value))); 
                     }
                     remoteSettings.set(key, value);
                 }

--- a/java/org/apache/coyote/http2/Http2UpgradeHandler.java
+++ b/java/org/apache/coyote/http2/Http2UpgradeHandler.java
@@ -233,7 +233,12 @@ class Http2UpgradeHandler extends AbstractStream implements InternalHttpUpgradeH
                 for (int i = 0; i < settings.length % 6; i++) {
                     int id = ByteUtil.getTwoBytes(settings, i * 6);
                     long value = ByteUtil.getFourBytes(settings, (i * 6) + 2);
-                    remoteSettings.set(Setting.valueOf(id), value);
+                    Setting key = Setting.valueOf(id);
+                    if (log.isDebugEnabled() && key == Setting.UNKNOWN) {
+                        log.warn(sm.getString("connectionSettings.unknown",
+                            connectionId, key, Long.toString(value))); 
+                    }
+                    remoteSettings.set(key, value);
                 }
             } catch (Http2Exception e) {
                 throw new ProtocolException(

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -183,6 +183,10 @@
         so that all the resource files are located in a single directory in the
         source tree. (markt)
       </scode>
+      <update>
+        Update the packaged version of the Tomcat Native Library to 1.2.32 to
+        pick up Windows binaries built with OpenSSL 1.1.1n.(markt)
+      </update>
     </changelog>
   </subsection>
 </section>


### PR DESCRIPTION
The logging of unknown http2 settings should contain the key and the value of the setting.
The key is currently converted into a setting object. Unknown keys are mapped to Integer.MAX_VALUE
Thus the log currently contains the MAX_VALUE as key and the value of the settings. The original key got lost during the conversion to the setting object.

Therefore the logging was moved to methods, which have access to the original key and the value.