### PR TITLE
transferTo can transfer only part of the file, so need to loop

### DIFF
--- a/java/org/apache/catalina/startup/ExpandWar.java
+++ b/java/org/apache/catalina/startup/ExpandWar.java
@@ -268,7 +268,19 @@ public class ExpandWar {
             } else {
                 try (FileChannel ic = (new FileInputStream(fileSrc)).getChannel();
                         FileChannel oc = (new FileOutputStream(fileDest)).getChannel()) {
-                    ic.transferTo(0, ic.size(), oc);
+                    long size = ic.size();
+                    long position = 0;
+                    while (size > 0) { // we still have bytes to transfer
+                        long count = ic.transferTo(position, size, oc);
+                        if (count > 0)
+                        {
+                            position += count;
+                            size -= count;
+                        } else {
+                            //shouldn't loop forever but just to be safe
+                            throw new IOException("file copy failed");
+                        }
+                    }
                 } catch (IOException e) {
                     log.error(sm.getString("expandWar.copy", fileSrc, fileDest), e);
                     result = false;


### PR DESCRIPTION
We (Elastic APM) have a customer (using tomcat 9.0.72) that is hitting this bug. The file copy is getting interrupted (likely from CPU time slicing signals, which is happening because of additional profiling executing in the background) and so only partly completes. As the current implementation doesn't loop, this results in a corrupt war/zip file that can't be loaded. To complete the file copy, transferTo needs to loop