### PR TITLE
Update tool-wrapper.bat

### DIFF
--- a/bin/tool-wrapper.bat
+++ b/bin/tool-wrapper.bat
@@ -85,6 +85,6 @@ shift
 goto setArgs
 :doneSetArgs
 
-%_RUNJAVA% %JAVA_OPTS% %TOOL_OPTS% -classpath "%CLASSPATH%" -Dcatalina.home="%CATALINA_HOME%" org.apache.catalina.startup.Tool %CMD_LINE_ARGS%
+"%_RUNJAVA%" %JAVA_OPTS% %TOOL_OPTS% -classpath "%CLASSPATH%" -Dcatalina.home="%CATALINA_HOME%" org.apache.catalina.startup.Tool %CMD_LINE_ARGS%
 
 :end


### PR DESCRIPTION
Solved issue with spaces in path.

If you install tomcat on windows in a path with spaces, the tool-wrapper.bat could be executed. This PR adds two missing qoutes to solve this issue.