### PR TITLE
UTF-8 makes Non-English Windows Console garbled

### DIFF
--- a/conf/logging.properties
+++ b/conf/logging.properties
@@ -48,7 +48,7 @@ handlers = 1catalina.org.apache.juli.AsyncFileHandler, 2localhost.org.apache.jul
 
 java.util.logging.ConsoleHandler.level = FINE
 java.util.logging.ConsoleHandler.formatter = org.apache.juli.OneLineFormatter
-java.util.logging.ConsoleHandler.encoding = UTF-8
+# java.util.logging.ConsoleHandler.encoding = UTF-8
 
 
 ############################################################


### PR DESCRIPTION
Windows console dose not use UTF-8 by default.
Unset the ConsoleHandler.encoding ,the JVM would choose the platform default.