### PR TITLE
Fix ConnectionState when exception

### DIFF
--- a/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/interceptor/ConnectionState.java
+++ b/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/interceptor/ConnectionState.java
@@ -155,14 +155,27 @@ public class ConnectionState extends JdbcInterceptor  {
             }
         }
 
-        result = super.invoke(proxy, method, args);
-        if (read || write) {
-            switch (index) {
-                case 0:{autoCommit = (Boolean) (read?result:args[0]); break;}
-                case 1:{transactionIsolation = (Integer)(read?result:args[0]); break;}
-                case 2:{readOnly = (Boolean)(read?result:args[0]); break;}
-                case 3:{catalog = (String)(read?result:args[0]); break;}
+        try {
+            result = super.invoke(proxy, method, args);
+            if (read || write) {
+                switch (index) {
+                    case 0:{autoCommit = (Boolean) (read?result:args[0]); break;}
+                    case 1:{transactionIsolation = (Integer)(read?result:args[0]); break;}
+                    case 2:{readOnly = (Boolean)(read?result:args[0]); break;}
+                    case 3:{catalog = (String)(read?result:args[0]); break;}
+                }
             }
+        } catch (Throwable e) {
+            if (write) {
+                log.info("Reset state to null when exception: index=" + index);
+                switch (index) {
+                    case 0:{autoCommit = null; break;}
+                    case 1:{transactionIsolation = null; break;}
+                    case 2:{readOnly = null; break;}
+                    case 3:{catalog = null; break;}
+                }
+            }
+            throw e;
         }
         return result;
     }


### PR DESCRIPTION
When an exception occurs while writing, the ConnectionState state will be inconsistent with the actual state on the connection, therefore, the state needs to be cleaned up on exception. Example code https://github.com/wenjunxiao/lab-tomcat-jdbc-autocommit