### PR TITLE
Don't allow idle threads to live forever

### DIFF
--- a/java/org/apache/tomcat/websocket/AsyncChannelGroupUtil.java
+++ b/java/org/apache/tomcat/websocket/AsyncChannelGroupUtil.java
@@ -79,8 +79,8 @@ public class AsyncChannelGroupUtil {
             // These are the same settings as the default
             // AsynchronousChannelGroup
             int initialSize = Runtime.getRuntime().availableProcessors();
-            ExecutorService executorService = new ThreadPoolExecutor(0, Integer.MAX_VALUE, Long.MAX_VALUE,
-                    TimeUnit.MILLISECONDS, new SynchronousQueue<>(), new AsyncIOThreadFactory());
+            ExecutorService executorService = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60,
+                    TimeUnit.SECONDS, new SynchronousQueue<>(), new AsyncIOThreadFactory());
 
             try {
                 return AsynchronousChannelGroup.withCachedThreadPool(executorService, initialSize);


### PR DESCRIPTION
From https://bz.apache.org/bugzilla/show_bug.cgi?id=66581 

Currently the ExecutorService used for this is as such:

ExecutorService executorService = new ThreadPoolExecutor(0, Integer.MAX_VALUE, Long.MAX_VALUE, TimeUnit.MILLISECONDS, new SynchronousQueue<>(), new AsyncIOThreadFactory());

This means that the threads never terminate and are spawned whenever a thread is not available, which for a server under a spike of load spawns many threads which never exit, consuming system resources indefinitely.

I would suggest that a saner idle timeout than Long.MAX_VALUE should be used, such as 60 seconds, unless there is a good reason I am unaware of as to why such threads should never die.