### PR TITLE
remove unnecessary code in InputBuffer.available()

### DIFF
--- a/java/org/apache/catalina/connector/InputBuffer.java
+++ b/java/org/apache/catalina/connector/InputBuffer.java
@@ -201,7 +201,9 @@ public class InputBuffer extends Reader implements ByteChunk.ByteInputChannel, A
         int available = availableInThisBuffer();
         if (available == 0) {
             coyoteRequest.action(ActionCode.AVAILABLE, Boolean.valueOf(coyoteRequest.getReadListener() != null));
-            available = (coyoteRequest.getAvailable() > 0) ? 1 : 0;
+            if (coyoteRequest.getAvailable() > 0) {
+                available = 1;
+            }
         }
         return available;
     }


### PR DESCRIPTION
in this case, to assign ```available = 0``` within the ```if (available == 0)``` by using conditional operator 

remove unnecessary code, improving readability.