### PR TITLE
Speedup by removing non pattern replaceAll with constant arg

### DIFF
--- a/java/org/apache/catalina/startup/ClassLoaderFactory.java
+++ b/java/org/apache/catalina/startup/ClassLoaderFactory.java
@@ -287,7 +287,7 @@ public final class ClassLoaderFactory {
         // JARs. If these URLs are used to construct URLs for resources in a JAR
         // the URL will be used as is. It is therefore necessary to ensure that
         // the sequence "!/" is not present in a class loader URL.
-        String result = urlString.replaceAll("!/", "%21/");
+        String result = urlString.replace("!/", "%21/");
         return new URI(result).toURL();
     }
 
@@ -295,7 +295,7 @@ public final class ClassLoaderFactory {
     private static URL buildClassLoaderUrl(File file) throws MalformedURLException, URISyntaxException {
         // Could be a directory or a file
         String fileUrlString = file.toURI().toString();
-        fileUrlString = fileUrlString.replaceAll("!/", "%21/");
+        fileUrlString = fileUrlString.replace("!/", "%21/");
         return new URI(fileUrlString).toURL();
     }
 

--- a/java/org/apache/catalina/util/ContextName.java
+++ b/java/org/apache/catalina/util/ContextName.java
@@ -185,7 +185,7 @@ public final class ContextName {
      */
     public static ContextName extractFromPath(String path) {
         // Convert '\' to '/'
-        path = path.replaceAll("\\\\", "/");
+        path = path.replace("\\", "/");
         // Remove trailing '/'. Use while just in case a value ends in ///
         while (path.endsWith("/")) {
             path = path.substring(0, path.length() - 1);

--- a/java/org/apache/jasper/compiler/SmapUtil.java
+++ b/java/org/apache/jasper/compiler/SmapUtil.java
@@ -770,12 +770,12 @@ public class SmapUtil {
 
         InputStream is = null;
         try {
-            is = cl.getResourceAsStream(className.replaceAll("\\.","/") + ".smap");
+            is = cl.getResourceAsStream(className.replace(".","/") + ".smap");
             if (is != null) {
                 encoding = SMAP_ENCODING;
                 found = true;
             } else {
-                is = cl.getResourceAsStream(className.replaceAll("\\.","/") + ".class");
+                is = cl.getResourceAsStream(className.replace(".","/") + ".class");
                 // Alternative approach would be to read the class file as per the
                 // JLS. That would require duplicating a lot of BCEL functionality.
                 int b = is.read();

--- a/java/org/apache/tomcat/buildutil/translate/Utils.java
+++ b/java/org/apache/tomcat/buildutil/translate/Utils.java
@@ -123,7 +123,7 @@ public class Utils {
 
         result = ESCAPE_LEADING_SPACE.matcher(result).replaceAll("\\\\$1");
 
-        result = result.replaceAll("\t", "\\t");
+        result = result.replace("\t", "\\t");
 
         return result;
     }

--- a/test/jakarta/el/TestImportHandlerStandardPackages.java
+++ b/test/jakarta/el/TestImportHandlerStandardPackages.java
@@ -119,7 +119,7 @@ public class TestImportHandlerStandardPackages {
                         // Skip directories
                         continue;
                     }
-                    Class<?> clazz = Class.forName(packageName + "." + name.replaceAll("\\.", "\\$"));
+                    Class<?> clazz = Class.forName(packageName + "." + name.replace(".", "$"));
                     if (!Modifier.isPublic(clazz.getModifiers())) {
                         // Skip non-public classes
                         continue;

--- a/test/org/apache/juli/TestFileHandler.java
+++ b/test/org/apache/juli/TestFileHandler.java
@@ -54,7 +54,7 @@ public class TestFileHandler {
         generateLogFiles(logsDir, PREFIX_3, SUFFIX_1, 3);
         generateLogFiles(logsDir, PREFIX_4, SUFFIX_1, 3);
 
-        String date = LocalDateTime.now().minusDays(3).toString().replaceAll(":", "-");
+        String date = LocalDateTime.now().minusDays(3).toString().replace(":", "-");
         File file = new File(logsDir, PREFIX_1 + date + SUFFIX_1);
         if (!file.createNewFile()) {
             Assert.fail("Unable to create " + file.getAbsolutePath());

--- a/test/org/apache/tomcat/util/http/parser/TestMediaType.java
+++ b/test/org/apache/tomcat/util/http/parser/TestMediaType.java
@@ -158,7 +158,7 @@ public class TestMediaType {
         MediaType m = MediaType.parseMediaType(sr);
 
         Assert.assertEquals(CHARSET_WS, m.getCharset());
-        Assert.assertEquals(TYPES.replaceAll(" ", ""),
+        Assert.assertEquals(TYPES.replace(" ", ""),
                 m.toStringNoCharset());
     }
 

--- a/test/org/apache/tomcat/util/net/openssl/ciphers/TesterOpenSSL.java
+++ b/test/org/apache/tomcat/util/net/openssl/ciphers/TesterOpenSSL.java
@@ -276,7 +276,7 @@ public class TesterOpenSSL {
         String ciphers[] = stdout.split("\n");
         for (String cipher : ciphers) {
             // Handle rename for 1.1.0 onwards
-            cipher = cipher.replaceAll("EDH", "DHE");
+            cipher = cipher.replace("EDH", "DHE");
             if (first) {
                 first = false;
             } else {


### PR DESCRIPTION
replaceAll("ABC", "") is non Pattern method and therefore must be replaced to simple fast replace()
A proofs of changes: https://gist.github.com/tbw777/8a6ef60af21487c5faec67037099fd0b