### PR TITLE
Refine native resources metadata

### DIFF
--- a/modules/stuffed/tomcat-resource.json
+++ b/modules/stuffed/tomcat-resource.json
@@ -73,9 +73,13 @@
     {"name":"org.apache.tomcat.websocket.server.LocalStrings"}
   ],
   "resources":[
-    {"pattern":".*/mbeans-descriptors.xml$"},
-    {"pattern":".*/*.properties$"},
-    {"pattern":".*/*.dtd$"},
-    {"pattern":".*/*.xsd$"}
+    {"pattern":"^org/apache/tomcat/.*mbeans-descriptors\\.xml$"},
+    {"pattern":"^org/apache/catalina/.*mbeans-descriptors\\.xml$"},
+    {"pattern":"^org/apache/coyote/.*mbeans-descriptors\\.xml$"},
+    {"pattern":"^org/apache/catalina/.*\\.properties$"},
+    {"pattern":"^jakarta/servlet/resources/.*"},
+    {"pattern":"^org/apache/tomcat/.*\\.dtd$"},
+    {"pattern":"^org/apache/jasper/.*mbeans-descriptors\\.xml$"},
+    {"pattern":"^jakarta/servlet/jsp/resources/.*"}
   ]
 }

--- a/res/graal/tomcat-embed-core/native-image/tomcat-resource.json
+++ b/res/graal/tomcat-embed-core/native-image/tomcat-resource.json
@@ -48,9 +48,10 @@
     {"name":"org.apache.tomcat.util.threads.LocalStrings"}
   ],
   "resources":[
-    {"pattern":".*/mbeans-descriptors.xml$"},
-    {"pattern":".*/*.properties$"},
-    {"pattern":".*/*.dtd$"},
-    {"pattern":".*/*.xsd$"}
+    {"pattern":"^org/apache/tomcat/.*mbeans-descriptors\\.xml$"},
+    {"pattern":"^org/apache/catalina/.*mbeans-descriptors\\.xml$"},
+    {"pattern":"^org/apache/coyote/.*mbeans-descriptors\\.xml$"},
+    {"pattern":"^org/apache/catalina/.*\\.properties$"},
+    {"pattern":"^org/apache/tomcat/.*\\.dtd$"}
   ]
 }

--- a/res/graal/tomcat-embed-el/native-image/tomcat-resource.json
+++ b/res/graal/tomcat-embed-el/native-image/tomcat-resource.json
@@ -2,11 +2,5 @@
   "bundles":[
     {"name":"jakarta.el.LocalStrings"},
     {"name":"org.apache.el.LocalStrings"}
-  ],
-  "resources":[
-    {"pattern":".*/mbeans-descriptors.xml$"},
-    {"pattern":".*/*.properties$"},
-    {"pattern":".*/*.dtd$"},
-    {"pattern":".*/*.xsd$"}
   ]
 }

--- a/res/graal/tomcat-embed-jasper/native-image/tomcat-resource.json
+++ b/res/graal/tomcat-embed-jasper/native-image/tomcat-resource.json
@@ -3,9 +3,7 @@
     {"name":"org.apache.jasper.resources.LocalStrings"}
   ],
   "resources":[
-    {"pattern":".*/mbeans-descriptors.xml$"},
-    {"pattern":".*/*.properties$"},
-    {"pattern":".*/*.dtd$"},
-    {"pattern":".*/*.xsd$"}
+    {"pattern":"^org/apache/jasper/.*mbeans-descriptors\\.xml$"},
+    {"pattern":"^jakarta/servlet/jsp/resources/.*"}
   ]
 }

--- a/res/graal/tomcat-embed-programmatic/native-image/tomcat-resource.json
+++ b/res/graal/tomcat-embed-programmatic/native-image/tomcat-resource.json
@@ -37,15 +37,6 @@
     {"name":"org.apache.tomcat.util.threads.LocalStrings"}
   ],
   "resources":[
-    {"pattern":".*/Authenticators.properties$"},
-    {"pattern":".*/MimeTypeMappings.properties$"},
-    {"pattern":".*/catalina.properties$"},
-    {"pattern":".*/CharsetMapperDefault.properties$"},
-    {"pattern":".*/ServerInfo.properties$"},
-    {"pattern":".*/RestrictedServlets.properties$"},
-    {"pattern":".*/RestrictedListeners.properties$"},
-    {"pattern":".*/RestrictedFilters.properties$"},
-    {"pattern":".*/*.dtd$"},
-    {"pattern":".*/*.xsd$"}
+    {"pattern":"^org/apache/catalina/.*\\.properties$"}
   ]
 }

--- a/res/graal/tomcat-embed-websocket/native-image/tomcat-resource.json
+++ b/res/graal/tomcat-embed-websocket/native-image/tomcat-resource.json
@@ -3,11 +3,5 @@
     {"name":"org.apache.tomcat.websocket.LocalStrings"},
     {"name":"org.apache.tomcat.websocket.pojo.LocalStrings"},
     {"name":"org.apache.tomcat.websocket.server.LocalStrings"}
-  ],
-  "resources":[
-    {"pattern":".*/mbeans-descriptors.xml$"},
-    {"pattern":".*/*.properties$"},
-    {"pattern":".*/*.dtd$"},
-    {"pattern":".*/*.xsd$"}
   ]
 }


### PR DESCRIPTION
This commit updates the native resources hints in order to avoid classpath wide inclusion of resources.

@markt-asf @mhalbritter Please check I did not make any mistake.