### PR TITLE
Warn when non default ciphers are removed because the engine rejects them.

### DIFF
--- a/java/org/apache/tomcat/util/net/SSLUtilBase.java
+++ b/java/org/apache/tomcat/util/net/SSLUtilBase.java
@@ -127,10 +127,11 @@ public abstract class SSLUtilBase implements SSLUtil {
             // TODO: sslHostConfig can query that with Panama, but skip for now
             this.enabledCiphers = new String[0];
         } else {
+            boolean warnOnSkip = !sslHostConfig.getCiphers().equals(sslHostConfig.DEFAULT_TLS_CIPHERS);
             List<String> configuredCiphers = sslHostConfig.getJsseCipherNames();
             Set<String> implementedCiphers = getImplementedCiphers();
             List<String> enabledCiphers =
-                    getEnabled("ciphers", getLog(), false, configuredCiphers, implementedCiphers);
+                    getEnabled("ciphers", getLog(), warnOnSkip, configuredCiphers, implementedCiphers);
             this.enabledCiphers = enabledCiphers.toArray(new String[0]);
         }
     }


### PR DESCRIPTION
When using nmap --script ssl-enum-ciphers -p port host
the ciphers proposed are often a small subset of the expect ones.
A warning helps to see what is rejected.