### PR TITLE
feat(Http11Processor): Add max value in keepalive.

### DIFF
--- a/java/org/apache/coyote/http11/Http11Processor.java
+++ b/java/org/apache/coyote/http11/Http11Processor.java
@@ -999,7 +999,12 @@ public class Http11Processor extends AbstractProcessor {
                     int keepAliveTimeout = protocol.getKeepAliveTimeout();
 
                     if (keepAliveTimeout > 0) {
-                        String value = "timeout=" + keepAliveTimeout / 1000L;
+                        StringBuilder value = new StringBuilder();
+                        value.append("timeout=").append(keepAliveTimeout / 1000L);
+                        int maxKeepAliveRequests = protocol.getMaxKeepAliveRequests();
+                        if (maxKeepAliveRequests > 0) {
+                            value.append(", max=").append(maxKeepAliveRequests);
+                        }
                         headers.setValue(Constants.KEEP_ALIVE_HEADER_NAME).setString(value);
 
                         if (http11) {


### PR DESCRIPTION
__HttpClient__ uses keepalive header max value to set __keepAliveConnections__, but __Http11Processor__ doesn't provide it, so __HttpClient__ __keepAliveConnections__ is always __5__.

## sun.net.www.http.HttpClient

Parse keepalive headers for max connections.

* __parseHTTPHeader__
        
```java
HeaderParser p = new HeaderParser(responses.findValue("Keep-Alive"));
/* default should be larger in case of proxy */
keepAliveConnections = p.findInt("max", usingProxy?50:5);
keepAliveTimeout = p.findInt("timeout", usingProxy?60:5);
```
    
 * __finished__

```java
public void finished() {
    if (reuse) /* will be reused */
        return;
    keepAliveConnections--;
    poster = null;
    if (keepAliveConnections > 0 && isKeepingAlive() &&
           !(serverOutput.checkError())) {
        /* This connection is keepingAlive && still valid.
         * Return it to the cache.
         */
        putInKeepAliveCache();
    } else {
        closeServer();
    }
}
```