### PR TITLE
Remove unnecessary -1 predicate because write will not return -1 unless NioChannel is CLOSED_NIO_CHANNEL

### DIFF
--- a/java/org/apache/catalina/tribes/transport/nio/NioSender.java
+++ b/java/org/apache/catalina/tribes/transport/nio/NioSender.java
@@ -206,9 +206,6 @@ public class NioSender extends AbstractSender {
                 //we have written everything, or we are starting a new package
                 //protect against buffer overwrite
                 int byteswritten = isUdpBased()?dataChannel.write(writebuf) : socketChannel.write(writebuf);
-                if (byteswritten == -1 ) {
-                    throw new EOFException();
-                }
                 remaining -= byteswritten;
                 //if the entire message was written from the buffer
                 //reset the position counter

--- a/java/org/apache/tomcat/util/net/NioEndpoint.java
+++ b/java/org/apache/tomcat/util/net/NioEndpoint.java
@@ -1373,7 +1373,7 @@ public class NioEndpoint extends AbstractNetworkChannelEndpoint<NioChannel,Socke
                     }
                     n = getSocket().write(buffer);
                     if (n == -1) {
-                        throw new EOFException();
+                        throw new ClosedChannelException();
                     } else if (n == 0 && (buffer.hasRemaining() || getSocket().getOutboundRemaining() > 0)) {
                         // n == 0 could be an incomplete write but it could also
                         // indicate that a previous incomplete write of the
@@ -1406,7 +1406,7 @@ public class NioEndpoint extends AbstractNetworkChannelEndpoint<NioChannel,Socke
                 do {
                     n = getSocket().write(buffer);
                     if (n == -1) {
-                        throw new EOFException();
+                        throw new ClosedChannelException();
                     }
                 } while (n > 0 && buffer.hasRemaining());
                 // If there is data left in the buffer the socket will be registered for


### PR DESCRIPTION
The following are the low-level implementations of the Solaris platform, other platforms are similar:

[Java_sun_nio_ch_DatagramDispatcher_write0](https://github.com/openjdk/jdk/blob/jdk8-b120/jdk/src/solaris/native/sun/nio/ch/DatagramDispatcher.c#L82-L94):

```c
JNIEXPORT jint JNICALL
Java_sun_nio_ch_DatagramDispatcher_write0(JNIEnv *env, jclass clazz,
                              jobject fdo, jlong address, jint len)
{
    jint fd = fdval(env, fdo);
    void *buf = (void *)jlong_to_ptr(address);
    int result = send(fd, buf, len, 0);
    if (result < 0 && errno == ECONNREFUSED) {
        JNU_ThrowByName(env, JNU_JAVANETPKG "PortUnreachableException", 0);
        return -2;
    }
    return convertReturnVal(env, result, JNI_FALSE);
}
```

[Java_sun_nio_ch_FileDispatcherImpl_write0](https://github.com/openjdk/jdk/blob/jdk8-b120/jdk/src/solaris/native/sun/nio/ch/FileDispatcherImpl.c#L100-L108):

```c
JNIEXPORT jint JNICALL
Java_sun_nio_ch_FileDispatcherImpl_write0(JNIEnv *env, jclass clazz,
                              jobject fdo, jlong address, jint len)
{
    jint fd = fdval(env, fdo);
    void *buf = (void *)jlong_to_ptr(address);

    return convertReturnVal(env, write(fd, buf, len), JNI_FALSE);
}
```

[convertReturnVal](https://github.com/openjdk/jdk/blob/jdk8-b120/jdk/src/solaris/native/sun/nio/ch/IOUtil.c#L149-L172):

```c
/* Declared in nio_util.h for use elsewhere in NIO */

jint
convertReturnVal(JNIEnv *env, jint n, jboolean reading)
{
    if (n > 0) /* Number of bytes written */
        return n;
    else if (n == 0) {
        if (reading) {
            return IOS_EOF; /* EOF is -1 in javaland */
        } else {
            return 0;
        }
    }
    else if (errno == EAGAIN)
        return IOS_UNAVAILABLE;
    else if (errno == EINTR)
        return IOS_INTERRUPTED;
    else {
        const char *msg = reading ? "Read failed" : "Write failed";
        JNU_ThrowIOExceptionWithLastError(env, msg);
        return IOS_THROWN;
    }
}
```

In fact, it is only possible to return -1 when `read` is called, indicating that the end of the channel stream has been reached.

