### PR TITLE
Eliminating duplicate execution of checkFacade logic

### DIFF
--- a/java/org/apache/catalina/connector/RequestFacade.java
+++ b/java/org/apache/catalina/connector/RequestFacade.java
@@ -413,7 +413,6 @@ public class RequestFacade implements HttpServletRequest {
 
     @Override
     public HttpSession getSession() {
-        checkFacade();
         return getSession(true);
     }
 


### PR DESCRIPTION
In the current implementation of the `getSession` method in the `RequestFacade` class, the checkFacade logic was redundantly executed twice.
I improved this by eliminating the redundancy.