### PR TITLE
Custom ssl engine parameters

### DIFF
--- a/java/org/apache/tomcat/util/net/AbstractNetworkChannelEndpoint.java
+++ b/java/org/apache/tomcat/util/net/AbstractNetworkChannelEndpoint.java
@@ -26,6 +26,7 @@ public abstract class AbstractNetworkChannelEndpoint<S extends Channel, U extend
         extends AbstractEndpoint<S, U> {
 
     protected abstract NetworkChannel getServerSocket();
+    protected abstract S createChannel(SocketBufferHandler buffer);
 
 
     @Override

--- a/java/org/apache/tomcat/util/net/Nio2Endpoint.java
+++ b/java/org/apache/tomcat/util/net/Nio2Endpoint.java
@@ -307,11 +307,7 @@ public class Nio2Endpoint extends AbstractNetworkChannelEndpoint<Nio2Channel,Asy
                         socketProperties.getAppReadBufSize(),
                         socketProperties.getAppWriteBufSize(),
                         socketProperties.getDirectBuffer());
-                if (isSSLEnabled()) {
-                    channel = new SecureNio2Channel(bufhandler, this);
-                } else {
-                    channel = new Nio2Channel(bufhandler);
-                }
+                channel = createChannel(bufhandler);
             }
             Nio2SocketWrapper newWrapper = new Nio2SocketWrapper(channel, this);
             channel.reset(socket, newWrapper);
@@ -400,6 +396,13 @@ public class Nio2Endpoint extends AbstractNetworkChannelEndpoint<Nio2Channel,Asy
         return new SocketProcessor(socketWrapper, event);
     }
 
+    @Override
+    protected Nio2Channel createChannel(SocketBufferHandler buffer) {
+        if (isSSLEnabled()) {
+            return new SecureNio2Channel(buffer, this);
+        }
+        return new Nio2Channel(buffer);
+    }
 
     protected class Nio2Acceptor extends Acceptor<AsynchronousSocketChannel>
         implements CompletionHandler<AsynchronousSocketChannel, Void> {

--- a/java/org/apache/tomcat/util/net/NioEndpoint.java
+++ b/java/org/apache/tomcat/util/net/NioEndpoint.java
@@ -459,11 +459,7 @@ public class NioEndpoint extends AbstractNetworkChannelEndpoint<NioChannel,Socke
                         socketProperties.getAppReadBufSize(),
                         socketProperties.getAppWriteBufSize(),
                         socketProperties.getDirectBuffer());
-                if (isSSLEnabled()) {
-                    channel = new SecureNioChannel(bufhandler, this);
-                } else {
-                    channel = new NioChannel(bufhandler);
-                }
+                channel = createChannel(bufhandler);
             }
             NioSocketWrapper newWrapper = new NioSocketWrapper(channel, this);
             channel.reset(socket, newWrapper);
@@ -553,6 +549,16 @@ public class NioEndpoint extends AbstractNetworkChannelEndpoint<NioChannel,Socke
     protected SocketProcessorBase<NioChannel> createSocketProcessor(
             SocketWrapperBase<NioChannel> socketWrapper, SocketEvent event) {
         return new SocketProcessor(socketWrapper, event);
+    }
+
+    @Override
+    protected NioChannel createChannel(SocketBufferHandler buffer) {
+        if (isSSLEnabled()) {
+            return new SecureNioChannel(buffer, this);
+        }
+        return new NioChannel(buffer);
+                
+        
     }
 
     // ----------------------------------------------------- Poller Inner Classes

--- a/java/org/apache/tomcat/util/net/SecureNio2Channel.java
+++ b/java/org/apache/tomcat/util/net/SecureNio2Channel.java
@@ -92,6 +92,11 @@ public class SecureNio2Channel extends Nio2Channel  {
         handshakeWriteCompletionHandler = new HandshakeWriteCompletionHandler();
     }
 
+    protected void createSSLEngine(String hostName, List<Cipher> clientRequestedCiphers, List<String> clientRequestedApplicationProtocols) {
+        sslEngine = endpoint.createSSLEngine(hostName, clientRequestedCiphers,
+                clientRequestedApplicationProtocols);
+    }
+
 
     private class HandshakeReadCompletionHandler
             implements CompletionHandler<Integer, SocketWrapperBase<Nio2Channel>> {
@@ -370,7 +375,7 @@ public class SecureNio2Channel extends Nio2Channel  {
      * present and, if it is, what host name has been requested. Based on the
      * provided host name, configure the SSLEngine for this connection.
      */
-    private int processSNI() throws IOException {
+    protected int processSNI() throws IOException {
         // If there is no data to process, trigger a read immediately. This is
         // an optimisation for the typical case so we don't create an
         // SNIExtractor only to discover there is no data to process
@@ -432,7 +437,7 @@ public class SecureNio2Channel extends Nio2Channel  {
             log.debug(sm.getString("channel.nio.ssl.sniHostName", sc, hostName));
         }
 
-        sslEngine = endpoint.createSSLEngine(hostName, clientRequestedCiphers,
+        createSSLEngine(hostName, clientRequestedCiphers,
                 clientRequestedApplicationProtocols);
 
         // Populate additional TLS attributes obtained from the handshake that

--- a/java/org/apache/tomcat/util/net/SecureNioChannel.java
+++ b/java/org/apache/tomcat/util/net/SecureNioChannel.java
@@ -245,7 +245,7 @@ public class SecureNioChannel extends NioChannel {
      *
      * @throws IOException If an I/O error occurs during the SNI processing
      */
-    private int processSNI() throws IOException {
+    protected int processSNI() throws IOException {
         // Read some data into the network input buffer so we can peek at it.
         int bytesRead = sc.read(netInBuffer);
         if (bytesRead == -1) {
@@ -301,7 +301,7 @@ public class SecureNioChannel extends NioChannel {
             log.debug(sm.getString("channel.nio.ssl.sniHostName", sc, hostName));
         }
 
-        sslEngine = endpoint.createSSLEngine(hostName, clientRequestedCiphers,
+        createSSLEngine(hostName, clientRequestedCiphers,
                 clientRequestedApplicationProtocols);
 
         // Populate additional TLS attributes obtained from the handshake that
@@ -890,6 +890,11 @@ public class SecureNioChannel extends NioChannel {
 
     public ByteBuffer getEmptyBuf() {
         return emptyBuf;
+    }
+
+    protected void createSSLEngine(String hostName, List<Cipher> clientRequestedCiphers, List<String> clientRequestedApplicationProtocols) {
+        sslEngine = endpoint.createSSLEngine(hostName, clientRequestedCiphers,
+                clientRequestedApplicationProtocols);
     }
 
 


### PR DESCRIPTION
Deploying tomcat with a custom ssl engine could require to perform some extra configuration before its usage. As an example, [tomcatjss](https://github.com/dogtagpki/tomcatjss/) project needs to provide the actual IPs of client and server for audit purpose.
To provide the IPs we are working on a patch which require to copy several tomcat methods from _NIO_ endpoint and channel because the current implementation does not allow to access the ssl engine before it is used (the method to be replaced are in [this PR](https://github.com/dogtagpki/tomcatjss/pull/73)). 

Changes in this PR allow to extend tomcat _NIO_ classes and modify the ssl engine without reimplementing the existing methods.