### PR TITLE
Fix HTTP/2 support wording in HTTP docs

### DIFF
--- a/webapps/docs/config/http.xml
+++ b/webapps/docs/config/http.xml
@@ -1066,7 +1066,7 @@
 
   <subsection name="HTTP/2 Support">
 
-  <p>HTTP/2 is support is provided for TLS (h2), non-TLS via HTTP upgrade (h2c)
+  <p>HTTP/2 support is provided for TLS (h2), non-TLS via HTTP upgrade (h2c)
      and direct HTTP/2 (h2c) connections. To enable HTTP/2 support for an HTTP
      connector the following <strong>UpgradeProtocol</strong> element must be
      nested within the <strong>Connector</strong> with a


### PR DESCRIPTION
Trivial wording fix for config docs.

_(Unfortunately goes all the way back to `9.0.x` and `8.5.x`)_