### PR TITLE
Do not use legacy character encoding(Shift_JIS) as default

### DIFF
--- a/java/org/apache/catalina/util/CharsetMapperDefault.properties
+++ b/java/org/apache/catalina/util/CharsetMapperDefault.properties
@@ -15,4 +15,3 @@
 
 en=ISO-8859-1
 fr=ISO-8859-1
-ja=Shift_JIS

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -339,11 +339,6 @@
         list of JARs to skip when scanning for TLDs, web fragments and
         annotations. (michaelo)
       </add>
-      <add>
-        Expand the default mappings used by
-        <code>ServletResponse.setLocale()</code> to include a mapping from the
-        <code>ja</code> locale to the <code>Shift_JIS</code> encoding. (markt)
-      </add>
       <fix>
         <bug>65806</bug>: Improve the handling of session ID generation when the
         default algorithm for <code>SecureRandom</code> (<code>SHA1PRNG</code>)


### PR DESCRIPTION
## Motivation

With this commit, `Shift_JIS` is now used as the default for `jp`.
eda77cd88b84d6002d9efb818e6d3fbc241e2284

`Shift_JIS` is a legacy character code, and this change causes a bug in the behavior of the application at Japan.

For example, Spring Boot has the following support due to this commit.
https://github.com/spring-projects/spring-boot/pull/30535
However, I think it is better to revert the commit on the tomcat side as well.

## What

Revert eda77cd88b84d6002d9efb818e6d3fbc241e2284
