### PR TITLE
Fix a comment typo

### DIFF
--- a/java/org/apache/catalina/connector/Request.java
+++ b/java/org/apache/catalina/connector/Request.java
@@ -2894,7 +2894,7 @@ public class Request implements HttpServletRequest {
         if (context == null) {
             // No context. Possible call from Valve before a Host level
             // context rewrite when no ROOT content is configured. Use the
-            // default CookiePreocessor.
+            // default CookieProcessor.
             return new Rfc6265CookieProcessor();
         } else {
             return context.getCookieProcessor();


### PR DESCRIPTION
Hello,
I have fixed a typo in the Tomcat codebase by changing "CookiePreocessor" to "CookieProcessor" for better code clarity and correctness.