### PR TITLE
Update CoyoteAdapter.java

### DIFF
--- a/java/org/apache/catalina/connector/CoyoteAdapter.java
+++ b/java/org/apache/catalina/connector/CoyoteAdapter.java
@@ -1021,6 +1021,7 @@ public class CoyoteAdapter implements Adapter {
                     if (log.isDebugEnabled()) {
                         log.debug(" Requested cookie session id is " + request.getRequestedSessionId());
                     }
+                    break;
                 } else {
                     if (!request.isRequestedSessionIdValid()) {
                         // Replace the session id until one is valid


### PR DESCRIPTION
we have a problem at function parseSessionCookiesId. If the request has two JSESSIONID on the Cookie. The session will init twice. So request.isRequestedSessionIdValid() will  be invoked. But at request.isRequestedSessionIdValid() , it will call manager.findSession(requestedSessionId). This time request is not bind ClassLoader. We customized the manager. On the manager, will used some class at War. So it's will throw a ClassNotFound exception. So I think the session only need init once. Because the second init is the same as the first time. If request.isRequestedSessionIdValid return true,the second is not need.