### PR TITLE
Refactoring the main method of a Tomcat class to improve readability

### DIFF
--- a/java/org/apache/catalina/startup/Tomcat.java
+++ b/java/org/apache/catalina/startup/Tomcat.java
@@ -1303,7 +1303,7 @@ public class Tomcat {
                 break;
             }
         }
-        org.apache.catalina.startup.Tomcat tomcat = new org.apache.catalina.startup.Tomcat();
+        Tomcat tomcat = new Tomcat();
         // Create a Catalina instance and let it parse the configuration files
         // It will also set a shutdown hook to stop the Server when needed
         // Use the default configuration source

--- a/java/org/apache/catalina/startup/Tomcat.java
+++ b/java/org/apache/catalina/startup/Tomcat.java
@@ -1290,9 +1290,9 @@ public class Tomcat {
         // Process some command line parameters
         String[] catalinaArguments = null;
         for (int i = 0; i < args.length; i++) {
-            if (args[i].equals("--no-jmx")) {
+            if ("--no-jmx".equals(args[i])) {
                 Registry.disableRegistry();
-            } else if (args[i].equals("--catalina")) {
+            } else if ("--catalina".equals(args[i])) {
                 // This was already processed before
                 // Skip the rest of the arguments as they are for Catalina
                 ArrayList<String> result = new ArrayList<>();
@@ -1312,22 +1312,22 @@ public class Tomcat {
         String path = "";
         // Process command line parameters
         for (int i = 0; i < args.length; i++) {
-            if (args[i].equals("--war")) {
+            if ("--war".equals(args[i])) {
                 if (++i >= args.length) {
                     throw new IllegalArgumentException(sm.getString("tomcat.invalidCommandLine", args[i - 1]));
                 }
                 File war = new File(args[i]);
                 tomcat.addWebapp(path, war.getAbsolutePath());
-            } else if (args[i].equals("--path")) {
+            } else if ("--path".equals(args[i])) {
                 if (++i >= args.length) {
                     throw new IllegalArgumentException(sm.getString("tomcat.invalidCommandLine", args[i - 1]));
                 }
                 path = args[i];
-            } else if (args[i].equals("--await")) {
+            } else if ("--await".equals(args[i])) {
                 await = true;
-            } else if (args[i].equals("--no-jmx")) {
+            } else if ("--no-jmx".equals(args[i])) {
                 // This was already processed before
-            } else if (args[i].equals("--catalina")) {
+            } else if ("--catalina".equals(args[i])) {
                 // This was already processed before
                 // Skip the rest of the arguments as they are for Catalina
                 break;


### PR DESCRIPTION
Hello! 
While learning about Tomcat, I see something that I think I can contribute to, so I write this PR.

## Explanation

There are two commits here:

- Remove the FQCN when creating a Tomcat instance
- Change the order of equals method calls

### Remove the FQCN when creating a Tomcat instance

I removed the FQCN when creating the Tomcat instance, because I was creating an instance of myself and determined that there were no other Tomcat classes inside the org.apache.catalina package.

### Change the order of equals method calls

Previously, I was comparing strings based on their args(`args[i]`), and I thought I could reverse the order to make them a little more readable.

---

If I've misunderstood something, please let me know.