### PR TITLE
Don't perform protection checks in Unix Domain Socket mode

### DIFF
--- a/java/org/apache/tomcat/util/net/AprEndpoint.java
+++ b/java/org/apache/tomcat/util/net/AprEndpoint.java
@@ -813,11 +813,11 @@ public class AprEndpoint extends AbstractEndpoint<Long,Long> implements SNICallB
             // Do the duplicate accept check here rather than in serverSocketaccept()
             // so we can cache the results in the SocketWrapper
             AprSocketWrapper wrapper = new AprSocketWrapper(socket, this);
-            // Bug does not affect Windows. Skip the check on that platform.
-            if (!JrePlatform.IS_WINDOWS) {
+            // Bug does not affect Windows platform and Unix Domain Socket. Skip the check.
+            if (!JrePlatform.IS_WINDOWS && getUnixDomainSocketPath() == null) {
                 long currentNanoTime = System.nanoTime();
                 if (wrapper.getRemotePort() == previousAcceptedPort) {
-                    if (previousAcceptedAddress != null && wrapper.getRemoteAddr().equals(previousAcceptedAddress)) {
+                    if (wrapper.getRemoteAddr().equals(previousAcceptedAddress)) {
                         if (currentNanoTime - previousAcceptedSocketNanoTime < 1000) {
                             throw new IOException(sm.getString("endpoint.err.duplicateAccept"));
                         }

--- a/java/org/apache/tomcat/util/net/AprEndpoint.java
+++ b/java/org/apache/tomcat/util/net/AprEndpoint.java
@@ -813,12 +813,11 @@ public class AprEndpoint extends AbstractEndpoint<Long,Long> implements SNICallB
             // Do the duplicate accept check here rather than in serverSocketaccept()
             // so we can cache the results in the SocketWrapper
             AprSocketWrapper wrapper = new AprSocketWrapper(socket, this);
-            connections.put(socket, wrapper);
             // Bug does not affect Windows. Skip the check on that platform.
             if (!JrePlatform.IS_WINDOWS) {
                 long currentNanoTime = System.nanoTime();
                 if (wrapper.getRemotePort() == previousAcceptedPort) {
-                    if (previousAcceptedAddress != null && wrapper.getRemoteAddr().equals(previousAcceptedAddress)) {
+                    if (wrapper.getRemoteAddr().equals(previousAcceptedAddress)) {
                         if (currentNanoTime - previousAcceptedSocketNanoTime < 1000) {
                             throw new IOException(sm.getString("endpoint.err.duplicateAccept"));
                         }
@@ -829,6 +828,7 @@ public class AprEndpoint extends AbstractEndpoint<Long,Long> implements SNICallB
                 previousAcceptedSocketNanoTime = currentNanoTime;
             }
 
+            connections.put(socket, wrapper);
             wrapper.setKeepAliveLeft(getMaxKeepAliveRequests());
             wrapper.setReadTimeout(getConnectionTimeout());
             wrapper.setWriteTimeout(getConnectionTimeout());

--- a/java/org/apache/tomcat/util/net/AprEndpoint.java
+++ b/java/org/apache/tomcat/util/net/AprEndpoint.java
@@ -813,11 +813,12 @@ public class AprEndpoint extends AbstractEndpoint<Long,Long> implements SNICallB
             // Do the duplicate accept check here rather than in serverSocketaccept()
             // so we can cache the results in the SocketWrapper
             AprSocketWrapper wrapper = new AprSocketWrapper(socket, this);
+            connections.put(socket, wrapper);
             // Bug does not affect Windows. Skip the check on that platform.
             if (!JrePlatform.IS_WINDOWS) {
                 long currentNanoTime = System.nanoTime();
                 if (wrapper.getRemotePort() == previousAcceptedPort) {
-                    if (wrapper.getRemoteAddr().equals(previousAcceptedAddress)) {
+                    if (previousAcceptedAddress != null && wrapper.getRemoteAddr().equals(previousAcceptedAddress)) {
                         if (currentNanoTime - previousAcceptedSocketNanoTime < 1000) {
                             throw new IOException(sm.getString("endpoint.err.duplicateAccept"));
                         }
@@ -828,7 +829,6 @@ public class AprEndpoint extends AbstractEndpoint<Long,Long> implements SNICallB
                 previousAcceptedSocketNanoTime = currentNanoTime;
             }
 
-            connections.put(socket, wrapper);
             wrapper.setKeepAliveLeft(getMaxKeepAliveRequests());
             wrapper.setReadTimeout(getConnectionTimeout());
             wrapper.setWriteTimeout(getConnectionTimeout());

--- a/java/org/apache/tomcat/util/net/AprEndpoint.java
+++ b/java/org/apache/tomcat/util/net/AprEndpoint.java
@@ -817,7 +817,7 @@ public class AprEndpoint extends AbstractEndpoint<Long,Long> implements SNICallB
             if (!JrePlatform.IS_WINDOWS) {
                 long currentNanoTime = System.nanoTime();
                 if (wrapper.getRemotePort() == previousAcceptedPort) {
-                    if (wrapper.getRemoteAddr().equals(previousAcceptedAddress)) {
+                    if (previousAcceptedAddress != null && wrapper.getRemoteAddr().equals(previousAcceptedAddress)) {
                         if (currentNanoTime - previousAcceptedSocketNanoTime < 1000) {
                             throw new IOException(sm.getString("endpoint.err.duplicateAccept"));
                         }

--- a/java/org/apache/tomcat/util/net/NioEndpoint.java
+++ b/java/org/apache/tomcat/util/net/NioEndpoint.java
@@ -546,8 +546,8 @@ public class NioEndpoint extends AbstractJsseEndpoint<NioChannel,SocketChannel> 
     protected SocketChannel serverSocketAccept() throws Exception {
         SocketChannel result = serverSock.accept();
 
-        // Bug does not affect Windows. Skip the check on that platform.
-        if (!JrePlatform.IS_WINDOWS) {
+        // Bug does not affect Windows platform and Unix Domain Socket. Skip the check.
+        if (!JrePlatform.IS_WINDOWS && getUnixDomainSocketPath() == null) {
             SocketAddress currentRemoteAddress = result.getRemoteAddress();
             long currentNanoTime = System.nanoTime();
             if (currentRemoteAddress.equals(previousAcceptedSocketRemoteAddress) &&


### PR DESCRIPTION
See [stackoverflow](https://stackoverflow.com/questions/72975059/tomcat-crashes-while-using-unixdomainsocket-as-a-connector) and #402 


8.5.x, 9.0.x, 10.0.x all have this problem.
