### PR TITLE
Optimize when call getSessionCookieName & getSessionUriParamName

### DIFF
--- a/java/org/apache/catalina/util/SessionConfig.java
+++ b/java/org/apache/catalina/util/SessionConfig.java
@@ -32,14 +32,10 @@ public class SessionConfig {
      * @return the cookie name for the context
      */
     public static String getSessionCookieName(Context context) {
-
-        String result = getConfiguredSessionCookieName(context);
-
-        if (result == null) {
-            result = DEFAULT_SESSION_COOKIE_NAME;
+        if (context == null) {
+            return DEFAULT_SESSION_COOKIE_NAME;
         }
-
-        return result;
+        return getConfiguredSessionCookieName(context, DEFAULT_SESSION_COOKIE_NAME);
     }
 
     /**
@@ -49,38 +45,30 @@ public class SessionConfig {
      * @return the parameter name for the session
      */
     public static String getSessionUriParamName(Context context) {
-
-        String result = getConfiguredSessionCookieName(context);
-
-        if (result == null) {
-            result = DEFAULT_SESSION_PARAMETER_NAME;
+        if (context == null) {
+            return DEFAULT_SESSION_PARAMETER_NAME;
         }
-
-        return result;
+        return getConfiguredSessionCookieName(context, DEFAULT_SESSION_PARAMETER_NAME);
     }
 
 
-    private static String getConfiguredSessionCookieName(Context context) {
-
+    private static String getConfiguredSessionCookieName(Context context, String defaultName) {
         // Priority is:
         // 1. Cookie name defined in context
         // 2. Cookie name configured for app
         // 3. Default defined by spec
-        if (context != null) {
-            String cookieName = context.getSessionCookieName();
-            if (cookieName != null && cookieName.length() > 0) {
-                return cookieName;
-            }
-
-            SessionCookieConfig scc =
-                context.getServletContext().getSessionCookieConfig();
-            cookieName = scc.getName();
-            if (cookieName != null && cookieName.length() > 0) {
-                return cookieName;
-            }
+        String cookieName = context.getSessionCookieName();
+        if (cookieName != null && cookieName.length() > 0) {
+            return cookieName;
         }
 
-        return null;
+        SessionCookieConfig scc = context.getServletContext().getSessionCookieConfig();
+        cookieName = scc.getName();
+        if (cookieName != null && cookieName.length() > 0) {
+            return cookieName;
+        }
+
+        return defaultName;
     }
 
 

--- a/java/org/apache/catalina/util/SessionConfig.java
+++ b/java/org/apache/catalina/util/SessionConfig.java
@@ -32,9 +32,6 @@ public class SessionConfig {
      * @return the cookie name for the context
      */
     public static String getSessionCookieName(Context context) {
-        if (context == null) {
-            return DEFAULT_SESSION_COOKIE_NAME;
-        }
         return getConfiguredSessionCookieName(context, DEFAULT_SESSION_COOKIE_NAME);
     }
 
@@ -45,14 +42,14 @@ public class SessionConfig {
      * @return the parameter name for the session
      */
     public static String getSessionUriParamName(Context context) {
-        if (context == null) {
-            return DEFAULT_SESSION_PARAMETER_NAME;
-        }
         return getConfiguredSessionCookieName(context, DEFAULT_SESSION_PARAMETER_NAME);
     }
 
 
     private static String getConfiguredSessionCookieName(Context context, String defaultName) {
+        if (context == null) {
+            return defaultName;
+        }
         // Priority is:
         // 1. Cookie name defined in context
         // 2. Cookie name configured for app

--- a/java/org/apache/catalina/util/SessionConfig.java
+++ b/java/org/apache/catalina/util/SessionConfig.java
@@ -47,24 +47,22 @@ public class SessionConfig {
 
 
     private static String getConfiguredSessionCookieName(Context context, String defaultName) {
-        if (context == null) {
-            return defaultName;
-        }
         // Priority is:
         // 1. Cookie name defined in context
         // 2. Cookie name configured for app
         // 3. Default defined by spec
-        String cookieName = context.getSessionCookieName();
-        if (cookieName != null && cookieName.length() > 0) {
-            return cookieName;
-        }
+        if (context != null) {
+            String cookieName = context.getSessionCookieName();
+            if (cookieName != null && cookieName.length() > 0) {
+                return cookieName;
+            }
 
-        SessionCookieConfig scc = context.getServletContext().getSessionCookieConfig();
-        cookieName = scc.getName();
-        if (cookieName != null && cookieName.length() > 0) {
-            return cookieName;
+            SessionCookieConfig scc = context.getServletContext().getSessionCookieConfig();
+            cookieName = scc.getName();
+            if (cookieName != null && cookieName.length() > 0) {
+                return cookieName;
+            }
         }
-
         return defaultName;
     }
 


### PR DESCRIPTION
### Description

Optimization when call getSessionCookieName & getSessionUriParamName

### Explanation

Existing code calls getConfiguredSessionCookieName even if the context is empty.
In getConfiguredSessionCookieName, only act to get the session cookie if the context is non-null.
I think it's possible to avoid calling getConfiguredSessionCookieName and use Default defined by spec if context is null.
It's a small optimisation, but I think it saves us one less function call.

Additionally, modified getConfiguredSessionCookieName to not require a null check on its result.

### Comment

One fewer comparison operation if context is non-null. and I think it makes the code a little easier to understand for the remaining priority comments.