### PR TITLE
Decode and normalize URIs before processing them

### DIFF
--- a/java/org/apache/catalina/connector/Connector.java
+++ b/java/org/apache/catalina/connector/Connector.java
@@ -271,7 +271,7 @@ public class Connector extends LifecycleMBeanBase {
     /**
      * The behavior when an encoded solidus (slash) is submitted.
      */
-    private EncodedSolidusHandling encodedSolidusHandling = EncodedSolidusHandling.REJECT;
+    private EncodedSolidusHandling encodedSolidusHandling = EncodedSolidusHandling.DECODE;
 
 
     /**

--- a/java/org/apache/catalina/connector/CoyoteAdapter.java
+++ b/java/org/apache/catalina/connector/CoyoteAdapter.java
@@ -583,6 +583,7 @@ public class CoyoteAdapter implements Adapter {
         }
 
         MessageBytes undecodedURI = req.requestURI();
+        undecodedURI.setCharset(connector.getURICharset());
 
         // Check for ping OPTIONS * request
         if (undecodedURI.equals("*")) {
@@ -619,9 +620,6 @@ public class CoyoteAdapter implements Adapter {
                 // Copy the raw URI to the decodedURI
                 decodedURI.duplicate(undecodedURI);
 
-                // Parse (and strip out) the path parameters
-                parsePathParameters(req, request);
-
                 // URI decoding
                 // %xx decoding of the URL
                 try {
@@ -640,6 +638,9 @@ public class CoyoteAdapter implements Adapter {
                 } else {
                     response.sendError(400, sm.getString("coyoteAdapter.invalidURI"));
                 }
+
+                // Parse (and strip out) the path parameters after decoding and normalizing the URI
+                parsePathParameters(req, request);
             } else {
                 /*
                  * The URI is chars or String, and has been sent using an in-memory protocol handler. The following

--- a/java/org/apache/tomcat/util/buf/UDecoder.java
+++ b/java/org/apache/tomcat/util/buf/UDecoder.java
@@ -61,24 +61,6 @@ public final class UDecoder {
 
     /**
      * URLDecode, will modify the source. Assumes source bytes are encoded using a superset of US-ASCII as per RFC 7230.
-     * "%2f" will be rejected unless the input is a query string.
-     *
-     * @param mb    The URL encoded bytes
-     * @param query {@code true} if this is a query string. For a query string '+' will be decoded to ' '
-     *
-     * @throws IOException Invalid %xx URL encoding
-     */
-    public void convert(ByteChunk mb, boolean query) throws IOException {
-        if (query) {
-            convert(mb, true, EncodedSolidusHandling.DECODE);
-        } else {
-            convert(mb, false, EncodedSolidusHandling.REJECT);
-        }
-    }
-
-
-    /**
-     * URLDecode, will modify the source. Assumes source bytes are encoded using a superset of US-ASCII as per RFC 7230.
      *
      * @param mb                     The URL encoded bytes
      * @param encodedSolidusHandling How should the %2f sequence handled by the decoder? For query strings this
@@ -91,7 +73,18 @@ public final class UDecoder {
     }
 
 
-    private void convert(ByteChunk mb, boolean query, EncodedSolidusHandling encodedSolidusHandling)
+    /**
+     * URLDecode, will modify the source. Assumes source bytes are encoded using a superset of US-ASCII as per RFC 7230.
+     *
+     * @param mb                     The URL encoded bytes
+     * @param query                  {@code true} if this is a query string. For a query string '+' will be decoded
+     *                                   to ' '
+     * @param encodedSolidusHandling How should the %2f sequence handled by the decoder? For query strings this
+     *                                   parameter will be ignored and the %2f sequence will be decoded
+     *
+     * @throws IOException Invalid %xx URL encoding
+     */
+    public void convert(ByteChunk mb, boolean query, EncodedSolidusHandling encodedSolidusHandling)
             throws IOException {
 
         int start = mb.getOffset();

--- a/java/org/apache/tomcat/util/http/Parameters.java
+++ b/java/org/apache/tomcat/util/http/Parameters.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import org.apache.juli.logging.Log;
 import org.apache.juli.logging.LogFactory;
 import org.apache.tomcat.util.buf.ByteChunk;
+import org.apache.tomcat.util.buf.EncodedSolidusHandling;
 import org.apache.tomcat.util.buf.MessageBytes;
 import org.apache.tomcat.util.buf.StringUtils;
 import org.apache.tomcat.util.buf.UDecoder;
@@ -364,7 +365,7 @@ public final class Parameters {
         if (urlDec == null) {
             urlDec = new UDecoder();
         }
-        urlDec.convert(bc, true);
+        urlDec.convert(bc, true, EncodedSolidusHandling.DECODE);
     }
 
     public void processParameters(MessageBytes data, Charset charset) {

--- a/test/org/apache/catalina/connector/TestCoyoteAdapter.java
+++ b/test/org/apache/catalina/connector/TestCoyoteAdapter.java
@@ -226,6 +226,35 @@ public class TestCoyoteAdapter extends TomcatBaseTest {
         // Invalid UTF-8
         doTestUriDecoding("/foo%ed%a0%80", "UTF-8", null);
     }
+    @Test
+    public void testPathTraversal1() throws Exception {
+        doTestUriDecoding("/foo/..", "UTF-8", "/");
+    }
+
+    @Test
+    public void testPathTraversal2() throws Exception {
+        doTestUriDecoding("/foo%2F..", "UTF-8", "/");
+    }
+
+    @Test
+    public void testPathTraversal3() throws Exception {
+        doTestUriDecoding("/foo%2F..%2F..", "UTF-8", null);
+    }
+
+    @Test
+    public void testSemicolonPathTraversal1() throws Exception {
+        doTestUriDecoding("/foo;a=b/..", "UTF-8", "/");
+    }
+
+    @Test
+    public void testSemicolonPathTraversal2() throws Exception {
+        doTestUriDecoding("/foo;a=b%2F..", "UTF-8", "/");
+    }
+
+    @Test
+    public void testSemicolonPathTraversal3() throws Exception {
+        doTestUriDecoding("/foo;a=b%2F..%2F..", "UTF-8", null);
+    }
 
     private void doTestUriDecoding(String path, String encoding,
             String expectedPathInfo) throws Exception{


### PR DESCRIPTION
URIs must be at least decoded in order to process sub-delims as defined in RFC 3986, because slashes and their encoded counterparts are equivalent when processing paths. Normalization before the processing also makes sense to avoid unnecessary stripping of path parameters in case of path traversal. This fixes a bug where URIs like "/test;%2F.." would not properly resolve to "/", but to "/test".