### PR TITLE
Avoid errors from shutting down `LoggerThread`

### DIFF
--- a/java/org/apache/juli/AsyncFileHandler.java
+++ b/java/org/apache/juli/AsyncFileHandler.java
@@ -205,6 +205,12 @@ public class AsyncFileHandler extends FileHandler {
                 } catch (InterruptedException x) {
                     // Ignore the attempt to interrupt the thread.
                 } catch (Throwable x) {
+                    if (x instanceof VirtualMachineError) {
+                        throw (VirtualMachineError) x;
+                    }
+                    if (x instanceof ThreadDeath) {
+                        throw (ThreadDeath) x;
+                    }
                     x.printStackTrace();
                 }
             }

--- a/java/org/apache/juli/AsyncFileHandler.java
+++ b/java/org/apache/juli/AsyncFileHandler.java
@@ -204,7 +204,7 @@ public class AsyncFileHandler extends FileHandler {
                     entry.flush();
                 } catch (InterruptedException x) {
                     // Ignore the attempt to interrupt the thread.
-                } catch (Exception x) {
+                } catch (Throwable x) {
                     x.printStackTrace();
                 }
             }


### PR DESCRIPTION
A Java `Error` in the `LoggerThread` can effectively cripple Tomcat JULI, preventing all `AsyncFileHandler` from writing to their files.

We experienced such a logging shutdown on a real Gerrit installation, when a `toString()` method threw a `NoClassDefFoundError` and stopped the logger thread used by all the applications on the server.

Should I file a BZ bug?