### PR TITLE
Unify conditional statement format for some constants in http1 package

### DIFF
--- a/java/org/apache/catalina/ant/AbstractCatalinaTask.java
+++ b/java/org/apache/catalina/ant/AbstractCatalinaTask.java
@@ -233,7 +233,7 @@ public abstract class AbstractCatalinaTask extends BaseRedirectorHelperTask {
                 int ch = reader.read();
                 if (ch < 0) {
                     break;
-                } else if ((ch == '\r') || (ch == '\n')) {
+                } else if (ch == '\r' || ch == '\n') {
                     // in Win \r\n would cause handleOutput() to be called
                     // twice, the second time with an empty string,
                     // producing blank lines

--- a/java/org/apache/catalina/ant/AbstractCatalinaTask.java
+++ b/java/org/apache/catalina/ant/AbstractCatalinaTask.java
@@ -233,7 +233,7 @@ public abstract class AbstractCatalinaTask extends BaseRedirectorHelperTask {
                 int ch = reader.read();
                 if (ch < 0) {
                     break;
-                } else if (ch == '\r' || ch == '\n') {
+                } else if ((ch == '\r') || (ch == '\n')) {
                     // in Win \r\n would cause handleOutput() to be called
                     // twice, the second time with an empty string,
                     // producing blank lines

--- a/java/org/apache/coyote/http11/Http11InputBuffer.java
+++ b/java/org/apache/coyote/http11/Http11InputBuffer.java
@@ -998,7 +998,7 @@ public class Http11InputBuffer implements InputBuffer, ApplicationBufferHandler 
 
             byte peek = byteBuffer.get(byteBuffer.position());
             if (headerParsePos == HeaderParsePosition.HEADER_MULTI_LINE) {
-                if ((peek != Constants.SP) && (peek != Constants.HT)) {
+                if (!(peek == Constants.SP || peek == Constants.HT)) {
                     headerParsePos = HeaderParsePosition.HEADER_START;
                     break;
                 } else {

--- a/java/org/apache/coyote/http11/Http11InputBuffer.java
+++ b/java/org/apache/coyote/http11/Http11InputBuffer.java
@@ -369,7 +369,7 @@ public class Http11InputBuffer implements InputBuffer, ApplicationBufferHandler 
                     request.setStartTimeNanos(System.nanoTime());
                 }
                 chr = byteBuffer.get();
-            } while ((chr == Constants.CR) || (chr == Constants.LF));
+            } while (chr == Constants.CR || chr == Constants.LF);
             byteBuffer.position(byteBuffer.position() - 1);
 
             parsingRequestLineStart = byteBuffer.position();

--- a/java/org/apache/coyote/http11/filters/ChunkedInputFilter.java
+++ b/java/org/apache/coyote/http11/filters/ChunkedInputFilter.java
@@ -484,7 +484,7 @@ public class ChunkedInputFilter implements InputFilter, ApplicationBufferHandler
 
             // readBytes() above will set readChunk unless it returns a value < 0
             chr = readChunk.get(readChunk.position());
-            if ((chr >= Constants.A) && (chr <= Constants.Z)) {
+            if (chr >= Constants.A && chr <= Constants.Z) {
                 chr = (byte) (chr - Constants.LC_OFFSET);
             }
 
@@ -522,7 +522,7 @@ public class ChunkedInputFilter implements InputFilter, ApplicationBufferHandler
                 }
 
                 chr = readChunk.get(readChunk.position());
-                if ((chr == Constants.SP) || (chr == Constants.HT)) {
+                if (chr == Constants.SP || chr == Constants.HT) {
                     readChunk.position(readChunk.position() + 1);
                     // If we swallow whitespace, make sure it counts towards the
                     // limit placed on trailing header size

--- a/java/org/apache/coyote/http11/filters/ChunkedInputFilter.java
+++ b/java/org/apache/coyote/http11/filters/ChunkedInputFilter.java
@@ -574,7 +574,7 @@ public class ChunkedInputFilter implements InputFilter, ApplicationBufferHandler
             }
 
             chr = readChunk.get(readChunk.position());
-            if ((chr != Constants.SP) && (chr != Constants.HT)) {
+            if (!(chr == Constants.SP || chr == Constants.HT)) {
                 validLine = false;
             } else {
                 eol = false;


### PR DESCRIPTION
Although I totally agree that there could be some unnecessary parentheses to aid the readability of the code, I think that the unity of the code is still important for readability.

### Conditional statements of CR & LF in Http11InputBuffer
```java
// Line 445
if (prevChr == Constants.CR && chr != Constants.LF) {
    // ...
}

// Line 544
} else if (prevChr == Constants.CR && chr == Constants.LF) {
    // ...
}
``` 
Except for Line 372 that I changed, all conditional statements that have two conditions about CR and LF don't have parentheses for each condition.


### Conditional statements in ChunkedInputFilter
```java
// Line 344
if (chr == Constants.CR || chr == Constants.LF) {
    // ...
}

// Line 462
if (chr == Constants.CR || chr == Constants.LF) {
    // ...
}

// Line 551
if (chr == Constants.CR || chr == Constants.LF) {
    // ...
}
``` 
Except for Line 487 and 525 that I changed, all conditional statements that have two conditions about constants don't have parentheses for each condition.


### Logic about space and tab in Http11InputBuffer
```java
// Line 395, 453, 974(else if)
if (chr == Constants.SP || chr == Constants.HT) {
    // …
}

// Line 419, 515, 935
if (!(chr == Constants.SP || chr == Constants.HT)) {
    // …
}
``` 
Because of the above codes, I tried to change Line 1001 of Http11InputBuffer, and Line 577 of ChunkedInputFilter. 

