### PR TITLE
Adding ASL Bundle-License to the manifests

### DIFF
--- a/res/bnd/annotations-api.jar.tmp.bnd
+++ b/res/bnd/annotations-api.jar.tmp.bnd
@@ -15,6 +15,7 @@
 
 -include: build-defaults.bnd, spec-defaults.bnd
 
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
 Bundle-Name: tomcat-annotations-api
 Bundle-SymbolicName: org.apache.tomcat-annotations-api
 Export-Package: \

--- a/res/bnd/catalina-ha.jar.tmp.bnd
+++ b/res/bnd/catalina-ha.jar.tmp.bnd
@@ -15,6 +15,7 @@
 
 -include: build-defaults.bnd
 
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
 Bundle-Name: tomcat-catalina-ha
 Bundle-SymbolicName: org.apache.tomcat-catalina-ha
 Export-Package: \

--- a/res/bnd/catalina-ssi.jar.tmp.bnd
+++ b/res/bnd/catalina-ssi.jar.tmp.bnd
@@ -15,6 +15,7 @@
 
 -include: build-defaults.bnd
 
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
 Bundle-Name: tomcat-ssi
 Bundle-SymbolicName: org.apache.tomcat-ssi
 Export-Package: \

--- a/res/bnd/catalina-storeconfig.jar.tmp.bnd
+++ b/res/bnd/catalina-storeconfig.jar.tmp.bnd
@@ -15,6 +15,7 @@
 
 -include: build-defaults.bnd
 
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
 Bundle-Name: tomcat-storeconfig
 Bundle-SymbolicName: org.apache.tomcat-storeconfig
 Export-Package: org.apache.catalina.storeconfig

--- a/res/bnd/catalina-tribes.jar.tmp.bnd
+++ b/res/bnd/catalina-tribes.jar.tmp.bnd
@@ -15,6 +15,7 @@
 
 -include: build-defaults.bnd
 
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
 Bundle-Name: tomcat-tribes
 Bundle-SymbolicName: org.apache.tomcat-tribes
 Export-Package: \

--- a/res/bnd/catalina.jar.tmp.bnd
+++ b/res/bnd/catalina.jar.tmp.bnd
@@ -15,6 +15,7 @@
 
 -include: build-defaults.bnd
 
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
 Bundle-Name: tomcat-catalina
 Bundle-SymbolicName: org.apache.tomcat-catalina
 Export-Package: \

--- a/res/bnd/el-api.jar.tmp.bnd
+++ b/res/bnd/el-api.jar.tmp.bnd
@@ -15,6 +15,7 @@
 
 -include: build-defaults.bnd, spec-defaults.bnd
 
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
 Bundle-Name: tomcat-el-api
 Bundle-SymbolicName: org.apache.tomcat-el-api
 Export-Package: jakarta.el;version=${el.spec.version}

--- a/res/bnd/jasper-el.jar.tmp.bnd
+++ b/res/bnd/jasper-el.jar.tmp.bnd
@@ -15,6 +15,7 @@
 
 -include: build-defaults.bnd
 
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
 Bundle-Name: tomcat-jasper-el
 Bundle-SymbolicName: org.apache.tomcat-jasper-el
 Export-Package: \

--- a/res/bnd/jasper.jar.tmp.bnd
+++ b/res/bnd/jasper.jar.tmp.bnd
@@ -15,6 +15,7 @@
 
 -include: build-defaults.bnd
 
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
 Bundle-Name: tomcat-jasper
 Bundle-SymbolicName: org.apache.tomcat-jasper
 Export-Package: \

--- a/res/bnd/jaspic-api.jar.tmp.bnd
+++ b/res/bnd/jaspic-api.jar.tmp.bnd
@@ -15,6 +15,7 @@
 
 -include: build-defaults.bnd, spec-defaults.bnd
 
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
 Bundle-Name: tomcat-jaspic-api
 Bundle-SymbolicName: org.apache.tomcat-jaspic-api
 Export-Package: \

--- a/res/bnd/jsp-api.jar.tmp.bnd
+++ b/res/bnd/jsp-api.jar.tmp.bnd
@@ -15,6 +15,7 @@
 
 -include: build-defaults.bnd, spec-defaults.bnd
 
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
 Bundle-Name: tomcat-jsp-api
 Bundle-SymbolicName: org.apache.tomcat-jsp-api
 Export-Package: \

--- a/res/bnd/servlet-api.jar.tmp.bnd
+++ b/res/bnd/servlet-api.jar.tmp.bnd
@@ -15,6 +15,7 @@
 
 -include: build-defaults.bnd, spec-defaults.bnd
 
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
 Bundle-Name: tomcat-servlet-api
 Bundle-SymbolicName: org.apache.tomcat-servlet-api
 Export-Package: \

--- a/res/bnd/tomcat-api.jar.tmp.bnd
+++ b/res/bnd/tomcat-api.jar.tmp.bnd
@@ -15,6 +15,7 @@
 
 -include: build-defaults.bnd
 
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
 Bundle-Name: tomcat-api
 Bundle-SymbolicName: org.apache.tomcat-api
 Export-Package: org.apache.tomcat

--- a/res/bnd/tomcat-coyote.jar.tmp.bnd
+++ b/res/bnd/tomcat-coyote.jar.tmp.bnd
@@ -15,6 +15,7 @@
 
 -include: build-defaults.bnd
 
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
 Bundle-Name: tomcat-coyote
 Bundle-SymbolicName: org.apache.tomcat-coyote
 Export-Package: \

--- a/res/bnd/tomcat-dbcp.jar.tmp.bnd
+++ b/res/bnd/tomcat-dbcp.jar.tmp.bnd
@@ -15,6 +15,7 @@
 
 -include: build-defaults.bnd
 
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
 Bundle-Name: tomcat-dbcp
 Bundle-SymbolicName: org.apache.tomcat-dbcp
 Export-Package: \

--- a/res/bnd/tomcat-embed-core.jar.tmp.bnd
+++ b/res/bnd/tomcat-embed-core.jar.tmp.bnd
@@ -15,6 +15,7 @@
 
 -include: build-defaults.bnd
 
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
 Bundle-Name: tomcat-embed-core
 Bundle-SymbolicName: org.apache.tomcat-embed-core
 Export-Package: \

--- a/res/bnd/tomcat-embed-el.jar.tmp.bnd
+++ b/res/bnd/tomcat-embed-el.jar.tmp.bnd
@@ -15,6 +15,7 @@
 
 -include: build-defaults.bnd
 
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
 Bundle-Name: tomcat-embed-jasper-el
 Bundle-SymbolicName: org.apache.tomcat-embed-jasper-el
 Export-Package: \

--- a/res/bnd/tomcat-embed-jasper.jar.tmp.bnd
+++ b/res/bnd/tomcat-embed-jasper.jar.tmp.bnd
@@ -15,6 +15,7 @@
 
 -include: build-defaults.bnd
 
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
 Bundle-Name: tomcat-embed-jasper
 Bundle-SymbolicName: org.apache.tomcat-embed-jasper
 Export-Package: \

--- a/res/bnd/tomcat-embed-websocket.jar.tmp.bnd
+++ b/res/bnd/tomcat-embed-websocket.jar.tmp.bnd
@@ -15,6 +15,7 @@
 
 -include: build-defaults.bnd
 
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
 Bundle-Name: tomcat-embed-websocket
 Bundle-SymbolicName: org.apache.tomcat-embed-websocket
 Export-Package: \

--- a/res/bnd/tomcat-jni.jar.tmp.bnd
+++ b/res/bnd/tomcat-jni.jar.tmp.bnd
@@ -15,6 +15,7 @@
 
 -include: build-defaults.bnd
 
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
 Bundle-Name: tomcat-jni
 Bundle-SymbolicName: org.apache.tomcat-jni
 Export-Package: org.apache.tomcat.jni

--- a/res/bnd/tomcat-juli.jar.tmp.bnd
+++ b/res/bnd/tomcat-juli.jar.tmp.bnd
@@ -15,6 +15,7 @@
 
 -include: build-defaults.bnd
 
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
 Bundle-Name: tomcat-juli
 Bundle-SymbolicName: org.apache.tomcat-juli
 Export-Package: \

--- a/res/bnd/tomcat-util-scan.jar.tmp.bnd
+++ b/res/bnd/tomcat-util-scan.jar.tmp.bnd
@@ -15,6 +15,7 @@
 
 -include: build-defaults.bnd
 
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
 Bundle-Name: tomcat-util-scan
 Bundle-SymbolicName: org.apache.tomcat-util-scan
 Export-Package: \

--- a/res/bnd/tomcat-util.jar.tmp.bnd
+++ b/res/bnd/tomcat-util.jar.tmp.bnd
@@ -15,6 +15,7 @@
 
 -include: build-defaults.bnd
 
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
 Bundle-Name: tomcat-util
 Bundle-SymbolicName: org.apache.tomcat-util
 Export-Package: \

--- a/res/bnd/tomcat-websocket.jar.tmp.bnd
+++ b/res/bnd/tomcat-websocket.jar.tmp.bnd
@@ -15,6 +15,7 @@
 
 -include: build-defaults.bnd
 
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
 Bundle-Name: tomcat-websocket
 Bundle-SymbolicName: org.apache.tomcat-websocket
 Export-Package: \

--- a/res/bnd/websocket-api.jar.tmp.bnd
+++ b/res/bnd/websocket-api.jar.tmp.bnd
@@ -15,6 +15,7 @@
 
 -include: build-defaults.bnd, spec-defaults.bnd
 
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
 Bundle-Name: tomcat-websocket-api
 Bundle-SymbolicName: org.apache.tomcat-websocket-api
 Export-Package: \

--- a/res/bnd/websocket-client-api.jar.tmp.bnd
+++ b/res/bnd/websocket-client-api.jar.tmp.bnd
@@ -15,6 +15,7 @@
 
 -include: build-defaults.bnd, spec-defaults.bnd
 
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
 Bundle-Name: tomcat-websocket-client-api
 Bundle-SymbolicName: org.apache.tomcat-websocket-client-api
 Export-Package: \


### PR DESCRIPTION
Other ASF projects like CXF that are built using the maven-bundle-plugin have the pom license automatically inserted into the manifest as "Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt". This helps tools like syft determine the license when building an SBOM. This PR adds this to the Tomcat jars so that Syft can automatically determine the correct license.

If approved please backport to 10.x + 9.x.