### PR TITLE
Update BUILDING.txt

### DIFF
--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -344,7 +344,7 @@ located.
 
 By default the "test.apr.loc" property specifies the following location:
 
-    output/build/bin/native/
+    output/build/bin/
 
 If you are on Windows and want to test the OpenSSL TLS implementation you can
 put the tcnative-1.dll file into ${tomcat.source}/bin/native/ and it will be


### PR DESCRIPTION
Regarding build.xml <property name="test.apr.loc"          value="${test.basedir}/bin"/>, there is not "native" directory in default path.