### PR TITLE
Bug 66684:  set the revocationEnabled as FALSE when crl file is empty

### DIFF
--- a/java/org/apache/tomcat/util/net/SSLUtilBase.java
+++ b/java/org/apache/tomcat/util/net/SSLUtilBase.java
@@ -502,10 +502,14 @@ public abstract class SSLUtilBase implements SSLUtil {
                 new PKIXBuilderParameters(trustStore, new X509CertSelector());
         if (crlf != null && crlf.length() > 0) {
             Collection<? extends CRL> crls = getCRLs(crlf);
-            CertStoreParameters csp = new CollectionCertStoreParameters(crls);
-            CertStore store = CertStore.getInstance("Collection", csp);
-            xparams.addCertStore(store);
-            xparams.setRevocationEnabled(true);
+            if (crls != null && crls.size() > 0){
+                CertStoreParameters csp = new CollectionCertStoreParameters(crls);
+                CertStore store = CertStore.getInstance("Collection", csp);
+                xparams.addCertStore(store);
+                xparams.setRevocationEnabled(true);
+            } else {
+                xparams.setRevocationEnabled(revocationEnabled);
+            }
         } else {
             xparams.setRevocationEnabled(revocationEnabled);
         }


### PR DESCRIPTION
https://bz.apache.org/bugzilla/show_bug.cgi?id=66684

Recently, we tested the use of the crLFile configuration （in server.xml） in the scenario where two-way certificate authentication is enabled. When the file pointed to by the crlFile configuration item is an empty file (the file exists but the file content is blank), Tomcat cannot provide services and SSL HandShake reports an error（certificate_unknown）. When crlFile is not configured or the content in crlFile is correct, no error is reported.

I'm thinking that don't need to set the revocationEnabled parameter to true (In org.apache.tomcat.util.net.SSLUtilBase#getParameters 498L) when the file content is blank.
