### PR TITLE
Fix Javadoc to reflect the change in default formatter

### DIFF
--- a/java/org/apache/juli/FileHandler.java
+++ b/java/org/apache/juli/FileHandler.java
@@ -84,7 +84,7 @@ import java.util.regex.Pattern;
  *    implementation class name for this Handler. Default value: unset</li>
  *   <li><code>formatter</code> - The <code>java.util.logging.Formatter</code>
  *    implementation class name for this Handler. Default value:
- *    <code>java.util.logging.SimpleFormatter</code></li>
+ *    <code>org.apache.juli.OneLineFormatter</code></li>
  *   <li><code>maxDays</code> - The maximum number of days to keep the log
  *    files. If the specified value is <code>&lt;=0</code> then the log files
  *    will be kept on the file system forever, otherwise they will be kept the


### PR DESCRIPTION
The default formatter was changed [here](https://github.com/apache/tomcat/commit/7d0408eb47c52376cf210cc4b8d897d1bffac947#diff-e0d7b86da38bd411282a14bd82e8cc517ff64f68fc3c882647e5a3e0ed736840R335).