### PR TITLE
Make ConnectionHandler accessible through API from AbstractProtocol to ultimately acess RequestGroupInfo

### DIFF
--- a/java/org/apache/coyote/AbstractProtocol.java
+++ b/java/org/apache/coyote/AbstractProtocol.java
@@ -458,7 +458,7 @@ public abstract class AbstractProtocol<S> implements ProtocolHandler, MBeanRegis
     }
 
 
-    protected Handler<S> getHandler() {
+    public Handler<S> getHandler() {
         return handler;
     }
 
@@ -769,7 +769,7 @@ public abstract class AbstractProtocol<S> implements ProtocolHandler, MBeanRegis
 
     // ------------------------------------------- Connection handler base class
 
-    protected static class ConnectionHandler<S> implements AbstractEndpoint.Handler<S> {
+    public static class ConnectionHandler<S> implements AbstractEndpoint.Handler<S> {
 
         private final AbstractProtocol<S> proto;
         private final RequestGroupInfo global = new RequestGroupInfo();


### PR DESCRIPTION
Goal is to be able to have metrics without having to re-register them or to use reflection, even when JMX is disabled - including GraalVM case.