### PR TITLE
not report stack error information

### DIFF
--- a/java/org/apache/catalina/valves/ErrorReportValve.java
+++ b/java/org/apache/catalina/valves/ErrorReportValve.java
@@ -274,36 +274,7 @@ public class ErrorReportValve extends ValveBase {
             sb.append(smClient.getString("errorReportValve.description"));
             sb.append("</b> ");
             sb.append(description);
-            sb.append("</p>");
-            if (throwable != null) {
-                String stackTrace = getPartialServletStackTrace(throwable);
-                sb.append("<p><b>");
-                sb.append(smClient.getString("errorReportValve.exception"));
-                sb.append("</b></p><pre>");
-                sb.append(Escape.htmlElementContent(stackTrace));
-                sb.append("</pre>");
-
-                int loops = 0;
-                Throwable rootCause = throwable.getCause();
-                while (rootCause != null && (loops < 10)) {
-                    stackTrace = getPartialServletStackTrace(rootCause);
-                    sb.append("<p><b>");
-                    sb.append(smClient.getString("errorReportValve.rootCause"));
-                    sb.append("</b></p><pre>");
-                    sb.append(Escape.htmlElementContent(stackTrace));
-                    sb.append("</pre>");
-                    // In case root cause is somehow heavily nested
-                    rootCause = rootCause.getCause();
-                    loops++;
-                }
-
-                sb.append("<p><b>");
-                sb.append(smClient.getString("errorReportValve.note"));
-                sb.append("</b> ");
-                sb.append(smClient.getString("errorReportValve.rootCauseInLogs"));
-                sb.append("</p>");
-
-            }
+            sb.append("</p>");      
             sb.append("<hr class=\"line\" />");
         }
         if (isShowServerInfo()) {


### PR DESCRIPTION
When a user enters a backslash (\) or other special characters in the URL of the account suspension page, the page returns error code 400 and stack error information；