### PR TITLE
Issue 66195 observe mr jar system property

### DIFF
--- a/java/org/apache/tomcat/util/compat/Jre9Compat.java
+++ b/java/org/apache/tomcat/util/compat/Jre9Compat.java
@@ -39,6 +39,15 @@ class Jre9Compat extends JreCompat {
 
     private static final Log log = LogFactory.getLog(Jre9Compat.class);
     private static final StringManager sm = StringManager.getManager(Jre9Compat.class);
+    /**
+     * @see <a href="https://docs.oracle.com/javase/9/docs/api/java/util/jar/JarFile.html">Multi-Release JAR API</a>
+     */
+    private static String JDK_MULTI_RELEASE_JAR_PROPERTY =
+        System.getProperty("jdk.util.jar.enableMultiRelease", null);
+    private static Boolean JDK_MULTI_RELEASE_JAR_ENABLED =
+        JDK_MULTI_RELEASE_JAR_PROPERTY == null ?
+            null :
+            Boolean.parse(JDK_MULTI_RELEASE_JAR_PROPERTY);
 
     private static final Class<?> inaccessibleObjectExceptionClazz;
     private static final Method setDefaultUseCachesMethod;
@@ -213,6 +222,9 @@ class Jre9Compat extends JreCompat {
 
     @Override
     public boolean jarFileIsMultiRelease(JarFile jarFile) {
+        if (JDK_MULTI_RELEASE_JAR_ENABLED != null) {
+            return JDK_MULTI_RELEASE_JAR_ENABLED;
+        }
         try {
             return ((Boolean) isMultiReleaseMethod.invoke(jarFile)).booleanValue();
         } catch (ReflectiveOperationException | IllegalArgumentException e) {

--- a/java/org/apache/tomcat/util/compat/Jre9Compat.java
+++ b/java/org/apache/tomcat/util/compat/Jre9Compat.java
@@ -44,9 +44,11 @@ class Jre9Compat extends JreCompat {
      */
     private static String JDK_MULTI_RELEASE_JAR_PROPERTY =
         System.getProperty("jdk.util.jar.enableMultiRelease", null);
+    private static boolean JDK_MULTI_RELEASE_JAR_FORCED =
+        JDK_MULTI_RELEASE_JAR_PROPERTY != null && "force".equalsIgnoreCase(JDK_MULTI_RELEASE_JAR_PROPERTY);
     private static Boolean JDK_MULTI_RELEASE_JAR_ENABLED =
         JDK_MULTI_RELEASE_JAR_PROPERTY == null ?
-            null :
+            null : // not specified -> delegate to JarFile API
             Boolean.parse(JDK_MULTI_RELEASE_JAR_PROPERTY);
 
     private static final Class<?> inaccessibleObjectExceptionClazz;
@@ -222,9 +224,10 @@ class Jre9Compat extends JreCompat {
 
     @Override
     public boolean jarFileIsMultiRelease(JarFile jarFile) {
-        if (JDK_MULTI_RELEASE_JAR_ENABLED != null) {
+        if (JDK_MULTI_RELEASE_JAR_PROPERTY != null && !JDK_MULTI_RELEASE_JAR_FORCED) {
             return JDK_MULTI_RELEASE_JAR_ENABLED;
         }
+        // either "force" or the property is not specified
         try {
             return ((Boolean) isMultiReleaseMethod.invoke(jarFile)).booleanValue();
         } catch (ReflectiveOperationException | IllegalArgumentException e) {


### PR DESCRIPTION
Observe if system property for MR JAR is available
    
    - Check if the JVM system property for MR-JAR is set
    - If set, parse the value as a boolean
    - If set, and when `#isMultiRelease()` is invoked, return the configured
      value
    
Refs #66195