### PR TITLE
Fix Bug 66543 -  Wrong log message used in StandardContext#fireRequestDestroyEvent

### DIFF
--- a/java/org/apache/catalina/core/LocalStrings.properties
+++ b/java/org/apache/catalina/core/LocalStrings.properties
@@ -209,6 +209,7 @@ standardContext.predestroy.duplicate=Duplicate @PreDestroy method definition for
 standardContext.predestroy.required=Both fully qualified class name and method name are required
 standardContext.reloadingCompleted=Reloading Context with name [{0}] is completed
 standardContext.reloadingStarted=Reloading Context with name [{0}] has started
+standardContext.requestListener.requestDestroyed=Exception sending request destroyed lifecycle event to listener instance of class [{0}]
 standardContext.requestListener.requestInit=Exception sending request initialized lifecycle event to listener instance of class [{0}]
 standardContext.resourcesInit=Error initializing static Resources
 standardContext.resourcesStart=Error starting static Resources

--- a/java/org/apache/catalina/core/StandardContext.java
+++ b/java/org/apache/catalina/core/StandardContext.java
@@ -5629,7 +5629,7 @@ public class StandardContext extends ContainerBase implements Context, Notificat
                     listener.requestDestroyed(event);
                 } catch (Throwable t) {
                     ExceptionUtils.handleThrowable(t);
-                    getLogger().error(sm.getString("standardContext.requestListener.requestInit",
+                    getLogger().error(sm.getString("standardContext.requestListener.requestDestroyed",
                             instances[j].getClass().getName()), t);
                     request.setAttribute(RequestDispatcher.ERROR_EXCEPTION, t);
                     return false;

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -174,6 +174,10 @@
         with some OSGi custom URL schemes that can trigger potentially slow DNS
         lookups in some configurations. (markt)
       </fix>
+      <fix>
+        <bug>66543</bug>: Give <code>StandardContext#fireRequestDestroyEvent</code>
+         its own log message. (fschumacher)
+      </fix>
     </changelog>
   </subsection>
   <subsection name="Coyote">


### PR DESCRIPTION
Give it its own log message instead of re-using the one from fireRequestInitEvent.