### PR TITLE
Avoid int overflow when parsing octet

### DIFF
--- a/java/org/apache/tomcat/util/http/parser/HttpParser.java
+++ b/java/org/apache/tomcat/util/http/parser/HttpParser.java
@@ -754,6 +754,9 @@ public class HttpParser {
                     }
                 } else {
                     octet = octet * 10 + c - '0';
+                    if (octet > 255) {
+                        break;
+                    }
                 }
             } else if (c == ':') {
                 break;


### PR DESCRIPTION
When parsing an octet stop when value exceeds 255. Should fix [bug 66240](https://bz.apache.org/bugzilla/show_bug.cgi?id=66240)