### PR TITLE
Remove org.apache.catalina.ssi from tomcat-embed-core.jar.tmp.bnd

### DIFF
--- a/res/bnd/tomcat-embed-core.jar.tmp.bnd
+++ b/res/bnd/tomcat-embed-core.jar.tmp.bnd
@@ -38,7 +38,6 @@ Export-Package: \
     org.apache.catalina.security,\
     org.apache.catalina.servlets,\
     org.apache.catalina.session,\
-    org.apache.catalina.ssi,\
     org.apache.catalina.startup,\
     org.apache.catalina.users,\
     org.apache.catalina.util,\


### PR DESCRIPTION
This package no longer exits in `tomcat-embed-core.jar`. It is in the `module-info.class` of the current `10.1.18` and earlier `10.x` releases.

Running `jlink` or `jpackage` with a Module Path that contains `tomcat-embed-core-10.1.18.jar` gives the following error:

> jlink failed with: Error: Packages that are exported or open in org.apache.tomcat.embed.core are not present: [org.apache.catalina.ssi]