### PR TITLE
Improved code readability

### DIFF
--- a/java/org/apache/coyote/http11/Http11InputBuffer.java
+++ b/java/org/apache/coyote/http11/Http11InputBuffer.java
@@ -416,7 +416,7 @@ public class Http11InputBuffer implements InputBuffer, ApplicationBufferHandler 
                     }
                 }
                 chr = byteBuffer.get();
-                if (!(chr == Constants.SP || chr == Constants.HT)) {
+                if (chr != Constants.SP && chr != Constants.HT) {
                     space = false;
                     byteBuffer.position(byteBuffer.position() - 1);
                 }


### PR DESCRIPTION
While seeing the code in the Coyote project, I came across this code snippet: 
`if (!(chr == Constants.SP || chr == Constants.HT))`.

It appears to be challenging to read, so I enhanced its readability using De Morgan's law.

---
before
`if (!(chr == Constants.SP || chr == Constants.HT))`.

after
`if (chr != Constants.SP && chr != Constants.HT)`