### PR TITLE
Update objenesis and unboundid versions for IDE configs

### DIFF
--- a/res/ide-support/eclipse/eclipse.classpath
+++ b/res/ide-support/eclipse/eclipse.classpath
@@ -26,9 +26,9 @@
     <classpathentry kind="var" path="TOMCAT_LIBS_BASE/easymock-4.3/easymock-4.3.jar"/>
     <classpathentry kind="var" path="TOMCAT_LIBS_BASE/hamcrest-2.2/hamcrest-2.2.jar"/>
     <classpathentry kind="var" path="TOMCAT_LIBS_BASE/cglib-3.3.0/cglib-nodep-3.3.0.jar"/>
-    <classpathentry kind="var" path="TOMCAT_LIBS_BASE/objenesis-3.2/objenesis-3.2.jar"/>
+    <classpathentry kind="var" path="TOMCAT_LIBS_BASE/objenesis-3.3/objenesis-3.3.jar"/>
     <classpathentry kind="var" path="TOMCAT_LIBS_BASE/bnd-6.4.0/biz.aQute.bnd-6.4.0.jar"/>
     <classpathentry kind="var" path="TOMCAT_LIBS_BASE/migration-1.0.6/jakartaee-migration-1.0.6-shaded.jar"/>
-    <classpathentry kind="var" path="TOMCAT_LIBS_BASE/unboundid-6.0.3/unboundid-ldapsdk-6.0.3.jar"/>
+    <classpathentry kind="var" path="TOMCAT_LIBS_BASE/unboundid-6.0.7/unboundid-ldapsdk-6.0.7.jar"/>
     <classpathentry kind="output" path=".settings/output"/>
 </classpath>

--- a/res/ide-support/idea/tomcat.iml
+++ b/res/ide-support/idea/tomcat.iml
@@ -86,7 +86,7 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$TOMCAT_BUILD_LIBS$/objenesis-3.2/objenesis-3.2.jar!/" />
+          <root url="jar://$TOMCAT_BUILD_LIBS$/objenesis-3.3/objenesis-3.3.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />
@@ -113,7 +113,7 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$TOMCAT_BUILD_LIBS$/unboundid-6.0.3/unboundid-ldapsdk-6.0.3.jar!/" />
+          <root url="jar://$TOMCAT_BUILD_LIBS$/unboundid-6.0.7/unboundid-ldapsdk-6.0.7.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />

--- a/res/ide-support/netbeans/nb-tomcat-build.properties
+++ b/res/ide-support/netbeans/nb-tomcat-build.properties
@@ -37,7 +37,7 @@ nb-test.io-method=org.apache.coyote.http11.Http11NioProtocol
 # it is not possible to retrieve the classpaths from the build to
 # use in the NetBeans targets, so they must be explicitly declared
 
-nb-test.classpath=${test.classes}:${tomcat.build}/webapps/examples/WEB-INF/classes:${base.path}/junit-4.13.2/junit-4.13.2.jar:${base.path}/easymock-4.3/easymock-4.3.jar:${base.path}/objenesis-3.2/objenesis-3.2.jar:${base.path}/cglib-3.3.0/cglib-nodep-3.3.0.jar:${base.path}/hamcrest-2.2/hamcrest-2.2.jar:${base.path}/ecj-4.26/ecj-4.26.jar:${tomcat.classes}
+nb-test.classpath=${test.classes}:${tomcat.build}/webapps/examples/WEB-INF/classes:${base.path}/junit-4.13.2/junit-4.13.2.jar:${base.path}/easymock-4.3/easymock-4.3.jar:${base.path}/objenesis-3.3/objenesis-3.3.jar:${base.path}/cglib-3.3.0/cglib-nodep-3.3.0.jar:${base.path}/hamcrest-2.2/hamcrest-2.2.jar:${base.path}/ecj-4.26/ecj-4.26.jar:${tomcat.classes}
 
 # Extra properties used by the Tomcat project additional NetBeans targets.
 

--- a/res/ide-support/netbeans/project.xml
+++ b/res/ide-support/netbeans/project.xml
@@ -189,7 +189,7 @@
             <compilation-unit>
                 <package-root>test</package-root>
                 <unit-tests/>
-                <classpath mode="compile">output/classes:output/testclasses:${base.path}/junit-4.13.2/junit-4.13.2.jar:${base.path}/easymock-4.3/easymock-4.3.jar:${base.path}/objenesis-3.2/objenesis-3.3.jar:${base.path}/cglib-3.3.0/cglib-nodep-3.3.0.jar:${base.path}/hamcrest/hamcrest-2.2.jar</classpath>
+                <classpath mode="compile">output/classes:output/testclasses:${base.path}/junit-4.13.2/junit-4.13.2.jar:${base.path}/easymock-4.3/easymock-4.3.jar:${base.path}/objenesis-3.3/objenesis-3.3.jar:${base.path}/cglib-3.3.0/cglib-nodep-3.3.0.jar:${base.path}/hamcrest/hamcrest-2.2.jar</classpath>
                 <source-level>1.7</source-level>
             </compilation-unit>
         </java-data>

--- a/res/ide-support/netbeans/project.xml
+++ b/res/ide-support/netbeans/project.xml
@@ -189,7 +189,7 @@
             <compilation-unit>
                 <package-root>test</package-root>
                 <unit-tests/>
-                <classpath mode="compile">output/classes:output/testclasses:${base.path}/junit-4.13.2/junit-4.13.2.jar:${base.path}/easymock-4.3/easymock-4.3.jar:${base.path}/objenesis-3.2/objenesis-3.2.jar:${base.path}/cglib-3.3.0/cglib-nodep-3.3.0.jar:${base.path}/hamcrest/hamcrest-2.2.jar</classpath>
+                <classpath mode="compile">output/classes:output/testclasses:${base.path}/junit-4.13.2/junit-4.13.2.jar:${base.path}/easymock-4.3/easymock-4.3.jar:${base.path}/objenesis-3.2/objenesis-3.3.jar:${base.path}/cglib-3.3.0/cglib-nodep-3.3.0.jar:${base.path}/hamcrest/hamcrest-2.2.jar</classpath>
                 <source-level>1.7</source-level>
             </compilation-unit>
         </java-data>


### PR DESCRIPTION
There seems to be a difference in the dependency versions in the build.properties file and the IDE config files, which I have corrected.