### PR TITLE
Configurable HTML subtitle in Manager web application

### DIFF
--- a/java/org/apache/catalina/manager/HTMLManagerServlet.java
+++ b/java/org/apache/catalina/manager/HTMLManagerServlet.java
@@ -321,6 +321,10 @@ public final class HTMLManagerServlet extends ManagerServlet {
         Object[] args = new Object[2];
         args[0] = getServletContext().getContextPath();
         args[1] = smClient.getString("htmlManagerServlet.title");
+        String HTMLSubtitle = getServletContext().getInitParameter("HTMLSubtitle");
+        if (HTMLSubtitle != null) {
+            args[1] += "</font><br/><font size=\"+1\">" + HTMLSubtitle;
+        }
 
         // HTML Header Section
         writer.print(MessageFormat.format(Constants.HTML_HEADER_SECTION, args));

--- a/webapps/docs/manager-howto.xml
+++ b/webapps/docs/manager-howto.xml
@@ -237,6 +237,21 @@ action does not have correct value of the token, the action will be denied.
 If the token has expired you can start again from the main page or
 <em>List Applications</em> page of Manager.</p>
 
+<p>To customize the subtitle of the HTML interface of the Manager web application,
+you can add any valid xml escaped html code to the <code>HTMLSubtitle</code>
+parameter of the <code>Context</code>
+</p>
+
+<source><![CDATA[<Context privileged="true" ...>
+    ...
+    <Parameter name="HTMLSubtitle"
+    value="Company Inc.&lt;br&gt;&lt;i style=&apos;color:red&apos;&gt;Staging&lt;/i&gt;"/>
+</Context>]]></source>
+
+<p>The above string value would unescape and be appended to the title</p>
+
+<source><![CDATA[Company Inc.<br><i style='color:red'>Staging</i>]]></source>
+
 </section>
 
 <section name="Supported Manager Commands">


### PR DESCRIPTION
Managing multiple tomcats on multiple servers, the need came to have a way of customizing the Manager HTML interface. 
This PR proposes to add a simple configurable html subtitle.
![Example_of_customized_subtitle](https://github.com/apache/tomcat/assets/2412297/4716550e-37f1-4532-a388-381e1c95289d)
