### PR TITLE
Replace non-existent com.h2database version.

### DIFF
--- a/modules/jdbc-pool/pom.xml
+++ b/modules/jdbc-pool/pom.xml
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>2.0.210</version>
+      <version>2.1.210</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
com.h2database version 2.0.210 does not exist in maven central repository. It should be replaced with version 2.1.210 which is flawless.