### PR TITLE
Added option to use custom SSLContext

### DIFF
--- a/java/org/apache/tomcat/util/net/AbstractJsseEndpoint.java
+++ b/java/org/apache/tomcat/util/net/AbstractJsseEndpoint.java
@@ -99,14 +99,15 @@ public abstract class AbstractJsseEndpoint<S,U> extends AbstractEndpoint<S,U> {
                 sslHostConfig.setEnabledCiphers(sslUtil.getEnabledCiphers());
             }
 
-            SSLContext sslContext;
-            try {
-                sslContext = sslUtil.createSSLContext(negotiableProtocols);
-            } catch (Exception e) {
-                throw new IllegalArgumentException(e.getMessage(), e);
+            SSLContext sslContext = certificate.getSslContext();
+            if (sslContext == null) {
+                try {
+                    sslContext = sslUtil.createSSLContext(negotiableProtocols);
+                    certificate.setSslContext(sslContext);
+                } catch (Exception e) {
+                    throw new IllegalArgumentException(e.getMessage(), e);
+                }
             }
-
-            certificate.setSslContext(sslContext);
             logCertificate(certificate);
         }
     }


### PR DESCRIPTION
Tomcat supports configuring a custom SSLContext when configuring the `SSLHostConfigCertificate`. However the custom SSLContext gets ignored during the server startup and ssl initialization. A new SSLContext will be created and it will fail if not all properties are provided. A fix would be to use the custom SSLContext if it is present or fallback to the original behaviour of still creating it.

I noticed this issue when I tried to configure the embedded tomcat server within Spring Boot. Although it is possible to configure it, it was just ignoring it which I found strange. I asked for help at stackoverflow here: https://stackoverflow.com/questions/77322685/configuring-ssl-programatically-of-a-spring-boot-server-with-tomcat-is-failing

However after debugging the source code I found out the custom ssl is being ignored. I made the code adjustment and created local artificats to test with my project and it worked.

My motivation to have this feature is to use tomcat with a custom ssl configuration with different kind of options for constructing a trustmanager/keymanager, such as hot reloadable option, existing truststore alongside jdk trusted certificates and OS trusted certificates etc, or a trustmanager which can just grow over time adding trusted certificates whenever needed to a running instance without restarting, encrypted private keys as pem files etc. Basically allowing all kind of advanced ssl options with the following library: https://github.com/Hakky54/sslcontext-kickstart

Spring boot 3.x.x is using tomcat 10.1.x however it might be possible to backport it to earlier versions such as 9.x wich is being used in Spring boot 2.x