### PR TITLE
Refactor 'getSession' Method in 'Request' Class to Eliminate Code Redundancy

### DIFF
--- a/java/org/apache/catalina/connector/Request.java
+++ b/java/org/apache/catalina/connector/Request.java
@@ -2288,12 +2288,7 @@ public class Request implements HttpServletRequest {
      */
     @Override
     public HttpSession getSession() {
-        Session session = doGetSession(true);
-        if (session == null) {
-            return null;
-        }
-
-        return session.getSession();
+        getSession(true);
     }
 
 

--- a/java/org/apache/catalina/connector/Request.java
+++ b/java/org/apache/catalina/connector/Request.java
@@ -2288,7 +2288,7 @@ public class Request implements HttpServletRequest {
      */
     @Override
     public HttpSession getSession() {
-        getSession(true);
+        return getSession(true);
     }
 
 


### PR DESCRIPTION
This Pull Request aims to reduce code duplication in the `getSession` method of the `Request` class.

The refactoring closely follows the structure and principles used in the `reset` method of `java.org.apache.catalina.connector.OutputBuffer`:
```java
public void reset() {
	reset(false);
}

public void reset(boolean resetWriterStreamFlags) {
	clear(bb);
	clear(cb);
	bytesWritten = 0;
	charsWritten = 0;
	if (resetWriterStreamFlags) {
		if (conv != null) {
			conv.recycle();
		}
		conv = null;
	}
	initial = true;
}
```