### PR TITLE
Add a fallback when people use Parameters class concurrently, to avoid lost params

### DIFF
--- a/java/org/apache/tomcat/util/http/Parameters.java
+++ b/java/org/apache/tomcat/util/http/Parameters.java
@@ -144,7 +144,11 @@ public final class Parameters {
      */
     public void handleQueryParameters() {
         if (didQueryParameters) {
-            return;
+            if (!queryMB.isNull() && decodedQuery.isNull()) {
+                log.debug("This class is not thread safe but handled by multiple threads now. This is just a fallback to avoid severely error.");
+            } else {
+                return;
+            }
         }
 
         didQueryParameters = true;


### PR DESCRIPTION
We just found that in most cases, if people use Parameters class with multi-threads, adding such a fallback would make them not suffer from losting params.
It might cause duplicate params, but 1. that shall never happened in single-thread cases, so shall not break something.
2. in most multi-thread cases, getting duplicate params is actually acceptable, but losting params be not acceptable