### PR TITLE
Unify comma-separated-value code and optimize the implementation

### DIFF
--- a/java/org/apache/catalina/connector/Connector.java
+++ b/java/org/apache/catalina/connector/Connector.java
@@ -41,6 +41,7 @@ import org.apache.tomcat.util.IntrospectionUtils;
 import org.apache.tomcat.util.buf.B2CConverter;
 import org.apache.tomcat.util.buf.CharsetUtil;
 import org.apache.tomcat.util.buf.EncodedSolidusHandling;
+import org.apache.tomcat.util.buf.StringUtils;
 import org.apache.tomcat.util.compat.JreCompat;
 import org.apache.tomcat.util.net.SSLHostConfig;
 import org.apache.tomcat.util.net.openssl.OpenSSLImplementation;
@@ -528,7 +529,7 @@ public class Connector extends LifecycleMBeanBase {
         HashSet<String> methodSet = new HashSet<>();
 
         if (null != methods) {
-            methodSet.addAll(Arrays.asList(methods.split("\\s*,\\s*")));
+            methodSet.addAll(Arrays.asList(StringUtils.splitCommaSeparated(methods)));
         }
 
         if (methodSet.contains("TRACE")) {

--- a/java/org/apache/catalina/filters/ExpiresFilter.java
+++ b/java/org/apache/catalina/filters/ExpiresFilter.java
@@ -28,7 +28,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.StringTokenizer;
-import java.util.regex.Pattern;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.FilterConfig;
@@ -44,6 +43,7 @@ import jakarta.servlet.http.MappingMatch;
 
 import org.apache.juli.logging.Log;
 import org.apache.juli.logging.LogFactory;
+import org.apache.tomcat.util.buf.StringUtils;
 
 /**
  * <p>
@@ -1010,11 +1010,6 @@ public class ExpiresFilter extends FilterBase {
 
     }
 
-    /**
-     * {@link Pattern} for a comma delimited string that support whitespace characters
-     */
-    private static final Pattern commaSeparatedValuesPattern = Pattern.compile("\\s*,\\s*");
-
     private static final String HEADER_CACHE_CONTROL = "Cache-Control";
 
     private static final String HEADER_EXPIRES = "Expires";
@@ -1039,7 +1034,7 @@ public class ExpiresFilter extends FilterBase {
      * @return never {@code null} array
      */
     protected static int[] commaDelimitedListToIntArray(String commaDelimitedInts) {
-        String[] intsAsStrings = commaDelimitedListToStringArray(commaDelimitedInts);
+        String[] intsAsStrings = StringUtils.splitCommaSeparated(commaDelimitedInts);
         int[] ints = new int[intsAsStrings.length];
         for (int i = 0; i < intsAsStrings.length; i++) {
             String intAsString = intsAsStrings[i];
@@ -1051,18 +1046,6 @@ public class ExpiresFilter extends FilterBase {
             }
         }
         return ints;
-    }
-
-    /**
-     * Convert a given comma delimited list of strings into an array of String
-     *
-     * @param commaDelimitedStrings the string to be split
-     *
-     * @return array of patterns (non {@code null})
-     */
-    protected static String[] commaDelimitedListToStringArray(String commaDelimitedStrings) {
-        return (commaDelimitedStrings == null || commaDelimitedStrings.length() == 0) ? new String[0] :
-                commaSeparatedValuesPattern.split(commaDelimitedStrings);
     }
 
     /**

--- a/java/org/apache/catalina/filters/RemoteCIDRFilter.java
+++ b/java/org/apache/catalina/filters/RemoteCIDRFilter.java
@@ -33,6 +33,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.apache.catalina.util.NetMask;
 import org.apache.juli.logging.Log;
 import org.apache.juli.logging.LogFactory;
+import org.apache.tomcat.util.buf.StringUtils;
 
 public final class RemoteCIDRFilter extends FilterBase {
 
@@ -221,7 +222,7 @@ public final class RemoteCIDRFilter extends FilterBase {
         final List<String> messages = new ArrayList<>();
         NetMask nm;
 
-        for (final String s : input.split("\\s*,\\s*")) {
+        for (final String s : StringUtils.splitCommaSeparated(input)) {
             try {
                 nm = new NetMask(s);
                 target.add(nm);

--- a/java/org/apache/catalina/filters/RemoteIpFilter.java
+++ b/java/org/apache/catalina/filters/RemoteIpFilter.java
@@ -640,11 +640,6 @@ public class RemoteIpFilter extends GenericFilter {
     }
 
 
-    /**
-     * {@link Pattern} for a comma delimited string that support whitespace characters
-     */
-    private static final Pattern commaSeparatedValuesPattern = Pattern.compile("\\s*,\\s*");
-
     protected static final String HTTP_SERVER_PORT_PARAMETER = "httpServerPort";
 
     protected static final String HTTPS_SERVER_PORT_PARAMETER = "httpsServerPort";
@@ -675,18 +670,6 @@ public class RemoteIpFilter extends GenericFilter {
     protected static final String TRUSTED_PROXIES_PARAMETER = "trustedProxies";
 
     protected static final String ENABLE_LOOKUPS_PARAMETER = "enableLookups";
-
-    /**
-     * Convert a given comma delimited list of regular expressions into an array of String
-     *
-     * @param commaDelimitedStrings The string to split
-     *
-     * @return array of patterns (non <code>null</code>)
-     */
-    protected static String[] commaDelimitedListToStringArray(String commaDelimitedStrings) {
-        return (commaDelimitedStrings == null || commaDelimitedStrings.length() == 0) ? new String[0] :
-                commaSeparatedValuesPattern.split(commaDelimitedStrings);
-    }
 
     /**
      * @see #setHttpServerPort(int)
@@ -764,7 +747,7 @@ public class RemoteIpFilter extends GenericFilter {
                 concatRemoteIpHeaderValue.append(e.nextElement());
             }
 
-            String[] remoteIpHeaderValue = commaDelimitedListToStringArray(concatRemoteIpHeaderValue.toString());
+            String[] remoteIpHeaderValue = StringUtils.splitCommaSeparated(concatRemoteIpHeaderValue.toString());
             int idx;
             if (!isInternal) {
                 proxiesHeaderValue.addFirst(request.getRemoteAddr());
@@ -898,7 +881,7 @@ public class RemoteIpFilter extends GenericFilter {
         if (!protocolHeaderValue.contains(",")) {
             return protocolHeaderHttpsValue.equalsIgnoreCase(protocolHeaderValue);
         }
-        String[] forwardedProtocols = commaDelimitedListToStringArray(protocolHeaderValue);
+        String[] forwardedProtocols = StringUtils.splitCommaSeparated(protocolHeaderValue);
         if (forwardedProtocols.length == 0) {
             return false;
         }

--- a/java/org/apache/catalina/realm/JNDIRealm.java
+++ b/java/org/apache/catalina/realm/JNDIRealm.java
@@ -963,11 +963,12 @@ public class JNDIRealm extends RealmBase {
         if (cipherSuites == null || cipherSuitesArray != null) {
             return cipherSuitesArray;
         }
-        if (this.cipherSuites.trim().isEmpty()) {
+        this.cipherSuites = this.cipherSuites.trim();
+        if (this.cipherSuites.isEmpty()) {
             containerLog.warn(sm.getString("jndiRealm.emptyCipherSuites"));
             this.cipherSuitesArray = null;
         } else {
-            this.cipherSuitesArray = StringUtils.splitCommaSeparated(cipherSuites.trim());
+            this.cipherSuitesArray = StringUtils.splitCommaSeparated(cipherSuites);
             if (containerLog.isTraceEnabled()) {
                 containerLog.trace(sm.getString("jndiRealm.cipherSuites", Arrays.toString(this.cipherSuitesArray)));
             }

--- a/java/org/apache/catalina/realm/JNDIRealm.java
+++ b/java/org/apache/catalina/realm/JNDIRealm.java
@@ -64,6 +64,7 @@ import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocketFactory;
 
 import org.apache.catalina.LifecycleException;
+import org.apache.tomcat.util.buf.StringUtils;
 import org.apache.tomcat.util.collections.SynchronizedStack;
 import org.ietf.jgss.GSSContext;
 import org.ietf.jgss.GSSCredential;
@@ -966,7 +967,7 @@ public class JNDIRealm extends RealmBase {
             containerLog.warn(sm.getString("jndiRealm.emptyCipherSuites"));
             this.cipherSuitesArray = null;
         } else {
-            this.cipherSuitesArray = cipherSuites.trim().split("\\s*,\\s*");
+            this.cipherSuitesArray = StringUtils.splitCommaSeparated(cipherSuites.trim());
             if (containerLog.isTraceEnabled()) {
                 containerLog.trace(sm.getString("jndiRealm.cipherSuites", Arrays.toString(this.cipherSuitesArray)));
             }

--- a/java/org/apache/catalina/util/NetMaskSet.java
+++ b/java/org/apache/catalina/util/NetMaskSet.java
@@ -25,6 +25,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.tomcat.util.buf.StringUtils;
+
 
 /**
  * This class maintains a Set of NetMask objects and allows to check if a given IP address is matched by any of the
@@ -124,7 +126,7 @@ public class NetMaskSet {
 
         List<String> errMessages = new ArrayList<>();
 
-        for (String s : input.split("\\s*,\\s*")) {
+        for (String s : StringUtils.splitCommaSeparated(input)) {
             try {
                 this.add(s);
             } catch (IllegalArgumentException e) {

--- a/java/org/apache/catalina/valves/RemoteCIDRValve.java
+++ b/java/org/apache/catalina/valves/RemoteCIDRValve.java
@@ -30,6 +30,7 @@ import org.apache.catalina.connector.Response;
 import org.apache.catalina.util.NetMask;
 import org.apache.juli.logging.Log;
 import org.apache.juli.logging.LogFactory;
+import org.apache.tomcat.util.buf.StringUtils;
 
 public final class RemoteCIDRValve extends RequestFilterValve {
 
@@ -236,7 +237,7 @@ public final class RemoteCIDRValve extends RequestFilterValve {
         final List<String> messages = new ArrayList<>();
         NetMask nm;
 
-        for (final String s : input.split("\\s*,\\s*")) {
+        for (final String s : StringUtils.splitCommaSeparated(input)) {
             try {
                 nm = new NetMask(s);
                 target.add(nm);

--- a/java/org/apache/catalina/valves/RemoteIpValve.java
+++ b/java/org/apache/catalina/valves/RemoteIpValve.java
@@ -357,28 +357,10 @@ import org.apache.tomcat.util.http.parser.Host;
  * </p>
  */
 public class RemoteIpValve extends ValveBase {
-
-    /**
-     * {@link Pattern} for a comma delimited string that support whitespace characters
-     */
-    private static final Pattern commaSeparatedValuesPattern = Pattern.compile("\\s*,\\s*");
-
     /**
      * Logger
      */
     private static final Log log = LogFactory.getLog(RemoteIpValve.class);
-
-    /**
-     * Convert a given comma delimited String into an array of String
-     *
-     * @param commaDelimitedStrings The string to convert
-     *
-     * @return array of String (non <code>null</code>)
-     */
-    protected static String[] commaDelimitedListToStringArray(String commaDelimitedStrings) {
-        return (commaDelimitedStrings == null || commaDelimitedStrings.length() == 0) ? new String[0]
-                : commaSeparatedValuesPattern.split(commaDelimitedStrings);
-    }
 
     private String hostHeader = null;
 
@@ -608,7 +590,7 @@ public class RemoteIpValve extends ValveBase {
                 concatRemoteIpHeaderValue.append(e.nextElement());
             }
 
-            String[] remoteIpHeaderValue = commaDelimitedListToStringArray(concatRemoteIpHeaderValue.toString());
+            String[] remoteIpHeaderValue = StringUtils.splitCommaSeparated(concatRemoteIpHeaderValue.toString());
             int idx;
             if (!isInternal) {
                 proxiesHeaderValue.addFirst(originalRemoteAddr);
@@ -769,7 +751,7 @@ public class RemoteIpValve extends ValveBase {
         if (!protocolHeaderValue.contains(",")) {
             return protocolHeaderHttpsValue.equalsIgnoreCase(protocolHeaderValue);
         }
-        String[] forwardedProtocols = commaDelimitedListToStringArray(protocolHeaderValue);
+        String[] forwardedProtocols = StringUtils.splitCommaSeparated(protocolHeaderValue);
         if (forwardedProtocols.length == 0) {
             return false;
         }

--- a/java/org/apache/tomcat/util/buf/StringUtils.java
+++ b/java/org/apache/tomcat/util/buf/StringUtils.java
@@ -19,7 +19,6 @@ package org.apache.tomcat.util.buf;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Function;
-import java.util.regex.Pattern;
 
 /**
  * Utility methods to build a separated list from a given set (not java.util.Set) of inputs and return that list as a
@@ -97,11 +96,6 @@ public final class StringUtils {
     }
 
     /**
-     * {@link Pattern} for a comma delimited string that support whitespace characters
-     */
-    private static final Pattern commaSeparatedValuesPattern = Pattern.compile("\\s*,\\s*");
-
-    /**
      * Splits a comma-separated string into an array of String values.
      *
      * Whitespace around the commas is removed.
@@ -113,8 +107,15 @@ public final class StringUtils {
      * @return An array of String values.
      */
     public static String[] splitCommaSeparated(String s) {
-        return (s == null || s.length() == 0) ? new String[0] :
-            commaSeparatedValuesPattern.split(s);
+        if (s == null || s.length() == 0) {
+            return new String[0];
+        }
 
+        String[] splits = s.split(",");
+        for (int i=0; i<splits.length; ++i) {
+            splits[i] = splits[i].trim();
+        }
+
+        return splits;
     }
 }

--- a/java/org/apache/tomcat/util/buf/StringUtils.java
+++ b/java/org/apache/tomcat/util/buf/StringUtils.java
@@ -112,7 +112,7 @@ public final class StringUtils {
         }
 
         String[] splits = s.split(",");
-        for (int i=0; i<splits.length; ++i) {
+        for (int i = 0; i < splits.length; ++i) {
             splits[i] = splits[i].trim();
         }
 

--- a/java/org/apache/tomcat/util/buf/StringUtils.java
+++ b/java/org/apache/tomcat/util/buf/StringUtils.java
@@ -19,6 +19,7 @@ package org.apache.tomcat.util.buf;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 
 /**
  * Utility methods to build a separated list from a given set (not java.util.Set) of inputs and return that list as a
@@ -93,5 +94,27 @@ public final class StringUtils {
             }
             sb.append(function.apply(value));
         }
+    }
+
+    /**
+     * {@link Pattern} for a comma delimited string that support whitespace characters
+     */
+    private static final Pattern commaSeparatedValuesPattern = Pattern.compile("\\s*,\\s*");
+
+    /**
+     * Splits a comma-separated string into an array of String values.
+     *
+     * Whitespace around the commas is removed.
+     *
+     * Null or empty values will return a zero-element array.
+     *
+     * @param s The string to split by commas.
+     *
+     * @return An array of String values.
+     */
+    public static String[] splitCommaSeparated(String s) {
+        return (s == null || s.length() == 0) ? new String[0] :
+            commaSeparatedValuesPattern.split(s);
+
     }
 }

--- a/test/org/apache/catalina/filters/TestRemoteIpFilter.java
+++ b/test/org/apache/catalina/filters/TestRemoteIpFilter.java
@@ -638,7 +638,7 @@ public class TestRemoteIpFilter extends TomcatBaseTest {
 
     @Test
     public void testListToCommaDelimitedString() {
-        String[] actual = RemoteIpFilter.commaDelimitedListToStringArray("element1, element2, element3");
+        String[] actual = StringUtils.splitCommaSeparated("element1, element2, element3");
         String[] expected = new String[] { "element1", "element2", "element3" };
         Assert.assertEquals(expected.length, actual.length);
         for (int i = 0; i < actual.length; i++) {
@@ -648,7 +648,7 @@ public class TestRemoteIpFilter extends TomcatBaseTest {
 
     @Test
     public void testListToCommaDelimitedStringMixedSpaceChars() {
-        String[] actual = RemoteIpFilter.commaDelimitedListToStringArray("element1  , element2,\t element3");
+        String[] actual = StringUtils.splitCommaSeparated("element1  , element2,\t element3");
         String[] expected = new String[] { "element1", "element2", "element3" };
         Assert.assertEquals(expected.length, actual.length);
         for (int i = 0; i < actual.length; i++) {

--- a/test/org/apache/catalina/valves/TestRemoteIpValve.java
+++ b/test/org/apache/catalina/valves/TestRemoteIpValve.java
@@ -32,6 +32,7 @@ import org.apache.catalina.Globals;
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
+import org.apache.tomcat.util.buf.StringUtils;
 
 /**
  * {@link RemoteIpValve} Tests
@@ -1031,14 +1032,14 @@ public class TestRemoteIpValve {
 
     @Test
     public void testCommaDelimitedListToStringArray() {
-        String[] actual = RemoteIpValve.commaDelimitedListToStringArray("element1, element2, element3");
+        String[] actual = StringUtils.splitCommaSeparated("element1, element2, element3");
         String[] expected = new String[] { "element1", "element2", "element3" };
         assertArrayEquals(expected, actual);
     }
 
     @Test
     public void testCommaDelimitedListToStringArrayMixedSpaceChars() {
-        String[] actual = RemoteIpValve.commaDelimitedListToStringArray("element1  , element2,\t element3");
+        String[] actual = StringUtils.splitCommaSeparated("element1  , element2,\t element3");
         String[] expected = new String[] { "element1", "element2", "element3" };
         assertArrayEquals(expected, actual);
     }


### PR DESCRIPTION
There was repeated code in various places in the source tree to spit simple comma-separated strings using the regular expression pattern `\s*,\s*`. This PR gathers those together into a single utility method and re-implements that method without using a regular expression which improves performance.

Given that this method is often used on request headers, the aggregate performance improvement over many requests is measurable especially for long strings, strings with many components, etc.

Implementation note: there is a subtle change to the behavior of this utility method relative to the original: this _new_ method results in the first and last strings being "trimmed" of whitespace while the _old_ implementation would have preserved leading whitespace in the first string value returned and trailing whitespace in the last string returned. Reviewing the uses of this method, I do not believe this will have any negative effects on the operation of Tomcat.