### PR TITLE
Remove transport.bio from catalina-tribes.jar.tmp.bnd

### DIFF
--- a/res/bnd/catalina-tribes.jar.tmp.bnd
+++ b/res/bnd/catalina-tribes.jar.tmp.bnd
@@ -26,7 +26,6 @@ Export-Package: \
     org.apache.catalina.tribes.membership,\
     org.apache.catalina.tribes.tipis,\
     org.apache.catalina.tribes.transport,\
-    org.apache.catalina.tribes.transport.bio,\
     org.apache.catalina.tribes.transport.nio,\
     org.apache.catalina.tribes.util
 


### PR DESCRIPTION
Since package org.apache.catalina.tribes.transport.bio was deprecated in tomcat 10, https://tomcat.apache.org/tomcat-9.0-doc/api/org/apache/catalina/tribes/transport/bio/package-summary.html , references to it in catalina-tribes.jar should be removed.
