### PR TITLE
Fix proxying null value result set

### DIFF
--- a/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/StatementFacade.java
+++ b/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/StatementFacade.java
@@ -119,21 +119,24 @@ public class StatementFacade extends AbstractCreateStatementInterceptor {
 
             Object result;
             try {
-                if (compare(GET_RESULTSET, method)) {
-                    return getConstructor(RESULTSET_IDX, ResultSet.class)
-                            .newInstance(new ResultSetProxy(method.invoke(delegate, args), proxy));
-                }
-                if (compare(GET_GENERATED_KEYS, method)) {
-                    return getConstructor(RESULTSET_IDX, ResultSet.class)
-                            .newInstance(new ResultSetProxy(method.invoke(delegate, args), proxy));
-                }
-                if (compare(EXECUTE_QUERY, method)) {
-                    return getConstructor(RESULTSET_IDX, ResultSet.class)
-                            .newInstance(new ResultSetProxy(method.invoke(delegate, args), proxy));
-                }
-
                 // invoke next
                 result = method.invoke(delegate, args);
+
+                // Don't create a ResultSet proxy for null
+                if (result != null) {
+                    if (compare(GET_RESULTSET, method)) {
+                        return getConstructor(RESULTSET_IDX, ResultSet.class)
+                                .newInstance(new ResultSetProxy(result, proxy));
+                    }
+                    if (compare(GET_GENERATED_KEYS, method)) {
+                        return getConstructor(RESULTSET_IDX, ResultSet.class)
+                                .newInstance(new ResultSetProxy(result, proxy));
+                    }
+                    if (compare(EXECUTE_QUERY, method)) {
+                        return getConstructor(RESULTSET_IDX, ResultSet.class)
+                                .newInstance(new ResultSetProxy(result, proxy));
+                    }
+                }
             } catch (Throwable t) {
                 if (t instanceof InvocationTargetException && t.getCause() != null) {
                     throw t.getCause();


### PR DESCRIPTION
When invoking a method on a proxied statement returns `null`, that statement's proxy should also return `null`.

In particular, `Statement#getResultSet` should not return a `ResultSetProxy` when the proxied statement returns `null`. Otherwise, that `ResultSet` proxy has a `null` delegate and calling methods on the proxy that lead to calling methods on the delegate could result in a `SqlException` with message "ResultSet closed."

We found this issue because our Spring + MyBatis application started throwing `SqlException`s when calling stored procedures after upgrading to Tomcat v. 10.1.28, whereas it didn't in version 10.1.26.

Looking in the MyBatis code, it checks if a `Statement`'s `ResultSet` is `null` or not. If it isn't—and it isn't when the `ResultSet` is proxied with a `null` delegate—, it later calls method `ResultSet#getMetaData()`. And that method now responds with the `SqlException` with message "ResultSet closed.".

I think the new behavior was introduced in https://github.com/apache/tomcat/pull/742.