### PR TITLE
Allow reproducible builds of all JDBC JAR files

### DIFF
--- a/modules/jdbc-pool/build.xml
+++ b/modules/jdbc-pool/build.xml
@@ -185,7 +185,9 @@
 
   <target name="build-src">
     <!-- connection pool source file-->
-    <jar jarfile="${tomcat-jdbc-src.jar}" update="true">
+    <jar jarfile="${tomcat-jdbc-src.jar}"
+         update="true"
+         modificationtime="${tstamp.file}">
       <fileset dir="${basedir}/src/main/java">
         <include name="org/apache/tomcat/jdbc/**" />
       </fileset>
@@ -207,7 +209,9 @@
       <include name="org/apache/tomcat/jdbc/**" />
     </javac>
     <!-- connection pool JAR File -->
-    <jar jarfile="${tomcat-jdbc-test.jar}" update="true">
+    <jar jarfile="${tomcat-jdbc-test.jar}"
+         update="true"
+         modificationtime="${tstamp.file}">
       <fileset dir="${tomcat.testclasses}">
         <include name="org/apache/tomcat/jdbc/**" />
       </fileset>
@@ -216,7 +220,9 @@
       </fileset>
       <fileset refid="license.notice"/>
     </jar>
-    <jar jarfile="${tomcat-jdbc-test-src.jar}" update="true">
+    <jar jarfile="${tomcat-jdbc-test-src.jar}"
+         update="true"
+         modificationtime="${tstamp.file}">
       <fileset dir="${basedir}/src/test/java">
         <include name="org/apache/tomcat/jdbc/**" />
       </fileset>


### PR DESCRIPTION
Fixes [Bug 66346](https://bz.apache.org/bugzilla/show_bug.cgi?id=66346). Only the first change is required to fix the timestamps in `tomcat-jdbc-src.jar`, but this seemed a good time to fix the timestamps in the other two JAR files as well (`tomcat-jdbc-test.jar` and `tomcat-jdbc-test-src.jar`).

Can someone let me know how I might test the building of those two test JAR files? I couldn't figure out which Ant target to use for building and comparing them. I did run the unit test cases, which were successful:

```console
$ ant test
...
   [concat] Testsuites with failed tests:

test:

BUILD SUCCESSFUL
Total time: 110 minutes 45 seconds
```
