### PR TITLE
Avoid the unnecessary parsing for web xml as it equals NoDefaultWebXml.

### DIFF
--- a/java/org/apache/catalina/startup/ContextConfig.java
+++ b/java/org/apache/catalina/startup/ContextConfig.java
@@ -982,8 +982,10 @@ public class ContextConfig implements LifecycleListener {
                     Boolean.valueOf(context.getXmlValidation()),
                     Boolean.valueOf(context.getXmlNamespaceAware())));
         }
-
-        webConfig();
+        
+        // If the defaultWebXml is not null and equals NoDefaultWebXml, then no need to proceed the web xml configuration.
+        if (this.defaultWebXml != null && !this.defaultWebXml.equals(Constants.NoDefaultWebXml))
+            webConfig();
 
         if (!context.getIgnoreAnnotations()) {
             applicationAnnotationsConfig();

--- a/java/org/apache/catalina/startup/ContextConfig.java
+++ b/java/org/apache/catalina/startup/ContextConfig.java
@@ -983,9 +983,10 @@ public class ContextConfig implements LifecycleListener {
                     Boolean.valueOf(context.getXmlNamespaceAware())));
         }
         
-        // If the defaultWebXml is not null and equals NoDefaultWebXml, then no need to proceed the web xml configuration.
-        if (this.defaultWebXml != null && !this.defaultWebXml.equals(Constants.NoDefaultWebXml))
+        // If the defaultWebXml is not null and equals NoDefaultWebXml, then no need to proceed the web xml configuration
+        if (this.defaultWebXml != null && !this.defaultWebXml.equals(Constants.NoDefaultWebXml)) {
             webConfig();
+        }
 
         if (!context.getIgnoreAnnotations()) {
             applicationAnnotationsConfig();


### PR DESCRIPTION
If the defaultWebXml is not null and equals NoDefaultWebXml, then no need to proceed the web xml configuration.