### PR TITLE
Catch NamingException instead of specialized sub-classes

### DIFF
--- a/java/org/apache/catalina/realm/JNDIRealm.java
+++ b/java/org/apache/catalina/realm/JNDIRealm.java
@@ -37,7 +37,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import javax.naming.AuthenticationException;
-import javax.naming.CommunicationException;
 import javax.naming.CompositeName;
 import javax.naming.Context;
 import javax.naming.InvalidNameException;
@@ -47,7 +46,6 @@ import javax.naming.NameParser;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.PartialResultException;
-import javax.naming.ServiceUnavailableException;
 import javax.naming.directory.Attribute;
 import javax.naming.directory.Attributes;
 import javax.naming.directory.DirContext;
@@ -2355,7 +2353,13 @@ public class JNDIRealm extends RealmBase {
                 // Authenticate the specified username if possible
                 principal = getPrincipal(connection, username, gssCredential);
 
-            } catch (CommunicationException | ServiceUnavailableException e) {
+            } catch (NamingException e) {
+                /* While we would like to catch specialized exceptions like
+                 * CommunicationException and ServiceUnavailableException,
+                 * some network communication problems are reported as
+                 * this general exception. This is fixed in Java 18 by
+                 * https://bugs.openjdk.org/browse/JDK-8273402
+                 */
                 // log the exception so we know it's there.
                 containerLog.info(sm.getString("jndiRealm.exception.retry"), e);
 

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -112,6 +112,10 @@
         presistence process, do not log a warning that null Principals are not
         serializable. Pull request <pr>638</pr> provided by tsryo. (markt)
       </fix>
+      <fix>
+        Catch <code>NamingException</code> in <code>JNDIRealm#getPrincipal</code>.
+        It is used in Java up to 17 to signal closed connections. (fschumacher)
+      </fix>
     </changelog>
   </subsection>
   <subsection name="Coyote">


### PR DESCRIPTION
In Java 8 and up to 17 a closed connection is signaled with a NamingException and not a CommunicationException ora ServiceUnavailableException.  Such a condition should lead to re-opening the LDAP connection.