### PR TITLE
Registry gives inaccurate log message saying "Creating MBeanServer ... " after already created the MBeanServer

### DIFF
--- a/java/org/apache/coyote/LocalStrings.properties
+++ b/java/org/apache/coyote/LocalStrings.properties
@@ -38,7 +38,7 @@ abstractProtocol.closeConnectionsAwait=Waiting [{0}] milliseconds for existing c
 abstractProtocol.mbeanDeregistrationFailed=Failed to deregister MBean named [{0}] from MBean server [{1}]
 abstractProtocol.processorRegisterError=Error registering request processor
 abstractProtocol.processorUnregisterError=Error unregistering request processor
-abstractProtocol.waitingProcessor.add=Added processor [{0}] to waiting processors
+abstractProtocol.waitingProcessor.add=Adding processor [{0}] to waiting processors
 abstractProtocol.waitingProcessor.remove=Removed processor [{0}] from waiting processors
 
 abstractProtocolHandler.asyncTimeoutError=Error processing async timeouts

--- a/java/org/apache/tomcat/util/modeler/Registry.java
+++ b/java/org/apache/tomcat/util/modeler/Registry.java
@@ -462,7 +462,7 @@ public class Registry implements RegistryMBean, MBeanRegistration {
                     } else {
                         server = ManagementFactory.getPlatformMBeanServer();
                         if (log.isDebugEnabled()) {
-                            log.debug("Creating MBeanServer" + (System.currentTimeMillis() - t1));
+                            log.debug("Created MBeanServer" + (System.currentTimeMillis() - t1));
                         }
                     }
                 }


### PR DESCRIPTION
Hello,

While viewing the https://issues.apache.org/jira/browse/MAPREDUCE-4262, I found that the logging statements might give inaccurate messages. 

I also found that the in the line [465](https://github.com/apache/tomcat/blob/529117d53fba06ef1b45699e8dda16398f88acde/java/org/apache/tomcat/util/modeler/Registry.java#L465) of the file Registry.java, the log messages says "Creating MBeanServer". However, the MBean server creation should already completed in previous code (line 463).

Would it be better if we change the verb "Creating" to "Created" to indicate the action is completed? Or can we move the logging statement to the line before 463? Since when there was an exception in line 465, the logging message would not be printed, which may be not good for debugging.

The detailed url is:
https://github.com/apache/tomcat/blob/529117d53fba06ef1b45699e8dda16398f88acde/java/org/apache/tomcat/util/modeler/Registry.java#L465

There is another same issue: in the line [378](https://github.com/apache/tomcat/blob/529117d53fba06ef1b45699e8dda16398f88acde/java/org/apache/coyote/AbstractProtocol.java#L378) of the file AbstractProtocol.java, the log messages says "Added processor ...". However, the exact adding action (source code) is placed after the logging statement, which means that the add is still not completed.

Would it be better if we change the verb "added" to "adding" to indicate the action is in progress? Or can we move the logging statement to the end of the method? 

The url of file: 
https://github.com/apache/tomcat/blob/529117d53fba06ef1b45699e8dda16398f88acde/java/org/apache/coyote/AbstractProtocol.java#L378