### PR TITLE
Catalina [StandardSession] bug id=66680 (misleading warn about non-serializable principal)

### DIFF
--- a/java/org/apache/catalina/session/StandardSession.java
+++ b/java/org/apache/catalina/session/StandardSession.java
@@ -1486,7 +1486,7 @@ public class StandardSession implements HttpSession, Session, Serializable {
         if (getPersistAuthentication()) {
             sessionAuthType = getAuthType();
             sessionPrincipal = getPrincipal();
-            if (!(sessionPrincipal instanceof Serializable)) {
+            if (sessionPrincipal != null && !(sessionPrincipal instanceof Serializable)) {
                 sessionPrincipal = null;
                 manager.getContext().getLogger().warn(sm.getString("standardSession.principalNotSerializable", id));
             }


### PR DESCRIPTION
Misleading warning message is logged in the following scenario:
- When persistAuthentication="true".
When a user is logged-out of the system and redirected to the login page, they are given a session whose principle object is null.

- If in that period the tomcat server is restarted, the doWriteObject from org.apache.catalina.session.StandardSession is called where on line 1489 it tries to check if the sessionPrincipal is serializable, but does not check if it is null before that - (https://github.com/apache/tomcat/blob/10.1.x/java/org/apache/catalina/session/StandardSession.java#L1489 ).

- If the principal is null (like in the above-described scenario) - then the manager logs a warning message saying it cannot serialize the principal for the session. This is somewhat misleading as there is simply no principal to serialize.

- Suggestion here would be to either add a null-check before logging the warning message, or add a configuration option where this particular case (one of a null principal) can be toggled, perhaps something like 'warnNullPrincipalSerialize'.


Implemented change in this PR- adding the null-check.

Without such an ability we would get a lot of these warning messages in our production and we would not know which ones came from a session that is simply unauthenticated (i.e. principal is null), and which ones came from an actual issue with serializing the principal of an authenticated user.