### PR TITLE
Use available constants

### DIFF
--- a/java/org/apache/catalina/startup/VersionLoggerListener.java
+++ b/java/org/apache/catalina/startup/VersionLoggerListener.java
@@ -113,9 +113,9 @@ public class VersionLoggerListener implements LifecycleListener {
         log.info(sm.getString("versionLoggerListener.vm.vendor",
                 System.getProperty("java.vm.vendor")));
         log.info(sm.getString("versionLoggerListener.catalina.base",
-                System.getProperty("catalina.base")));
+                System.getProperty(Constants.CATALINA_BASE_PROP)));
         log.info(sm.getString("versionLoggerListener.catalina.home",
-                System.getProperty("catalina.home")));
+                System.getProperty(Constants.CATALINA_HOME_PROP)));
 
         if (logArgs) {
             List<String> args = ManagementFactory.getRuntimeMXBean().getInputArguments();

--- a/java/org/apache/catalina/storeconfig/ConnectorStoreAppender.java
+++ b/java/org/apache/catalina/storeconfig/ConnectorStoreAppender.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.catalina.Globals;
 import org.apache.catalina.connector.Connector;
 import org.apache.coyote.ProtocolHandler;
 import org.apache.tomcat.util.IntrospectionUtils;
@@ -281,7 +282,7 @@ public class ConnectorStoreAppender extends StoreAppender {
 
     protected File getCatalinaBase() {
 
-        File file = new File(System.getProperty("catalina.base"));
+        File file = new File(System.getProperty(Globals.CATALINA_BASE_PROP));
         try {
             file = file.getCanonicalFile();
         } catch (IOException e) {

--- a/java/org/apache/catalina/storeconfig/StandardContextSF.java
+++ b/java/org/apache/catalina/storeconfig/StandardContextSF.java
@@ -28,6 +28,7 @@ import java.util.List;
 import org.apache.catalina.Container;
 import org.apache.catalina.Context;
 import org.apache.catalina.Engine;
+import org.apache.catalina.Globals;
 import org.apache.catalina.Host;
 import org.apache.catalina.LifecycleListener;
 import org.apache.catalina.Loader;
@@ -122,7 +123,7 @@ public class StandardContextSF extends StoreFactoryBase {
         if (configFile != null) {
             File config = new File(configFile.toURI());
             if (!config.isAbsolute()) {
-                config = new File(System.getProperty("catalina.base"),
+                config = new File(System.getProperty(Globals.CATALINA_BASE_PROP),
                         config.getPath());
             }
             if( (!config.isFile()) || (!config.canWrite())) {
@@ -188,7 +189,7 @@ public class StandardContextSF extends StoreFactoryBase {
         if (configFile != null) {
             File config = new File(configFile.toURI());
             if (!config.isAbsolute()) {
-                config = new File(System.getProperty("catalina.base"),
+                config = new File(System.getProperty(Globals.CATALINA_BASE_PROP),
                         config.getPath());
             }
             // Open an output writer for the new configuration file
@@ -294,7 +295,7 @@ public class StandardContextSF extends StoreFactoryBase {
      */
     protected File configBase(Context context) {
 
-        File file = new File(System.getProperty("catalina.base"), "conf");
+        File file = new File(System.getProperty(Globals.CATALINA_BASE_PROP), "conf");
         Container host = context.getParent();
 
         if (host instanceof Host) {
@@ -328,9 +329,9 @@ public class StandardContextSF extends StoreFactoryBase {
     protected String[] filterWatchedResources(StandardContext context,
             String[] wresources) throws Exception {
         File configBase = configBase(context);
-        String confContext = new File(System.getProperty("catalina.base"),
+        String confContext = new File(System.getProperty(Globals.CATALINA_BASE_PROP),
                 "conf/context.xml").getCanonicalPath();
-        String confWeb = new File(System.getProperty("catalina.base"),
+        String confWeb = new File(System.getProperty(Globals.CATALINA_BASE_PROP),
                 "conf/web.xml").getCanonicalPath();
         String confHostDefault = new File(configBase, "context.xml.default")
                 .getCanonicalPath();

--- a/java/org/apache/catalina/storeconfig/StoreContextAppender.java
+++ b/java/org/apache/catalina/storeconfig/StoreContextAppender.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 
 import org.apache.catalina.Container;
+import org.apache.catalina.Globals;
 import org.apache.catalina.core.StandardContext;
 import org.apache.catalina.core.StandardHost;
 
@@ -87,7 +88,7 @@ public class StoreContextAppender extends StoreAppender {
         File appBase;
         File file = new File(host.getAppBase());
         if (!file.isAbsolute()) {
-            file = new File(System.getProperty("catalina.base"), host
+            file = new File(System.getProperty(Globals.CATALINA_BASE_PROP), host
                     .getAppBase());
         }
         try {

--- a/java/org/apache/catalina/storeconfig/StoreFileMover.java
+++ b/java/org/apache/catalina/storeconfig/StoreFileMover.java
@@ -23,6 +23,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.sql.Timestamp;
 
+import org.apache.catalina.Globals;
 import org.apache.tomcat.util.res.StringManager;
 
 /**
@@ -38,7 +39,7 @@ public class StoreFileMover {
 
     private String encoding = "UTF-8";
 
-    private String basename = System.getProperty("catalina.base");
+    private String basename = System.getProperty(Globals.CATALINA_BASE_PROP);
 
     private File configOld;
 

--- a/java/org/apache/tomcat/jni/Library.java
+++ b/java/org/apache/tomcat/jni/Library.java
@@ -18,6 +18,8 @@ package org.apache.tomcat.jni;
 
 import java.io.File;
 
+import org.apache.catalina.Globals;
+
 public final class Library {
 
     /* Default library names */
@@ -30,7 +32,7 @@ public final class Library {
     private Library() throws Exception {
         boolean loaded = false;
         StringBuilder err = new StringBuilder();
-        File binLib = new File(System.getProperty("catalina.home"), "bin");
+        File binLib = new File(System.getProperty(Globals.CATALINA_HOME_PROP), "bin");
         for (int i = 0; i < NAMES.length; i++) {
             File library = new File(binLib, System.mapLibraryName(NAMES[i]));
             try {

--- a/test/org/apache/catalina/startup/LoggingBaseTest.java
+++ b/test/org/apache/catalina/startup/LoggingBaseTest.java
@@ -112,7 +112,7 @@ public abstract class LoggingBaseTest {
         Path tempBasePath = FileSystems.getDefault().getPath(tempBase.getAbsolutePath());
         tempDir = Files.createTempDirectory(tempBasePath, "test").toFile();
 
-        System.setProperty("catalina.base", tempDir.getAbsolutePath());
+        System.setProperty(Constants.CATALINA_BASE_PROP, tempDir.getAbsolutePath());
 
         // Configure logging
         System.setProperty("java.util.logging.manager",

--- a/test/org/apache/tomcat/util/file/TestConfigFileLoader.java
+++ b/test/org/apache/tomcat/util/file/TestConfigFileLoader.java
@@ -26,6 +26,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.apache.catalina.Globals;
 import org.apache.catalina.startup.CatalinaBaseConfigurationSource;
 import org.apache.catalina.webresources.TomcatURLStreamHandlerFactory;
 
@@ -34,8 +35,8 @@ public class TestConfigFileLoader {
     @BeforeClass
     public static void setup() {
         TomcatURLStreamHandlerFactory.getInstance();
-        System.setProperty("catalina.base", "");
-        ConfigFileLoader.setSource(new CatalinaBaseConfigurationSource(new File(System.getProperty("catalina.base")), null));
+        System.setProperty(Globals.CATALINA_BASE_PROP, "");
+        ConfigFileLoader.setSource(new CatalinaBaseConfigurationSource(new File(System.getProperty(Globals.CATALINA_BASE_PROP)), null));
     }
 
     @Test


### PR DESCRIPTION
We seem to have some duplication, e.g. `o.a.c.Globals.CATALINA_HOME_PROP` which is set from `o.a.c.startup.Constants.CATALINA_HOME_PROP`.

Do we need `o.a.c.startup.Constants` to be separate for some reason, e.g. for packaging different JARs, or can we consolidate the code and use just `o.a.c.Globals` instead?

The current PR does not modify that.  It only replaces the literal strings `"catalina.home"` and `"catalina.base"` with constants from `Globals`, or in the `o.a.c.startup` package with `Constants`.

I'm opening the PR so there are more eyes on it before I make the change, and will merge it after some reasonable time passes if no one raises any issues with it.