### PR TITLE
Remove uses of classes in deprecated package javax.security.cert

### DIFF
--- a/java/org/apache/tomcat/util/net/openssl/OpenSSLEngine.java
+++ b/java/org/apache/tomcat/util/net/openssl/OpenSSLEngine.java
@@ -151,8 +151,6 @@ public final class OpenSSLEngine extends SSLEngine implements SSLUtil.ProtocolIn
     private volatile String applicationProtocol;
 
     private volatile Certificate[] peerCerts;
-    @Deprecated
-    private volatile javax.security.cert.X509Certificate[] x509PeerCerts;
     private volatile ClientAuthMode clientAuth = ClientAuthMode.NONE;
 
     // SSL Engine status variables
@@ -947,7 +945,6 @@ public final class OpenSSLEngine extends SSLEngine implements SSLUtil.ProtocolIn
         }
         handshakeFinished = false;
         peerCerts = null;
-        x509PeerCerts = null;
         currentHandshake = SSL.getHandshakeCount(state.ssl);
         int code2 = SSL.doHandshake(state.ssl);
         if (code2 <= 0) {
@@ -1325,37 +1322,6 @@ public final class OpenSSLEngine extends SSLEngine implements SSLUtil.ProtocolIn
         public Certificate[] getLocalCertificates() {
             // FIXME (if possible): Not available in the OpenSSL API
             return EMPTY_CERTIFICATES;
-        }
-
-        @Deprecated
-        @Override
-        public javax.security.cert.X509Certificate[] getPeerCertificateChain()
-                throws SSLPeerUnverifiedException {
-            // these are lazy created to reduce memory overhead
-            javax.security.cert.X509Certificate[] c = x509PeerCerts;
-            if (c == null) {
-                byte[][] chain;
-                synchronized (OpenSSLEngine.this) {
-                    if (destroyed || SSL.isInInit(state.ssl) != 0) {
-                        throw new SSLPeerUnverifiedException(sm.getString("engine.unverifiedPeer"));
-                    }
-                    chain = SSL.getPeerCertChain(state.ssl);
-                }
-                if (chain == null) {
-                    throw new SSLPeerUnverifiedException(sm.getString("engine.unverifiedPeer"));
-                }
-                javax.security.cert.X509Certificate[] peerCerts =
-                        new javax.security.cert.X509Certificate[chain.length];
-                for (int i = 0; i < peerCerts.length; i++) {
-                    try {
-                        peerCerts[i] = javax.security.cert.X509Certificate.getInstance(chain[i]);
-                    } catch (javax.security.cert.CertificateException e) {
-                        throw new IllegalStateException(e);
-                    }
-                }
-                c = x509PeerCerts = peerCerts;
-            }
-            return c;
         }
 
         @Override

--- a/modules/openssl-foreign/src/main/java/org/apache/tomcat/util/net/openssl/panama/OpenSSLEngine.java
+++ b/modules/openssl-foreign/src/main/java/org/apache/tomcat/util/net/openssl/panama/OpenSSLEngine.java
@@ -203,8 +203,6 @@ public final class OpenSSLEngine extends SSLEngine implements SSLUtil.ProtocolIn
     private volatile String applicationProtocol;
 
     private volatile Certificate[] peerCerts;
-    @Deprecated
-    private volatile javax.security.cert.X509Certificate[] x509PeerCerts;
     private volatile ClientAuthMode clientAuth = ClientAuthMode.NONE;
 
     // SSL Engine status variables
@@ -1006,7 +1004,6 @@ public final class OpenSSLEngine extends SSLEngine implements SSLUtil.ProtocolIn
         }
         handshakeFinished = false;
         peerCerts = null;
-        x509PeerCerts = null;
         currentHandshake = state.handshakeCount;
         int code2 = SSL_do_handshake(state.ssl);
         if (code2 <= 0) {
@@ -1671,37 +1668,6 @@ public final class OpenSSLEngine extends SSLEngine implements SSLUtil.ProtocolIn
         public Certificate[] getLocalCertificates() {
             // FIXME (if possible): Not available in the OpenSSL API
             return EMPTY_CERTIFICATES;
-        }
-
-        @Deprecated
-        @Override
-        public javax.security.cert.X509Certificate[] getPeerCertificateChain()
-                throws SSLPeerUnverifiedException {
-            // these are lazy created to reduce memory overhead
-            javax.security.cert.X509Certificate[] c = x509PeerCerts;
-            if (c == null) {
-                byte[][] chain;
-                synchronized (OpenSSLEngine.this) {
-                    if (destroyed || SSL_in_init(state.ssl) != 0) {
-                        throw new SSLPeerUnverifiedException(sm.getString("engine.unverifiedPeer"));
-                    }
-                    chain = getPeerCertChain();
-                }
-                if (chain == null) {
-                    throw new SSLPeerUnverifiedException(sm.getString("engine.unverifiedPeer"));
-                }
-                javax.security.cert.X509Certificate[] peerCerts =
-                        new javax.security.cert.X509Certificate[chain.length];
-                for (int i = 0; i < peerCerts.length; i++) {
-                    try {
-                        peerCerts[i] = javax.security.cert.X509Certificate.getInstance(chain[i]);
-                    } catch (javax.security.cert.CertificateException e) {
-                        throw new IllegalStateException(e);
-                    }
-                }
-                c = x509PeerCerts = peerCerts;
-            }
-            return c;
         }
 
         @Override

--- a/modules/openssl-java17/src/main/java/org/apache/tomcat/util/net/openssl/panama/OpenSSLEngine.java
+++ b/modules/openssl-java17/src/main/java/org/apache/tomcat/util/net/openssl/panama/OpenSSLEngine.java
@@ -201,8 +201,6 @@ public final class OpenSSLEngine extends SSLEngine implements SSLUtil.ProtocolIn
     private volatile String applicationProtocol;
 
     private volatile Certificate[] peerCerts;
-    @Deprecated
-    private volatile javax.security.cert.X509Certificate[] x509PeerCerts;
     private volatile ClientAuthMode clientAuth = ClientAuthMode.NONE;
 
     // SSL Engine status variables
@@ -1063,7 +1061,6 @@ public final class OpenSSLEngine extends SSLEngine implements SSLUtil.ProtocolIn
         }
         handshakeFinished = false;
         peerCerts = null;
-        x509PeerCerts = null;
         currentHandshake = state.handshakeCount;
         int code2 = SSL_do_handshake(state.ssl);
         if (code2 <= 0) {
@@ -1726,37 +1723,6 @@ public final class OpenSSLEngine extends SSLEngine implements SSLUtil.ProtocolIn
         public Certificate[] getLocalCertificates() {
             // FIXME (if possible): Not available in the OpenSSL API
             return EMPTY_CERTIFICATES;
-        }
-
-        @Deprecated
-        @Override
-        public javax.security.cert.X509Certificate[] getPeerCertificateChain()
-                throws SSLPeerUnverifiedException {
-            // these are lazy created to reduce memory overhead
-            javax.security.cert.X509Certificate[] c = x509PeerCerts;
-            if (c == null) {
-                byte[][] chain;
-                synchronized (OpenSSLEngine.this) {
-                    if (destroyed || SSL_in_init(state.ssl) != 0) {
-                        throw new SSLPeerUnverifiedException(sm.getString("engine.unverifiedPeer"));
-                    }
-                    chain = getPeerCertChain();
-                }
-                if (chain == null) {
-                    throw new SSLPeerUnverifiedException(sm.getString("engine.unverifiedPeer"));
-                }
-                javax.security.cert.X509Certificate[] peerCerts =
-                        new javax.security.cert.X509Certificate[chain.length];
-                for (int i = 0; i < peerCerts.length; i++) {
-                    try {
-                        peerCerts[i] = javax.security.cert.X509Certificate.getInstance(chain[i]);
-                    } catch (javax.security.cert.CertificateException e) {
-                        throw new IllegalStateException(e);
-                    }
-                }
-                c = x509PeerCerts = peerCerts;
-            }
-            return c;
         }
 
         @Override


### PR DESCRIPTION
Efforts are underway in the OpenJDK project to remove the long deprecated-for-removal classes in the package `javax.security.cert`. These classes were introduced for backwards compatibility concerns with the unbundled JSSE release for JDK 1.2/1.3, but their use have been discouraged since they were introduced.

It would be good to update Tomcat to not depend on / use these archaic APIs.

See https://bugs.openjdk.org/browse/JDK-8227024 and the corresponding CSR https://bugs.openjdk.org/browse/JDK-8227395