### PR TITLE
Adding a ServiceBindingPropertySource

### DIFF
--- a/java/org/apache/tomcat/util/digester/ServiceBindingPropertySource.java
+++ b/java/org/apache/tomcat/util/digester/ServiceBindingPropertySource.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tomcat.util.digester;
+
+import java.security.Permission;
+
+import org.apache.tomcat.util.IntrospectionUtils;
+import org.apache.tomcat.util.security.PermissionCheck;
+import java.io.IOException;
+import java.io.FilePermission;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * A {@link org.apache.tomcat.util.IntrospectionUtils.SecurePropertySource}
+ * that uses Kubernetes service bindings to resolve expressions.
+ *
+ * <p><strong>Usage example:</strong></p>
+ *
+ * Configure the certificate with a service binding.
+ *
+ * When the service binding is constructed as follows:
+ *
+ * <pre>
+ *    $SERVICE_BINDING_ROOT/
+ *                         /custom-certificate/
+ *                                            /keyFile
+ *                                            /file
+ *                                            /chainFile
+ * </pre>
+ * <pre>
+ *   {@code
+ *     <SSLHostConfig>
+ *           <Certificate certificateKeyFile="${custom-certificate.keyFile}"
+ *                        certificateFile="${custom-certificate.file}"
+ *                        certificateChainFile="${custom-certificate.chainFile}"
+ *                        type="RSA" />
+ *     </SSLHostConfig> }
+ * </pre>
+ *
+ * How to configure:
+ * <pre>
+ * {@code
+ *   echo "org.apache.tomcat.util.digester.PROPERTY_SOURCE=org.apache.tomcat.util.digester.ServiceBindingPropertySource" >> conf/catalina.properties}
+ * </pre>
+ * or add this to {@code CATALINA_OPTS}
+ *
+ * <pre>
+ * {@code
+ *   -Dorg.apache.tomcat.util.digester.PROPERTY_SOURCE=org.apache.tomcat.util.digester.ServiceBindingPropertySource}
+ * </pre>
+ *
+ * <b>NOTE</b>: When configured the PropertySource for resolving expressions
+ *              from system properties is still active.
+ *
+ * @see Digester
+ *
+ * @see <a href="https://tomcat.apache.org/tomcat-9.0-doc/config/systemprops.html#Property_replacements">Tomcat Configuration Reference System Properties</a>
+ */
+public class ServiceBindingPropertySource implements IntrospectionUtils.SecurePropertySource {
+
+    private static final String SERVICE_BINDING_ROOT_ENV_VAR = "SERVICE_BINDING_ROOT";
+
+    @Override
+    public String getProperty(String key) {
+        return null;
+    }
+
+    @Override
+    public String getProperty(String key, ClassLoader classLoader) {
+        // can we determine the service binding root
+        if (classLoader instanceof PermissionCheck) {
+            Permission p = new RuntimePermission("getenv." + SERVICE_BINDING_ROOT_ENV_VAR, null);
+            if (!((PermissionCheck) classLoader).check(p)) {
+                return null;
+            }
+        }
+
+        // get the root to search from
+        String serviceBindingRoot = System.getenv(SERVICE_BINDING_ROOT_ENV_VAR);
+        if (serviceBindingRoot == null) {
+            return null;
+        }
+
+        // we expect the keys to be in the format $SERVICE_BINDING_ROOT/<binding-name>/<key>
+        String[] parts = key.split("\\.");
+        if (parts.length != 2) {
+            return null;
+        }
+
+        Path path = Paths.get(serviceBindingRoot, parts[0], parts[1]);
+        try {
+            if (classLoader instanceof PermissionCheck) {
+                Permission p = new FilePermission(path.toString(), "read");
+                if (!((PermissionCheck) classLoader).check(p)) {
+                    return null;
+                }
+            }
+            return new String(Files.readAllBytes(path));
+        } catch (IOException e) {
+            return null;
+        }
+    }
+}

--- a/webapps/docs/config/systemprops.xml
+++ b/webapps/docs/config/systemprops.xml
@@ -51,13 +51,16 @@
       <p>Property replacement from the specified property source on the JVM
          system properties can also be done using the
          <code>REPLACE_SYSTEM_PROPERTIES</code> system property.</p>
+      <p><code>org.apache.tomcat.util.digester.ServiceBindingPropertySource</code>
+        can be used to replace parameters from any Kubernetes service bindings
+        that follows the <a href="https://servicebinding.io/">servicebinding.io</a> spec</p>
       <p><code>org.apache.tomcat.util.digester.EnvironmentPropertySource</code>
          can be used to replace parameters from the process' environment
          variables, e.g. injected ConfigMaps or Secret objects in container
          based systems like OpenShift or Kubernetes.</p>
       <p><code>org.apache.tomcat.util.digester.SystemPropertySource</code>
          does replacement with system properties. It is always enabled,
-         but can also be spefied as part of the property value.</p>
+         but can also be specified as part of the property value.</p>
     </property>
     <property name="org.apache.tomcat.util.digester. REPLACE_SYSTEM_PROPERTIES">
       <p>Set this boolean system property to <code>true</code> to cause


### PR DESCRIPTION
The property source allows values in Tomcat's configuration
files to be injected directly from a servicebinding.io's
Service Binding without having to be converted to an
environment variable first.

Co-authored-by: Sumit Kulhadia <sumit.kulhadia@sap.com>
Co-authored-by: Gareth Evans <g.evans@sap.com>