### PR TITLE
Add activateDropConnection config to choose drop connection by http status code

### DIFF
--- a/java/org/apache/coyote/http11/AbstractHttp11Protocol.java
+++ b/java/org/apache/coyote/http11/AbstractHttp11Protocol.java
@@ -661,6 +661,20 @@ public abstract class AbstractHttp11Protocol<S> extends AbstractProtocol<S> {
         getEndpoint().setMaxKeepAliveRequests(mkar);
     }
 
+    public boolean getActivateDropConnection() {
+        return getEndpoint().getActivateDropConnection();
+    }
+    /**
+     * If drop connection activate,
+     * then connection doesn't close even though response http status code is abnormal.
+     * The default is false
+     *
+     * @see Http11Processor#statusDropsConnection(int)
+     */
+    public void setActivateDropConnection(boolean activateDropConnection) {
+        getEndpoint().setActivateDropConnection(activateDropConnection);
+    }
+
 
     // ----------------------------------------------- HTTPS specific properties
     // ------------------------------------------ passed through to the EndPoint

--- a/java/org/apache/coyote/http11/Http11Processor.java
+++ b/java/org/apache/coyote/http11/Http11Processor.java
@@ -195,7 +195,11 @@ public class Http11Processor extends AbstractProcessor {
      * Determine if we must drop the connection because of the HTTP status
      * code.  Use the same list of codes as Apache/httpd.
      */
-    private static boolean statusDropsConnection(int status) {
+    private boolean statusDropsConnection(int status) {
+        if (!protocol.getActivateDropConnection()) {
+            return false;
+        }
+
         return status == 400 /* SC_BAD_REQUEST */ ||
                status == 408 /* SC_REQUEST_TIMEOUT */ ||
                status == 411 /* SC_LENGTH_REQUIRED */ ||

--- a/java/org/apache/tomcat/util/net/AbstractEndpoint.java
+++ b/java/org/apache/tomcat/util/net/AbstractEndpoint.java
@@ -938,6 +938,17 @@ public abstract class AbstractEndpoint<S,U> {
         this.maxKeepAliveRequests = maxKeepAliveRequests;
     }
 
+    /**
+     * activate drop connection when response http status code is abnormal.
+     */
+    private boolean activateDropConnection = true;
+    public boolean getActivateDropConnection() {
+        return activateDropConnection;
+    }
+    public void setActivateDropConnection(boolean activateDropConnection) {
+        this.activateDropConnection = activateDropConnection;
+    }
+
 
     /**
      * Name of the thread pool, which will be used for naming child threads.


### PR DESCRIPTION
when response http status code is `400, 408, 411, 413, 414, 500, 501, 503`, the connection is closed by tomcat even though that is keep-alive. undertow and jetty and netty don't close keep-alive connection unlike tomcat. i believe that it can be optional feature. 

+ our service run on kubernetes and we use istio as service mesh. so tomcat only connects to sidecar. we don't need to frequently close the connection for easily load balancing or other reason.

the first image is before remove statusDropsConnection method, and the second image is after that.
(upstream connection count means creating new connection count)
<img width="1843" alt="image" src="https://user-images.githubusercontent.com/27043428/216298213-473d96bb-ac64-4129-a7ae-3304b835a0fa.png">

<img width="1838" alt="image" src="https://user-images.githubusercontent.com/27043428/216298292-9e00b5d4-70c0-4fe9-8bf7-791b17ce3018.png">

`activateDropConnection` field name can be change, if someone give more good thing. thank you. (--)(__)