### PR TITLE
adds missing quotation mark - makes changelog.xml parsable again

### DIFF
--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -104,7 +104,7 @@
   They eventually become mixed with the numbered issues (i.e., numbered
   issues do not "pop up" wrt. others).
 -->
-<section name="Tomcat 10.1.25 (schultz) rtext="in development">
+<section name="Tomcat 10.1.25 (schultz)" rtext="in development">
 </section>
 
 <section name="Tomcat 10.1.24 (schultz)" rtext="releaser in progress">


### PR DESCRIPTION
Hey,

we figured, that atm the changelog.xml can not be parsed

```python
>>> import requests
>>> import xmltodict
>>> xml = requests.get(f"https://raw.githubusercontent.com/apache/tomcat/10.1.x/webapps/docs/changelog.xml",timeout=1800).text
>>> mydict = xmltodict.parse(xml)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3/dist-packages/xmltodict.py", line 378, in parse
    parser.Parse(xml_input, True)
xml.parsers.expat.ExpatError: not well-formed (invalid token): line 107, column 47
>>> xml = xml.replace('"Tomcat 10.1.25 (schultz)','"Tomcat 10.1.25 (schultz)"')
>>> mydict = xmltodict.parse(xml)
```

due to the missing quotation mark.

Thanks for all the work, all the years!

BR
Christian