### PR TITLE
Bug:Deadlocks occur when both engine and host startStopThreads values are set and the latter value is larger than the former

### DIFF
--- a/java/org/apache/catalina/core/StandardServer.java
+++ b/java/org/apache/catalina/core/StandardServer.java
@@ -187,6 +187,7 @@ public final class StandardServer extends LifecycleMBeanBase implements Server {
      * Utility executor with scheduling capabilities.
      */
     private ScheduledThreadPoolExecutor utilityExecutor = null;
+    private final Object utilityExecutorObject = new Object();
 
     /**
      * Utility executor wrapper.
@@ -431,19 +432,21 @@ public final class StandardServer extends LifecycleMBeanBase implements Server {
     }
 
 
-    private synchronized void reconfigureUtilityExecutor(int threads) {
-        // The ScheduledThreadPoolExecutor doesn't use MaximumPoolSize, only CorePoolSize is available
-        if (utilityExecutor != null) {
-            utilityExecutor.setCorePoolSize(threads);
-        } else {
-            ScheduledThreadPoolExecutor scheduledThreadPoolExecutor =
+    private void reconfigureUtilityExecutor(int threads) {
+        synchronized (utilityExecutorObject) {
+            // The ScheduledThreadPoolExecutor doesn't use MaximumPoolSize, only CorePoolSize is available
+            if (utilityExecutor != null) {
+                utilityExecutor.setCorePoolSize(threads);
+            } else {
+                ScheduledThreadPoolExecutor scheduledThreadPoolExecutor =
                     new ScheduledThreadPoolExecutor(threads,
-                            new TaskThreadFactory("Catalina-utility-", utilityThreadsAsDaemon, Thread.MIN_PRIORITY));
-            scheduledThreadPoolExecutor.setKeepAliveTime(10, TimeUnit.SECONDS);
-            scheduledThreadPoolExecutor.setRemoveOnCancelPolicy(true);
-            scheduledThreadPoolExecutor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
-            utilityExecutor = scheduledThreadPoolExecutor;
-            utilityExecutorWrapper = new org.apache.tomcat.util.threads.ScheduledThreadPoolExecutor(utilityExecutor);
+                        new TaskThreadFactory("Catalina-utility-", utilityThreadsAsDaemon, Thread.MIN_PRIORITY));
+                scheduledThreadPoolExecutor.setKeepAliveTime(10, TimeUnit.SECONDS);
+                scheduledThreadPoolExecutor.setRemoveOnCancelPolicy(true);
+                scheduledThreadPoolExecutor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+                utilityExecutor = scheduledThreadPoolExecutor;
+                utilityExecutorWrapper = new org.apache.tomcat.util.threads.ScheduledThreadPoolExecutor(utilityExecutor);
+            }
         }
     }
 

--- a/java/org/apache/catalina/core/StandardServer.java
+++ b/java/org/apache/catalina/core/StandardServer.java
@@ -187,7 +187,7 @@ public final class StandardServer extends LifecycleMBeanBase implements Server {
      * Utility executor with scheduling capabilities.
      */
     private ScheduledThreadPoolExecutor utilityExecutor = null;
-    private final Object utilityExecutorObject = new Object();
+    private final Object utilityExecutorLock = new Object();
 
     /**
      * Utility executor wrapper.
@@ -433,7 +433,7 @@ public final class StandardServer extends LifecycleMBeanBase implements Server {
 
 
     private void reconfigureUtilityExecutor(int threads) {
-        synchronized (utilityExecutorObject) {
+        synchronized (utilityExecutorLock) {
             // The ScheduledThreadPoolExecutor doesn't use MaximumPoolSize, only CorePoolSize is available
             if (utilityExecutor != null) {
                 utilityExecutor.setCorePoolSize(threads);


### PR DESCRIPTION
**_apache-tomcat-10.0.21 version has been reproduced, I have not tried other versions_**
# Reproduce
```xml
<Engine name="Catalina" defaultHost="localhost"  startStopThreads="3">
      <Host name="localhost"  appBase="webapps"
            unpackWARs="true" autoDeploy="true" startStopThreads="4">
      </Host>
</Engine>
```
**When starting tomcat as configured above, the situation shown in the image below will occur.**

<img width="1669" alt="image" src="https://user-images.githubusercontent.com/40265686/169047128-b7fefd31-7a1a-4ba4-96e7-05dfbd2156dc.png">

**been stuck here**⬆️⬆️⬆️

**Then  i used the Arthas tool to look at the threads and the results are shown below.**

<img width="1709" alt="image" src="https://user-images.githubusercontent.com/40265686/169047640-8c2d689d-3e23-49c4-861b-b1c5a4d6ce3e.png">
<img width="1350" alt="image" src="https://user-images.githubusercontent.com/40265686/169047710-d9d8e8a9-c2f0-41ff-92dc-148d9d99a52c.png">
<img width="1509" alt="image" src="https://user-images.githubusercontent.com/40265686/169048027-9b1c1e43-8ccc-4782-b9ed-cbf2d518dcf6.png">



 When starting tomcat, the current StandardServer instance object has been locked in LifecycleBase#start. When we do not set the startStopThreads value of StandardEngine, startStopThreads defaults to 1. 
At this time, startStopExecutor in StandardEngine is actually an instance of InlineExecutorService (in fact, the current thread), ⬇️
https://github.com/apache/tomcat/blob/22ceccc5a3e1361e82bb4f10e2a9f4117714183d/java/org/apache/catalina/core/ContainerBase.java#L882
so when StandardEngine starts its subcontainer StandardHost through the startStopExecutor thread pool, because it is the current thread, there is no problem when executing the StandardServer#reconfigureUtilityExecutor method.
https://github.com/apache/tomcat/blob/22ceccc5a3e1361e82bb4f10e2a9f4117714183d/java/org/apache/catalina/core/StandardServer.java#L434
However, when the startStopExecutor in StandardEngine is not InlineExecutorService (ie Server#getUtilityExecutor()),
https://github.com/apache/tomcat/blob/22ceccc5a3e1361e82bb4f10e2a9f4117714183d/java/org/apache/catalina/core/ContainerBase.java#L888
 the StandardServer#reconfigureUtilityExecutor method is executed again（The host's startStopThreads value is greater than the engine's startStopThreads ）, because the lock of the StandardServer instance has not been released at this time, resulting in a deadlock.


> My English is limited, I don't know if I have explained it clearly, or I am thinking in the wrong direction


