### PR TITLE
Remove the prestartminSpareThreads field from StandardThreadExecutor

### DIFF
--- a/java/org/apache/catalina/core/StandardThreadExecutor.java
+++ b/java/org/apache/catalina/core/StandardThreadExecutor.java
@@ -75,11 +75,6 @@ public class StandardThreadExecutor extends LifecycleMBeanBase
     protected String name;
 
     /**
-     * prestart threads?
-     */
-    protected boolean prestartminSpareThreads = false;
-
-    /**
      * The maximum number of elements that can queue up before we reject them
      */
     protected int maxQueueSize = Integer.MAX_VALUE;
@@ -121,9 +116,6 @@ public class StandardThreadExecutor extends LifecycleMBeanBase
         TaskThreadFactory tf = new TaskThreadFactory(namePrefix,daemon,getThreadPriority());
         executor = new ThreadPoolExecutor(getMinSpareThreads(), getMaxThreads(), maxIdleTime, TimeUnit.MILLISECONDS,taskqueue, tf);
         executor.setThreadRenewalDelay(threadRenewalDelay);
-        if (prestartminSpareThreads) {
-            executor.prestartAllCoreThreads();
-        }
         taskqueue.setParent(executor);
 
         setState(LifecycleState.STARTING);
@@ -203,10 +195,6 @@ public class StandardThreadExecutor extends LifecycleMBeanBase
         return name;
     }
 
-    public boolean isPrestartminSpareThreads() {
-
-        return prestartminSpareThreads;
-    }
     public void setThreadPriority(int threadPriority) {
         this.threadPriority = threadPriority;
     }
@@ -238,10 +226,6 @@ public class StandardThreadExecutor extends LifecycleMBeanBase
         if (executor != null) {
             executor.setCorePoolSize(minSpareThreads);
         }
-    }
-
-    public void setPrestartminSpareThreads(boolean prestartminSpareThreads) {
-        this.prestartminSpareThreads = prestartminSpareThreads;
     }
 
     public void setName(String name) {

--- a/java/org/apache/catalina/core/mbeans-descriptors.xml
+++ b/java/org/apache/catalina/core/mbeans-descriptors.xml
@@ -1524,10 +1524,6 @@
                type="int"
                writeable="false" />
 
-    <attribute name="prestartminSpareThreads"
-               description="Prestart threads?"
-               is="true"
-               type="boolean"/>
 
     <attribute name="queueSize"
                description="Number of tasks waiting to be processed"

--- a/webapps/docs/config/executor.xml
+++ b/webapps/docs/config/executor.xml
@@ -107,10 +107,6 @@
       <p>(int) The maximum number of runnable tasks that can queue up awaiting
         execution before we reject them. Default value is <code>Integer.MAX_VALUE</code></p>
     </attribute>
-    <attribute name="prestartminSpareThreads" required="false">
-      <p>(boolean) Whether minSpareThreads should be started when starting the Executor or not,
-          the default is <code>false</code></p>
-    </attribute>
     <attribute name="threadRenewalDelay" required="false">
       <p>(long) If a <a href="listeners.html">ThreadLocalLeakPreventionListener</a> is configured,
         it will notify this executor about stopped contexts.


### PR DESCRIPTION
I found that in the constructor of the ThreadPoolExecutor, all core threads are started by default, so in the StandardThreadExecutor, prestartminSpareThreads becomes meaningless.But I don't know if it's right to just remove.