### PR TITLE
Further fix for BZ 66508

### DIFF
--- a/java/org/apache/tomcat/websocket/server/WsHttpUpgradeHandler.java
+++ b/java/org/apache/tomcat/websocket/server/WsHttpUpgradeHandler.java
@@ -117,7 +117,8 @@ public class WsHttpUpgradeHandler implements InternalHttpUpgradeHandler {
         ClassLoader cl = t.getContextClassLoader();
         t.setContextClassLoader(applicationClassLoader);
         try {
-            wsRemoteEndpointServer = new WsRemoteEndpointImplServer(socketWrapper, upgradeInfo, webSocketContainer);
+            wsRemoteEndpointServer =
+                    new WsRemoteEndpointImplServer(socketWrapper, upgradeInfo, webSocketContainer, connection);
             wsSession = new WsSession(wsRemoteEndpointServer, webSocketContainer, handshakeRequest.getRequestURI(),
                     handshakeRequest.getParameterMap(), handshakeRequest.getQueryString(),
                     handshakeRequest.getUserPrincipal(), httpSessionId, negotiatedExtensions, subProtocol,

--- a/java/org/apache/tomcat/websocket/server/WsRemoteEndpointImplServer.java
+++ b/java/org/apache/tomcat/websocket/server/WsRemoteEndpointImplServer.java
@@ -24,6 +24,7 @@ import java.nio.channels.CompletionHandler;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import jakarta.servlet.http.WebConnection;
 import jakarta.websocket.SendHandler;
 import jakarta.websocket.SendResult;
 
@@ -33,6 +34,7 @@ import org.apache.juli.logging.LogFactory;
 import org.apache.tomcat.util.net.SocketWrapperBase;
 import org.apache.tomcat.util.net.SocketWrapperBase.BlockingMode;
 import org.apache.tomcat.util.res.StringManager;
+import org.apache.tomcat.websocket.Constants;
 import org.apache.tomcat.websocket.Transformation;
 import org.apache.tomcat.websocket.WsRemoteEndpointImplBase;
 
@@ -47,16 +49,19 @@ public class WsRemoteEndpointImplServer extends WsRemoteEndpointImplBase {
 
     private final SocketWrapperBase<?> socketWrapper;
     private final UpgradeInfo upgradeInfo;
+    private final WebConnection connection;
     private final WsWriteTimeout wsWriteTimeout;
+    private final Object semaphoreManagementLock = new Object();
     private volatile SendHandler handler = null;
     private volatile ByteBuffer[] buffers = null;
 
     private volatile long timeoutExpiry = -1;
 
     public WsRemoteEndpointImplServer(SocketWrapperBase<?> socketWrapper, UpgradeInfo upgradeInfo,
-            WsServerContainer serverContainer) {
+            WsServerContainer serverContainer, WebConnection connection) {
         this.socketWrapper = socketWrapper;
         this.upgradeInfo = upgradeInfo;
+        this.connection = connection;
         this.wsWriteTimeout = serverContainer.getTimeout();
     }
 
@@ -64,6 +69,75 @@ public class WsRemoteEndpointImplServer extends WsRemoteEndpointImplBase {
     @Override
     protected final boolean isMasked() {
         return false;
+    }
+
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The close message is a special case. It needs to be blocking else implementing the clean-up that follows the
+     * sending of the close message gets a lot more complicated. On the server, this creates additional complications
+     * as a dead-lock may occur in the following scenario:
+     * <ol>
+     *   <li>Application thread writes message using non-blocking</li>
+     *   <li>Write does not complete (write logic holds message pending lock)</li>
+     *   <li>Socket is added to poller (or equivalent) for write
+     *   <li>Client sends close message</li>
+     *   <li>Container processes received close message and tries to send close message in response</li>
+     *   <li>Container holds socket lock and is blocked waiting for message pending lock</li>
+     *   <li>Poller fires write possible event for socket</li>
+     *   <li>Container tries to process write possible event but is blocked waiting for socket lock</li>
+     *   <li>Processing of the WebSocket connection is dead-locked until the original message write times out</li>
+     * </ol>
+     * The purpose of this method is to break the above dead-lock. It does this by returning control of the processor to
+     * the socket wrapper and releasing the socket lock while waiting for the pending message write to complete.
+     * Normally, that would be a terrible idea as it creates the possibility that the processor is returned to the pool
+     * more than once under various error conditions. In this instance it is safe because these are upgrade processors
+     * (isUpgrade() returns {@code true}) and upgrade processors are never pooled.
+     * <p>
+     * TODO: Despite the complications it creates, it would be worth exploring the possibility of processing a received
+     * close frame in a non-blocking manner.
+     */
+    @Override
+    protected boolean acquireMessagePartInProgressSemaphore(byte opCode, long timeoutExpiry)
+            throws InterruptedException {
+
+        // Only close requires special handling.
+        if (opCode != Constants.OPCODE_CLOSE) {
+            return super.acquireMessagePartInProgressSemaphore(opCode, timeoutExpiry);
+        }
+
+        synchronized (semaphoreManagementLock) {
+            while (!messagePartInProgress.tryAcquire()) {
+                long timeout = timeoutExpiry - System.currentTimeMillis();
+                if (timeout < 0) {
+                    return false;
+                }
+                try {
+                    // Release control of the processor
+                    socketWrapper.setCurrentProcessor(connection);
+                    // Release the per socket lock
+                    socketWrapper.getLock().unlock();
+                    // Wait for another thread to call #endMessage()
+                    semaphoreManagementLock.wait(timeout);
+                } finally {
+                    // Re-obtain the per socket lock
+                    socketWrapper.getLock().lock();
+                    // Re-take control of the processor
+                    socketWrapper.takeCurrentProcessor();
+                }
+            }
+        }
+        return true;
+    }
+
+
+    @Override
+    protected void endMessage(SendHandler handler, SendResult result) {
+        synchronized (semaphoreManagementLock) {
+            super.endMessage(handler, result);
+            semaphoreManagementLock.notifyAll();
+        }
     }
 
 


### PR DESCRIPTION
https://bz.apache.org/bugzilla/show_bug.cgi?id=66508

Avoid deadlock for close messages when
WsRemoteEndpointImplServer.endMessage() for a previous message is processed on a container thread

The fix for this involves the thread currently processing a socket effectively yielding the socket lock and processor to another thread. I think that is worthy of closer review before merge.

There are a couple of potential alternatives.

Plan B would be to make handing of the close message async. That is potentially better but will be more complex to implement and may uncover other complexities.

Plan C would be to require useAsyncIO="true" to enable WebSocket.