### PR TITLE
Fix NioChannel's toString() throwing NullPointerException in some cases

### DIFF
--- a/java/org/apache/tomcat/util/net/Nio2Channel.java
+++ b/java/org/apache/tomcat/util/net/Nio2Channel.java
@@ -136,7 +136,7 @@ public class Nio2Channel implements AsynchronousByteChannel {
 
     @Override
     public String toString() {
-        return super.toString() + ":" + sc.toString();
+        return super.toString() + ":" + sc;
     }
 
     @Override

--- a/java/org/apache/tomcat/util/net/NioChannel.java
+++ b/java/org/apache/tomcat/util/net/NioChannel.java
@@ -185,7 +185,7 @@ public class NioChannel implements ByteChannel, ScatteringByteChannel, Gathering
 
     @Override
     public String toString() {
-        return super.toString() + ":" + (sc!=null ? sc.toString() : "");
+        return super.toString() + ":" + sc;
     }
 
     public int getOutboundRemaining() {

--- a/java/org/apache/tomcat/util/net/NioChannel.java
+++ b/java/org/apache/tomcat/util/net/NioChannel.java
@@ -185,7 +185,7 @@ public class NioChannel implements ByteChannel, ScatteringByteChannel, Gathering
 
     @Override
     public String toString() {
-        return super.toString() + ":" + sc.toString();
+        return super.toString() + ":" + (sc!=null ? sc.toString() : "");
     }
 
     public int getOutboundRemaining() {


### PR DESCRIPTION
NioChannel's toString() causes NioEndpoint's setSocketOptions method to throw a NullPointerException in some scenarios (e.g. idea breakpoint debugging).