### PR TITLE
Eliminating duplicate execution of checkFacade logic in ResponseFacade

### DIFF
--- a/java/org/apache/catalina/connector/ResponseFacade.java
+++ b/java/org/apache/catalina/connector/ResponseFacade.java
@@ -407,5 +407,3 @@ public class ResponseFacade implements HttpServletResponse {
         }
     }
 }
-
-


### PR DESCRIPTION
This PR is closely related to https://github.com/apache/tomcat/pull/649.
Prevent double execution of the `checkFacade()` logic when invoking the `isCommitted()`, `isFinished()` method.
It already invokes `checkFacade()` internally !
```java
@Override
public boolean isCommitted() {
    checkFacade();
    return response.isAppCommitted();
}

public boolean isFinished() {
    checkFacade();
    return response.isSuspended();
}
```

thanks !! 😁