### PR TITLE
Fix explicit chunked encoding specification

### DIFF
--- a/java/org/apache/coyote/http11/Http11Processor.java
+++ b/java/org/apache/coyote/http11/Http11Processor.java
@@ -937,7 +937,7 @@ public class Http11Processor extends AbstractProcessor {
         } else {
             // If the response code supports an entity body and we're on
             // HTTP 1.1 then we chunk unless we have a Connection: close header
-            if (http11 && entityBody && !connectionClosePresent) {
+            if (http11 && entityBody && (!connectionClosePresent || isChunked(headers))) {
                 outputBuffer.addActiveFilter(outputFilters[Constants.CHUNKED_FILTER]);
                 contentDelimitation = true;
                 headers.addValue(Constants.TRANSFERENCODING).setString(Constants.CHUNKED);
@@ -1069,6 +1069,17 @@ public class Http11Processor extends AbstractProcessor {
         }
 
         outputBuffer.commit();
+    }
+
+    /**
+     * Checks if the given headers indicate chunked transfer encoding.
+     *
+     * @param headers The MimeHeaders object containing the headers to check.
+     * @return {@code true} if the headers indicate chunked transfer encoding, {@code false} otherwise.
+     */
+    private static boolean isChunked(MimeHeaders headers) {
+        MessageBytes transferEncoding = headers.getValue(Constants.TRANSFERENCODING);
+        return transferEncoding != null && Constants.CHUNKED.equals(transferEncoding.getString());
     }
 
     private static boolean isConnectionToken(MimeHeaders headers, String token) throws IOException {


### PR DESCRIPTION
Summary:
This commit fixes a bug in the code related to handling chunked transfer encoding. The original code only handled chunked transfer encoding when http11 was true, entityBody was true, and connectionClosePresent was false. However, this did not take into account the case where the request headers indicated chunked transfer encoding.

The modified code now includes a check for isChunked(headers) in addition to the existing conditions. This ensures that chunked transfer encoding is correctly handled when all the specified conditions are met, as well as when the request headers indicate chunked transfer encoding.

Detailed Explanation:

The original code snippet did not consider the situation where the request headers explicitly specified chunked transfer encoding. This resulted in a bug where chunked transfer encoding was not handled correctly.
example: 
javax.servlet.http.HttpServletResponse#setHeader("Transfer-encoding","chunked");
javax.servlet.http.HttpServletResponse#setHeader("Connection","close");

The modification addresses this issue by introducing a call to isChunked(headers) as an additional condition. This ensures that chunked transfer encoding is handled correctly when all the conditions (http11, entityBody, connectionClosePresent) are met, or when the request headers indicate chunked transfer encoding.

