### PR TITLE
Bugfix for 66104 - Check for the existence of the log directory before executing the cleanup task at startup

### DIFF
--- a/java/org/apache/juli/FileHandler.java
+++ b/java/org/apache/juli/FileHandler.java
@@ -538,7 +538,7 @@ public class FileHandler extends Handler {
     }
 
     private void clean() {
-        if (maxDays.intValue() <= 0) {
+        if (maxDays.intValue() <= 0 || Files.notExists(Path.of(directory))) {
             return;
         }
         DELETE_FILES_SERVICE.submit(() -> {


### PR DESCRIPTION
fix:[https://bz.apache.org/bugzilla/show_bug.cgi?id=66104](https://bz.apache.org/bugzilla/show_bug.cgi?id=66104)