### PR TITLE
remove obsolete bean attributes

### DIFF
--- a/java/org/apache/tomcat/util/net/mbeans-descriptors.xml
+++ b/java/org/apache/tomcat/util/net/mbeans-descriptors.xml
@@ -29,16 +29,8 @@
     <attribute   name="acceptCount"
                  type="int"/>
 
-    <attribute   name="acceptorThreadCount"
-                 type="int"/>
-
     <attribute   name="acceptorThreadPriority"
                  type="int"/>
-
-    <attribute   name="alpnSupported"
-                 type="boolean"
-            writeable="false"
-                   is="true"/>
 
     <attribute   name="bindOnInit"
                  type="boolean"/>
@@ -66,10 +58,6 @@
 
     <attribute   name="defaultSSLHostConfigName"
                  type="java.lang.String"/>
-
-    <attribute   name="deferAccept"
-                 type="boolean"
-            writeable="false"/>
 
     <attribute   name="domain"
                  type="java.lang.String"/>
@@ -111,9 +99,6 @@
                  type="boolean"
             writeable="false"
                    is="true"/>
-
-    <attribute   name="pollerThreadCount"
-                 type="int"/>
 
     <attribute   name="pollerThreadPriority"
                  type="int"/>


### PR DESCRIPTION
These attributes no longer existing in corresponding org.apache.tomcat.util.net.NioEndpoint, which will cause java.lang.NoSuchMethodException at run time.