### PR TITLE
easymock version change from 4.2 to 4.3

### DIFF
--- a/res/ide-support/idea/tomcat.iml
+++ b/res/ide-support/idea/tomcat.iml
@@ -77,7 +77,7 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$TOMCAT_BUILD_LIBS$/easymock-4.2/easymock-4.2.jar!/" />
+          <root url="jar://$TOMCAT_BUILD_LIBS$/easymock-4.3/easymock-4.3.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />


### PR DESCRIPTION
when i run idea with the main branch of the tomcat,i found the version of  easymock  in the tomcat/res/ide-support/idea/tomcat.iml should be sync update.