### PR TITLE
Unify Windows/Linux package filesets

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2808,24 +2808,24 @@ asf.ldap.username=${release.asfusername}
          encoding="UTF8">
       <zipfileset file="${tomcat.dist}" fullpath="${final.name}"/>
       <zipfileset dir="${tomcat.dist}" prefix="${final.name}">
-        <include name="bin/**"/>
-        <include name="conf/**"/>
-        <include name="logs/**"/>
-        <include name="lib/**"/>
-        <include name="webapps/**"/>
-        <include name="work/**"/>
-        <include name="temp/**"/>
-        <include name="LICENSE"/>
-        <include name="NOTICE"/>
-        <include name="README.md"/>
-        <include name="RELEASE-NOTES"/>
-        <include name="RUNNING.txt"/>
+        <include name="bin/**" />
         <include name="BUILDING.txt" />
-        <include name="CONTRIBUTING.md"/>
-        <exclude name="bin/service.bat"/>
-        <exclude name="bin/x64/"/>
-        <exclude name="bin/*.exe"/>
-        <exclude name="bin/*.dll"/>
+        <include name="conf/**" />
+        <include name="CONTRIBUTING.md" />
+        <include name="lib/**" />
+        <include name="LICENSE" />
+        <include name="logs/**" />
+        <include name="NOTICE" />
+        <include name="README.md" />
+        <include name="RELEASE-NOTES" />
+        <include name="RUNNING.txt" />
+        <include name="temp/**" />
+        <include name="webapps/**" />
+        <include name="work/**" />
+        <exclude name="bin/*.dll" />
+        <exclude name="bin/*.exe" />
+        <exclude name="bin/*.sh" />
+        <exclude name="bin/x64/" />
       </zipfileset>
     </zip>
 
@@ -2945,25 +2945,24 @@ asf.ldap.username=${release.asfusername}
       </tarfileset>
       <tarfileset dir="${tomcat.dist}" dirmode="750" filemode="640" prefix="${final.name}">
         <include name="bin/**" />
+        <include name="BUILDING.txt" />
+        <include name="conf/**" />
+        <include name="CONTRIBUTING.md" />
         <include name="lib/**" />
-        <include name="logs/**" />
-        <include name="temp/**" />
-        <include name="webapps/**" />
-        <include name="work/**" />
         <include name="LICENSE" />
+        <include name="logs/**" />
         <include name="NOTICE" />
         <include name="README.md" />
         <include name="RELEASE-NOTES" />
         <include name="RUNNING.txt" />
-        <include name="BUILDING.txt" />
-        <include name="CONTRIBUTING.md"/>
-        <exclude name="conf/**" />
-        <exclude name="src/**" />
-        <exclude name="bin/service.bat"/>
-        <exclude name="bin/*.sh"/>
-        <exclude name="bin/x64/"/>
-        <exclude name="bin/*.exe"/>
-        <exclude name="bin/*.dll"/>
+        <include name="temp/**" />
+        <include name="webapps/**" />
+        <include name="work/**" />
+        <exclude name="bin/*.dll" />
+        <exclude name="bin/*.exe" />
+        <exclude name="bin/*.sh" />
+        <exclude name="bin/x64/" />
+        <exclude name="bin/*.bat"/>
       </tarfileset>
       <!-- These need to be added after the bin directory is added else the  -->
       <!-- bin directory will pick up the wrong permissions.                 -->


### PR DESCRIPTION
This looks like a bigger change than it is, simply because I sorted the list.

**Changes**:
* Sorted the Windows/Linux include/exclude lists, to make it easy to compare the two
* **Windows**
  * Removed exclusion of `service.bat`.
  * Added exclusion of `bin/*.sh`
* **Linux**
  * Removed the exclusion of `conf/**`
    * This now matches Windows, and I think this was intended.
  * Changed the exclusion `bin/service.bat` to `bin/*.bat`
  * Removed the exclusion of `src/**`, as it's not excluded in Windows, and I don't think it's needed.

The "big" change is that now `service.bat` is included in the windows zip. I don't know why it was ever excluded, and when I asked about it in the mailing list I was told to create a PR.