### PR TITLE
Native metadata update for Tomcat 10.1

### DIFF
--- a/res/graal/tomcat-embed-core/native-image/tomcat-reflection.json
+++ b/res/graal/tomcat-embed-core/native-image/tomcat-reflection.json
@@ -40,6 +40,8 @@
 { "name":"org.apache.catalina.loader.ParallelWebappClassLoader", "allDeclaredConstructors" : true, "allPublicConstructors" : true, "allDeclaredMethods" : true, "allPublicMethods" : true},
 { "name":"org.apache.catalina.servlets.DefaultServlet", "allDeclaredFields":true, "allDeclaredMethods":true },
 { "name":"org.apache.catalina.valves.ErrorReportValve", "methods" : [{"name": "<init>","parameterTypes":[]}] },
+{ "name":"org.apache.coyote.AbstractProtocol", "methods": [{"name": "getLocalPort","parameterTypes": []},{"name": "getPort","parameterTypes": []}, {"name": "setPortOffset","parameterTypes": ["int"]}, {"name": "getPortOffset","parameterTypes": []}, {"name": "setPort","parameterTypes": ["int"]}]},
+{ "name":"org.apache.coyote.http11.AbstractHttp11Protocol", "methods": [{"name": "setSecure","parameterTypes": ["boolean"]}, {"name": "setMaxSavePostSize","parameterTypes": ["int"]}]},
 { "name":"org.apache.coyote.http11.Http11NioProtocol", "methods" : [{"name": "<init>","parameterTypes":[]}] },
 { "name":"org.apache.coyote.http11.Http11Nio2Protocol", "methods" : [{"name": "<init>","parameterTypes":[]}] },
 { "name":"org.apache.coyote.UpgradeProtocol" },

--- a/res/graal/tomcat-embed-el/native-image/tomcat-resource.json
+++ b/res/graal/tomcat-embed-el/native-image/tomcat-resource.json
@@ -1,7 +1,7 @@
 {
   "bundles":[
     {"name":"jakarta.el.LocalStrings"},
-    {"name":"org.apache.el.Messages"}
+    {"name":"org.apache.el.LocalStrings"}
   ],
   "resources":[
     {"pattern":".*/mbeans-descriptors.xml$"},


### PR DESCRIPTION
This pull request fixes regressions in the Tomcat 10.1 native support compared to Tomcat 10.0.

It brings back required reflection metadata on `AbstractProtocol` and `AbstractHttp11Protocol` lost after `Http11AprProtocol` removal, and rename resource metadata from `org.apache.el.Messages` to `org.apache.el.LocalStrings`.