### PR TITLE
Adding Redirect and Proxy Error Reporting Valves

### DIFF
--- a/java/org/apache/catalina/valves/ProxyErrorReportValve.java
+++ b/java/org/apache/catalina/valves/ProxyErrorReportValve.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.catalina.valves;
+
+import java.io.IOException;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ResourceBundle;
+import java.util.MissingResourceException;
+
+import java.net.URL;
+import java.net.URLEncoder;
+import java.net.HttpURLConnection;
+
+import org.apache.catalina.connector.Request;
+import org.apache.catalina.connector.Response;
+
+import org.apache.tomcat.util.ExceptionUtils;
+import org.apache.tomcat.util.res.StringManager;
+import org.apache.tomcat.util.http.fileupload.IOUtils;
+
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
+
+/**
+ * <p>Implementation of a Valve that forwards to jsps.</p>
+ *
+ * <p>This Valve should be attached at the Host level, although it will work
+ * if attached to a Context.</p>
+ *
+ */
+public class ProxyErrorReportValve extends ErrorReportValve {
+	private static final Log log = LogFactory.getLog(ProxyErrorReportValve.class);
+
+    public ProxyErrorReportValve() {
+        super();
+    }
+
+    @Override
+    protected void report(Request request, Response response, Throwable throwable) {
+		try {
+			reportImpl(request, response, throwable);
+		} catch(Throwable t) {
+			ExceptionUtils.handleThrowable(t);
+			log.warn("Returning error reporting to "+super.getClass().getName()+".", t);
+			super.report(request, response, throwable);
+		}
+	}
+
+	private String getProxyUrl(Response response) {
+        int statusCode = response.getStatus();
+
+		ResourceBundle resourceBundle = ResourceBundle.getBundle(this.getClass().getSimpleName(), response.getLocale());
+
+        String redirectUrl = null;
+		try {
+			redirectUrl = resourceBundle.getString(""+statusCode);
+		} catch(MissingResourceException e) {
+            redirectUrl = resourceBundle.getString("default");
+        }
+
+        return redirectUrl;
+	}
+
+    private void reportImpl(Request request, Response response, Throwable throwable) throws Throwable {
+
+        int statusCode = response.getStatus();
+
+        // Do nothing on a 1xx, 2xx and 3xx status
+        // Do nothing if anything has been written already
+        // Do nothing if the response hasn't been explicitly marked as in error
+        //    and that error has not been reported.
+        if (statusCode < 400 || response.getContentWritten() > 0 || !response.setErrorReported()) {
+            return;
+        }
+
+		String urlString = getProxyUrl(response)+"?requestUri="+request.getRequestURI()+"&statusCode="+statusCode;
+
+		try {
+			StringManager smClient = StringManager.getManager( Constants.Package, request.getLocales());
+			String statusDescription = smClient.getString("http." + statusCode);
+			urlString+="&statusDescription="+URLEncoder.encode(statusDescription);
+		} catch(Exception e) {
+			log.warn("Failed to get status description for "+statusCode, e);
+		}
+
+		if(null != throwable) {
+			urlString+="&throwable="+URLEncoder.encode(throwable.toString());
+		}
+
+
+		log.trace("Proxying error reporting to "+urlString);
+		URL url = new URL(urlString);
+		HttpURLConnection httpURLConnection = (HttpURLConnection) url.openConnection();
+		httpURLConnection.connect();
+		int responseCode = httpURLConnection.getResponseCode();
+		response.setContentType(httpURLConnection.getContentType()); 
+		OutputStream outputStream = response.getOutputStream();
+		InputStream inputStream = null;
+		try {
+			inputStream = url.openStream(); 
+			IOUtils.copy(inputStream, outputStream);
+		} finally {
+			inputStream.close();
+		}
+    }	
+}
+

--- a/java/org/apache/catalina/valves/ProxyErrorReportValve.java
+++ b/java/org/apache/catalina/valves/ProxyErrorReportValve.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *	  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -38,7 +38,7 @@ import org.apache.juli.logging.Log;
 import org.apache.juli.logging.LogFactory;
 
 /**
- * <p>Implementation of a Valve that forwards to jsps.</p>
+ * <p>Implementation of a Valve that proxies error reporting to other urls.</p>
  *
  * <p>This Valve should be attached at the Host level, although it will work
  * if attached to a Context.</p>
@@ -47,12 +47,12 @@ import org.apache.juli.logging.LogFactory;
 public class ProxyErrorReportValve extends ErrorReportValve {
 	private static final Log log = LogFactory.getLog(ProxyErrorReportValve.class);
 
-    public ProxyErrorReportValve() {
-        super();
-    }
+	public ProxyErrorReportValve() {
+		super();
+	}
 
-    @Override
-    protected void report(Request request, Response response, Throwable throwable) {
+	@Override
+	protected void report(Request request, Response response, Throwable throwable) {
 		try {
 			reportImpl(request, response, throwable);
 		} catch(Throwable t) {
@@ -63,53 +63,68 @@ public class ProxyErrorReportValve extends ErrorReportValve {
 	}
 
 	private String getProxyUrl(Response response) {
-        int statusCode = response.getStatus();
+		int statusCode = response.getStatus();
 
 		ResourceBundle resourceBundle = ResourceBundle.getBundle(this.getClass().getSimpleName(), response.getLocale());
 
-        String redirectUrl = null;
+		String redirectUrl = null;
 		try {
-			redirectUrl = resourceBundle.getString(""+statusCode);
+			redirectUrl = resourceBundle.getString(String.valueOf(statusCode));
 		} catch(MissingResourceException e) {
-            redirectUrl = resourceBundle.getString("default");
-        }
+			redirectUrl = resourceBundle.getString("0");
+		}
 
-        return redirectUrl;
+		return redirectUrl;
 	}
 
-    private void reportImpl(Request request, Response response, Throwable throwable) throws Throwable {
+	private void reportImpl(Request request, Response response, Throwable throwable) throws Throwable {
 
-        int statusCode = response.getStatus();
+		int statusCode = response.getStatus();
 
-        // Do nothing on a 1xx, 2xx and 3xx status
-        // Do nothing if anything has been written already
-        // Do nothing if the response hasn't been explicitly marked as in error
-        //    and that error has not been reported.
-        if (statusCode < 400 || response.getContentWritten() > 0 || !response.setErrorReported()) {
-            return;
-        }
+		// Do nothing on a 1xx, 2xx and 3xx status
+		// Do nothing if anything has been written already
+		// Do nothing if the response hasn't been explicitly marked as in error
+		//	and that error has not been reported.
+		if (statusCode < 400 || response.getContentWritten() > 0 || !response.setErrorReported()) {
+			return;
+		}
 
-		String urlString = getProxyUrl(response)+"?requestUri="+request.getRequestURI()+"&statusCode="+statusCode;
+		String urlString = getProxyUrl(response);
+		StringBuilder stringBuilder = new StringBuilder(urlString);
+		if(urlString.indexOf("?") > -1) {
+			stringBuilder.append("&");
+		} else {
+			stringBuilder.append("?");
+		}
+		stringBuilder.append("requestUri=");
+		stringBuilder.append(URLEncoder.encode(request.getRequestURI()));
+		stringBuilder.append("&statusCode=");
+		stringBuilder.append(URLEncoder.encode(String.valueOf(statusCode)));
 
 		try {
 			StringManager smClient = StringManager.getManager( Constants.Package, request.getLocales());
 			String statusDescription = smClient.getString("http." + statusCode);
-			urlString+="&statusDescription="+URLEncoder.encode(statusDescription);
+			stringBuilder.append("&statusDescription=");
+			stringBuilder.append(URLEncoder.encode(statusDescription));
 		} catch(Exception e) {
 			log.warn("Failed to get status description for "+statusCode, e);
 		}
 
 		if(null != throwable) {
-			urlString+="&throwable="+URLEncoder.encode(throwable.toString());
+			stringBuilder.append("&throwable=");
+			stringBuilder.append(URLEncoder.encode(throwable.toString()));
 		}
 
-
-		log.trace("Proxying error reporting to "+urlString);
+		urlString = stringBuilder.toString();
+		if(log.isTraceEnabled()) {
+			log.trace("Proxying error reporting to "+urlString);
+		}
 		URL url = new URL(urlString);
 		HttpURLConnection httpURLConnection = (HttpURLConnection) url.openConnection();
 		httpURLConnection.connect();
 		int responseCode = httpURLConnection.getResponseCode();
 		response.setContentType(httpURLConnection.getContentType()); 
+		response.setContentLength(httpURLConnection.getContentLength()); 
 		OutputStream outputStream = response.getOutputStream();
 		InputStream inputStream = null;
 		try {
@@ -118,6 +133,6 @@ public class ProxyErrorReportValve extends ErrorReportValve {
 		} finally {
 			inputStream.close();
 		}
-    }	
+	}	
 }
 

--- a/java/org/apache/catalina/valves/RedirectErrorReportValve.java
+++ b/java/org/apache/catalina/valves/RedirectErrorReportValve.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.catalina.valves;
+
+import java.io.IOException;
+
+import java.util.ResourceBundle;
+import java.util.MissingResourceException;
+
+import java.net.URLEncoder;
+
+import org.apache.catalina.connector.Request;
+import org.apache.catalina.connector.Response;
+
+import org.apache.tomcat.util.ExceptionUtils;
+import org.apache.tomcat.util.res.StringManager;
+
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
+
+/**
+ * <p>Implementation of a Valve that forwards to jsps.</p>
+ *
+ * <p>This Valve should be attached at the Host level, although it will work
+ * if attached to a Context.</p>
+ *
+ */
+public class RedirectErrorReportValve extends ErrorReportValve {
+	private static final Log log = LogFactory.getLog(RedirectErrorReportValve.class);
+
+	public RedirectErrorReportValve() {
+		super();
+	}
+
+	@Override
+	protected void report(Request request, Response response, Throwable throwable) {
+		try {
+			reportImpl(request, response, throwable);
+		} catch(Throwable t) {
+			ExceptionUtils.handleThrowable(t);
+			log.warn("Returning error reporting to "+super.getClass().getName()+".", t);
+			super.report(request, response, throwable);
+		}
+	}
+
+	private String getRedirectUrl(Response response) {
+		int statusCode = response.getStatus();
+
+		ResourceBundle resourceBundle = ResourceBundle.getBundle(this.getClass().getSimpleName(), response.getLocale());
+
+		String redirectUrl = null;
+		try {
+			redirectUrl = resourceBundle.getString(""+statusCode);
+		} catch(MissingResourceException e) {
+			redirectUrl = resourceBundle.getString("default");
+		}
+
+		return redirectUrl;
+	}
+
+	private void reportImpl(Request request, Response response, Throwable throwable) throws Throwable {
+		int statusCode = response.getStatus();
+
+		// Do nothing on a 1xx, 2xx and 3xx status
+		// Do nothing if anything has been written already
+		// Do nothing if the response hasn't been explicitly marked as in error
+		//	and that error has not been reported.
+		if (statusCode < 400 || response.getContentWritten() > 0 || !response.setErrorReported()) {
+			return;
+		}
+
+		String urlString = getRedirectUrl(response)+"?requestUri="+request.getRequestURI()+"&statusCode="+statusCode;
+
+		try {
+			StringManager smClient = StringManager.getManager( Constants.Package, request.getLocales());
+			String statusDescription = smClient.getString("http." + statusCode);
+			urlString+="&statusDescription="+URLEncoder.encode(statusDescription);
+		} catch(Exception e) {
+			log.warn("Failed to get status description for "+statusCode, e);
+		}
+
+		if(null != throwable) {
+			urlString+="&throwable="+URLEncoder.encode(throwable.toString());
+		}
+
+		response.sendRedirect(urlString);
+	}
+}
+

--- a/webapps/docs/config/valve.xml
+++ b/webapps/docs/config/valve.xml
@@ -2204,6 +2204,108 @@
 
 </section>
 
+<section name="Redirect Error Report Valve">
+
+  <subsection name="Introduction">
+
+    <p>The <strong>Redirect Error Report Valve</strong> is a simple error handler
+    for HTTP status codes that will issue a redirect to another location responsible for generation of the error report.</p>
+
+    <p>By specifying this class in <code>errorReportValveClass</code> attribute
+    in <code>HOST</code>, it will be used instead of
+    <code>ErrorReportValve</code> and will return a redirect url instead of HTML.
+    </p>
+
+
+  </subsection>
+
+  <subsection name="Attributes">
+
+    <p>The <strong>Redirect Error Report Valve</strong> supports the following
+    configuration attributes:</p>
+
+    <attributes>
+
+      <attribute name="className" required="true">
+        <p>Java class name of the implementation to use.  This MUST be set to
+        <strong>org.apache.catalina.valves.RedirectErrorReportValve</strong>.</p>
+      </attribute>
+
+    </attributes>
+
+  </subsection>
+
+  <subsection name="Configuration">
+
+	<p>The <strong>Redirect Error Report Valve</strong> requires <strong>RedirectErrorReportValve.properties</strong>
+   to be in a class path, where each entry is a statusCode=baseUrl. baseUrl should not include any url parameters. statusCode, statusDescription, requestUri, and throwable will be automatically appended.</p>
+	<attributes>
+
+      <attribute name="default" required="true">
+        <p>/error.jsp</p>
+      </attribute>
+
+      <attribute name="nnn" required="false">
+        <p>/nnn.jsp</p>
+      </attribute>
+
+    </attributes>
+
+  </subsection>
+
+</section>
+
+<section name="Proxy Error Report Valve">
+
+  <subsection name="Introduction">
+
+    <p>The <strong>Proxy Error Report Valve</strong> is a simple error handler
+    for HTTP status codes that will proxy to another location responsible for generation of the error report.</p>
+
+    <p>By specifying this class in <code>errorReportValveClass</code> attribute
+    in <code>HOST</code>, it will be used instead of
+    <code>ErrorReportValve</code> and will return a redirect url instead of HTML.
+    </p>
+
+
+  </subsection>
+
+  <subsection name="Attributes">
+
+    <p>The <strong>Proxy Error Report Valve</strong> supports the following
+    configuration attributes:</p>
+
+    <attributes>
+
+      <attribute name="className" required="true">
+        <p>Java class name of the implementation to use.  This MUST be set to
+        <strong>org.apache.catalina.valves.ProxyErrorReportValve</strong>.</p>
+      </attribute>
+
+    </attributes>
+
+  </subsection>
+
+  <subsection name="Configuration">
+
+	<p>The <strong>Proxy Error Report Valve</strong> requires <strong>ProxyErrorReportValve.properties</strong>
+   to be in a class path, where each entry is a statusCode=baseUrl. baseUrl should not include any url parameters. statusCode, statusDescription, requestUri, and throwable will be automatically appended.</p>
+	<attributes>
+
+      <attribute name="default" required="true">
+        <p>http://localhost:8080/error.jsp</p>
+      </attribute>
+
+      <attribute name="nnn" required="false">
+        <p>http://localhost:8080/nnn.jsp</p>
+      </attribute>
+
+    </attributes>
+
+  </subsection>
+
+</section>
+
 <section name="Crawler Session Manager Valve">
 
   <subsection name="Introduction">

--- a/webapps/docs/config/valve.xml
+++ b/webapps/docs/config/valve.xml
@@ -2241,7 +2241,7 @@
    to be in a class path, where each entry is a statusCode=baseUrl. baseUrl should not include any url parameters. statusCode, statusDescription, requestUri, and throwable will be automatically appended.</p>
 	<attributes>
 
-      <attribute name="default" required="true">
+      <attribute name="0" required="true">
         <p>/error.jsp</p>
       </attribute>
 
@@ -2292,7 +2292,7 @@
    to be in a class path, where each entry is a statusCode=baseUrl. baseUrl should not include any url parameters. statusCode, statusDescription, requestUri, and throwable will be automatically appended.</p>
 	<attributes>
 
-      <attribute name="default" required="true">
+      <attribute name="0" required="true">
         <p>http://localhost:8080/error.jsp</p>
       </attribute>
 


### PR DESCRIPTION
These 2 error reporting valves allow to delegate error report for dynamic generation to an external source either via issuing a redirect or proxying the request. 