### PR TITLE
Before closing the database connection, roll back the transaction

### DIFF
--- a/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/ProxyConnection.java
+++ b/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/ProxyConnection.java
@@ -18,6 +18,7 @@ package org.apache.tomcat.jdbc.pool;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.sql.Connection;
 import java.sql.SQLException;
 
 import javax.sql.XAConnection;
@@ -100,6 +101,10 @@ public class ProxyConnection extends JdbcInterceptor {
             }
             PooledConnection poolc = this.connection;
             this.connection = null;
+            if (!poolc.getAutoCommit() && !poolc.isReadOnly()) {
+                Connection con = poolc.getConnection();
+                con.rollback();
+            }
             pool.returnConnection(poolc);
             return null;
         } else if (compare(TOSTRING_VAL,method)) {


### PR DESCRIPTION
fix bug https://bz.apache.org/bugzilla/show_bug.cgi?id=64570
Before closing the database connection, roll back the transaction

 I have referred to implementation methods such as Druid and Hikari databases and believe that it is necessary to roll back uncommitted transactions before closing the connection 
