### PR TITLE
List duplicate locations when failing a deploy due to duplicated fragment names

### DIFF
--- a/java/org/apache/tomcat/util/descriptor/web/FragmentJarScannerCallback.java
+++ b/java/org/apache/tomcat/util/descriptor/web/FragmentJarScannerCallback.java
@@ -136,7 +136,7 @@ public class FragmentJarScannerCallback implements JarScannerCallback {
             // this name as having a duplicate so Tomcat can handle it
             // correctly when the fragments are being ordered.
             String duplicateName = fragment.getName();
-            fragments.get(duplicateName).setDuplicated(true);
+            fragments.get(duplicateName).addDuplicate(url);
             // Rename the current fragment so it doesn't clash
             fragment.setName(url.toString());
         }

--- a/java/org/apache/tomcat/util/descriptor/web/LocalStrings.properties
+++ b/java/org/apache/tomcat/util/descriptor/web/LocalStrings.properties
@@ -32,7 +32,7 @@ webRuleSet.relativeOrderingCount=<ordering> element is limited to 1 occurrence
 
 webXml.duplicateEnvEntry=Duplicate env-entry name [{0}]
 webXml.duplicateFilter=Duplicate filter name [{0}]
-webXml.duplicateFragment=More than one fragment with the name [{0}] was found. This is not legal with relative ordering. See section 8.2.2 2c of the Servlet specification for details. Consider using absolute ordering.
+webXml.duplicateFragment=More than one fragment with the name [{0}] was found. This is not legal with relative ordering. See section 8.2.2 2c of the Servlet specification for details. Consider using absolute ordering. (Duplicates found in: [{1}]).
 webXml.duplicateMessageDestination=Duplicate message-destination name [{0}]
 webXml.duplicateMessageDestinationRef=Duplicate message-destination-ref name [{0}]
 webXml.duplicateResourceEnvRef=Duplicate resource-env-ref name [{0}]

--- a/java/org/apache/tomcat/util/descriptor/web/WebXml.java
+++ b/java/org/apache/tomcat/util/descriptor/web/WebXml.java
@@ -85,12 +85,15 @@ public class WebXml extends XmlEncodingBase implements DocumentProperties.Charse
      * to know as the action that the specification requires (see 8.2.2 1.e and
      * 2.c) varies depending on the ordering method used.
      */
-    private boolean duplicated = false;
+    private final List<URL> duplicates = new ArrayList<>();
     public boolean isDuplicated() {
-        return duplicated;
+        return !this.duplicates.isEmpty();
     }
-    public void setDuplicated(boolean duplicated) {
-        this.duplicated = duplicated;
+    public void addDuplicate(URL duplicate) {
+        this.duplicates.add(duplicate);
+    }
+    public List<URL> getDuplicates() {
+        return new ArrayList<>(this.duplicates);
     }
 
     /**
@@ -2166,8 +2169,11 @@ public class WebXml extends XmlEncodingBase implements DocumentProperties.Charse
             // Stage 0. Check there were no fragments with duplicate names
             for (WebXml fragment : fragments.values()) {
                 if (fragment.isDuplicated()) {
+                    List<URL> duplicates = fragment.getDuplicates();
+                    duplicates.add(0, fragment.getURL());
                     throw new IllegalArgumentException(
-                            sm.getString("webXml.duplicateFragment", fragment.getName()));
+                            sm.getString("webXml.duplicateFragment", fragment.getName(),
+                                duplicates));
                 }
             }
             // Stage 1. Make all dependencies bi-directional - this makes the

--- a/test/org/apache/tomcat/util/descriptor/web/TestWebXmlOrdering.java
+++ b/test/org/apache/tomcat/util/descriptor/web/TestWebXmlOrdering.java
@@ -16,6 +16,8 @@
  */
 package org.apache.tomcat.util.descriptor.web;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -346,6 +348,17 @@ public class TestWebXmlOrdering {
         c.addAfterOrdering("b");
 
         WebXml.orderWebFragments(app, fragments, null);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testOrderWebFragmentsRelativeDuplicate() throws MalformedURLException {
+        WebXml withDuplicate = new WebXml();
+        withDuplicate.addDuplicate(new URL("https://example.com/example.jar"));
+
+        Map<String,WebXml> fragmentsWithDuplicate = new LinkedHashMap<>();
+        fragmentsWithDuplicate.put("has-duplicate", withDuplicate);
+
+        WebXml.orderWebFragments(app, fragmentsWithDuplicate, null);
     }
 
     private interface RelativeOrderingTestRunner {


### PR DESCRIPTION
For complex deployments with many dependencies, it's easy to lose track of exactly which ones are causing trouble. Currently, you need to look inside each of your dependency jars in order to figure out what's wrong - I think this change is a harmless quality-of-life improvement, and that it should apply cleanly to all three release branches.

```
Caused by: java.lang.IllegalArgumentException: More than one fragment with the name [some-popular-library] was found. 
This is not legal with relative ordering. See section 8.2.2 2c of the Servlet specification for details. 
Consider using absolute ordering. 
(Duplicates found in: [[file:/home/mads/dev/tomcat/output/build/webapps/madswar/WEB-INF/lib/popular-lib-duplicate.jar, file:/home/mads/dev/tomcat/output/build/webapps/madswar/WEB-INF/lib/popular-lib.jar]]).
```