### PR TITLE
Attempt to protect against asynchronous thread safety violations

### DIFF
--- a/java/org/apache/catalina/connector/OutputBuffer.java
+++ b/java/org/apache/catalina/connector/OutputBuffer.java
@@ -328,7 +328,6 @@ public class OutputBuffer extends Writer {
                 // An IOException on a write is almost always due to
                 // the remote client aborting the request. Wrap this
                 // so that it can be handled better by the error dispatcher.
-                coyoteResponse.setErrorException(e);
                 throw new ClientAbortException(e);
             }
         }

--- a/java/org/apache/coyote/LocalStrings.properties
+++ b/java/org/apache/coyote/LocalStrings.properties
@@ -65,6 +65,7 @@ request.nullReadListener=The listener passed to setReadListener() may not be nul
 request.readListenerSet=The non-blocking read listener has already been set
 
 response.encoding.invalid=The encoding [{0}] is not recognised by the JRE
+response.illegalConcurrentAccess=Concurrent attempts to write to the response and recycle the response were detected. This is not permitted as the response is not thread-safe. See section 2.3.3.4 of the Servlet specification.
 response.noTrailers.notSupported=A trailer fields supplier may not be set for this response. Either the underlying protocol does not support trailer fields or the protocol requires that the supplier is set before the response is committed
 response.notAsync=It is only valid to switch to non-blocking IO within async processing or HTTP upgrade processing
 response.nullWriteListener=The listener passed to setWriteListener() may not be null

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -112,6 +112,17 @@
       </update>
     </changelog>
   </subsection>
+  <subsection name="Coyote">
+    <changelog>
+      <add>
+        Attempt to protect against an application violating section 2.3.3.4
+        (Thread Safety) of the Servlet specification during asynchronous
+        processing and log a warning with a dedicated logger
+        (<code>org.apache.coyote.Response.concurrency</code>) if any such
+        violation is detected. (markt)
+      </add>
+    </changelog>
+  </subsection>
   <subsection name="Jasper">
     <changelog>
       <add>


### PR DESCRIPTION
Providing this as a PR as it isn't strictly a Tomcat bug or Tomcat's problem to solve. That said, we do see some asynchronous bug reports and this might help highlight application issues early and reduce the number of false positives.

If there are no objections, I'd like to get this merged for the March release round.