### PR TITLE
Update to use JakartaExpressionLanguage osgi.contract

### DIFF
--- a/res/bnd/el-api.jar.tmp.bnd
+++ b/res/bnd/el-api.jar.tmp.bnd
@@ -21,7 +21,7 @@ Export-Package: jakarta.el;version=${el.spec.version}
 
 Provide-Capability: \
     osgi.contract;\
-        osgi.contract=JavaEL;\
+        osgi.contract=JakartaExpressionLanguage;\
         version:Version=${el.spec.version};\
         uses:='${packages;NAMED;jakarta.el.*}'
 


### PR DESCRIPTION
I opened: https://bz.apache.org/bugzilla/show_bug.cgi?id=66834 last year and upon looking at the latest M16 release of Expression Language 6.0 here: https://repo1.maven.org/maven2/org/apache/tomcat/tomcat-el-api/11.0.0-M16/ I still see the following in the MANIFEST.MF:

`Provide-Capability: osgi.contract;osgi.contract=JavaEL`

This should now be using the new `JakartaExpressionLanguage` osgi.contract.