### PR TITLE
Remove duplicate if statements from the OutputBuffer.close() method

### DIFF
--- a/java/org/apache/catalina/connector/OutputBuffer.java
+++ b/java/org/apache/catalina/connector/OutputBuffer.java
@@ -223,9 +223,7 @@ public class OutputBuffer extends Writer {
         if ((!coyoteResponse.isCommitted()) && (coyoteResponse.getContentLengthLong() == -1)) {
             // If this didn't cause a commit of the response, the final content
             // length can be calculated.
-            if (!coyoteResponse.isCommitted()) {
-                coyoteResponse.setContentLength(bb.remaining());
-            }
+            coyoteResponse.setContentLength(bb.remaining());
         }
 
         if (coyoteResponse.getStatus() == HttpServletResponse.SC_SWITCHING_PROTOCOLS) {


### PR DESCRIPTION
Hello I was checking the code regarding the "Content-length" of the response and found it.
In my opinion, it is because I decided that it is unnecessary to double check !coyoteResponse.isCommitted() inside the if statement. So I made the code concise and clear by eliminating unnecessary duplicates.