### PR TITLE
disable jsp and jspx by default

### DIFF
--- a/conf/web.xml
+++ b/conf/web.xml
@@ -442,13 +442,13 @@
         <url-pattern>/</url-pattern>
     </servlet-mapping>
 
-    <!-- The mappings for the JSP servlet -->
+<!-- The mappings for the JSP servlet 
     <servlet-mapping>
         <servlet-name>jsp</servlet-name>
         <url-pattern>*.jsp</url-pattern>
         <url-pattern>*.jspx</url-pattern>
     </servlet-mapping>
-
+-->
     <!-- The mapping for the SSI servlet -->
 <!--
     <servlet-mapping>


### PR DESCRIPTION
jsp and jspx is dangerous. likes spring4shell and others hacker,they use uplaod jsp or write a webshell to disk.
If project need jsp or jspx, they pack web.xml in war with jsp mappings by themself.
secure by default.
thx!