### PR TITLE
unnecessary work is done before determining if it is a special header

### DIFF
--- a/java/org/apache/coyote/Response.java
+++ b/java/org/apache/coyote/Response.java
@@ -358,11 +358,8 @@ public final class Response {
 
 
     public void setHeader(String name, String value) {
-        char cc = name.charAt(0);
-        if (cc == 'C' || cc == 'c') {
-            if (checkSpecialHeader(name, value)) {
-                return;
-            }
+        if (checkSpecialHeader(name, value)) {
+            return;
         }
         if (value == null) {
             headers.removeHeader(name);
@@ -378,11 +375,8 @@ public final class Response {
 
 
     public void addHeader(String name, String value, Charset charset) {
-        char cc = name.charAt(0);
-        if (cc == 'C' || cc == 'c') {
-            if (checkSpecialHeader(name, value)) {
-                return;
-            }
+        if (checkSpecialHeader(name, value)) {
+            return;
         }
         MessageBytes mb = headers.addValue(name);
         if (charset != null) {


### PR DESCRIPTION
Hi there!

I found unnecessary code in the Response class.

Currently, it seems that only headers of Content-Length or Content-Type are called Special Headers.

However, as you can see in the code below, `checkSpecialHeader` already checks for Content-Type and Content-Length with ignoring cases, so It is not necessary to check whether the first letter is c or C in the setHeader or addHeader methods.

```java
private boolean checkSpecialHeader(String name, String value) {
    // XXX Eliminate redundant fields !!!
    // ( both header and in special fields )
    if (name.equalsIgnoreCase("Content-Type")) {
        setContentType(value);
        return true;
    }
    if (name.equalsIgnoreCase("Content-Length")) {
        try {
   ...
```

It's a simple change, but I suggest it because it makes it easier to see the flow.