### PR TITLE
Optimization when call getSessionCookieName & getSessionUriParamName

### DIFF
--- a/java/org/apache/catalina/util/SessionConfig.java
+++ b/java/org/apache/catalina/util/SessionConfig.java
@@ -32,14 +32,10 @@ public class SessionConfig {
      * @return the cookie name for the context
      */
     public static String getSessionCookieName(Context context) {
-
-        String result = getConfiguredSessionCookieName(context);
-
-        if (result == null) {
-            result = DEFAULT_SESSION_COOKIE_NAME;
+        if (context == null) {
+            return DEFAULT_SESSION_COOKIE_NAME;
         }
-
-        return result;
+        return getConfiguredSessionCookieName(context);
     }
 
     /**
@@ -49,38 +45,28 @@ public class SessionConfig {
      * @return the parameter name for the session
      */
     public static String getSessionUriParamName(Context context) {
-
-        String result = getConfiguredSessionCookieName(context);
-
-        if (result == null) {
-            result = DEFAULT_SESSION_PARAMETER_NAME;
+        if (context == null) {
+            return DEFAULT_SESSION_PARAMETER_NAME;
         }
-
-        return result;
+        return getConfiguredSessionCookieName(context);
     }
 
 
     private static String getConfiguredSessionCookieName(Context context) {
-
         // Priority is:
         // 1. Cookie name defined in context
         // 2. Cookie name configured for app
         // 3. Default defined by spec
-        if (context != null) {
-            String cookieName = context.getSessionCookieName();
-            if (cookieName != null && cookieName.length() > 0) {
-                return cookieName;
-            }
-
-            SessionCookieConfig scc =
-                context.getServletContext().getSessionCookieConfig();
-            cookieName = scc.getName();
-            if (cookieName != null && cookieName.length() > 0) {
-                return cookieName;
-            }
+        String cookieName = context.getSessionCookieName();
+        if (cookieName != null && cookieName.length() > 0) {
+            return cookieName;
         }
 
-        return null;
+        SessionCookieConfig scc = context.getServletContext().getSessionCookieConfig();
+        cookieName = scc.getName();
+        if (cookieName != null && cookieName.length() > 0) {
+            return cookieName;
+        }
     }
 
 


### PR DESCRIPTION
Existing code calls getConfiguredSessionCookieName even if the context is empty.

In getConfiguredSessionCookieName, only act to get the session cookie if the context is non-null.

I think it's possible to avoid calling getConfiguredSessionCookieName and use Default defined by spec if context is null.

It's a small optimisation, but I think it saves us one less function call.

The one thing that worries me is about the Priority comment

```
// Priority is:
// 1. Cookie name defined in context
// 2. Cookie name configured for app
// 3. Default defined by spec
```

For now, I didn't modify that part.