### PR TITLE
Bugfix for 66233 - Response error msg when the number of Cookie exceeds maxCookieCount

### DIFF
--- a/java/org/apache/catalina/connector/CoyoteAdapter.java
+++ b/java/org/apache/catalina/connector/CoyoteAdapter.java
@@ -753,7 +753,7 @@ public class CoyoteAdapter implements Adapter {
                 // Too many cookies
                 if (!response.isError()) {
                     response.setError();
-                    response.sendError(400);
+                    response.sendError(400, e.getMessage());
                 }
                 return true;
             }


### PR DESCRIPTION
Fix [BZ66233](https://bz.apache.org/bugzilla/show_bug.cgi?id=66233)