### PR TITLE
fix bz #69316 FastHttpDateFormat - getCurrentDate() returns inaccurate result

### DIFF
--- a/java/org/apache/tomcat/util/http/FastHttpDateFormat.java
+++ b/java/org/apache/tomcat/util/http/FastHttpDateFormat.java
@@ -71,9 +71,9 @@ public final class FastHttpDateFormat {
     }
 
     /**
-     * Instant on which the currentDate object was generated.
+     * Instant on which the currentDate object was generated. 
      */
-    private static volatile long currentDateGenerated = 0L;
+    private static volatile long currentDateGeneratedInSeconds = 0L;
 
 
     /**
@@ -103,12 +103,11 @@ public final class FastHttpDateFormat {
      * @return the HTTP date
      */
     public static String getCurrentDate() {
-        long now = System.currentTimeMillis();
-        // Ignore millisecond part.
-        now -= now % 1000L;
-        if (now != currentDateGenerated) {
-            currentDate = FORMAT_RFC5322.format(new Date(now));
-            currentDateGenerated = now;
+        // according rfc5322, date/time data is accurate to the second.
+        long nowInSeconds = System.currentTimeMillis() / 1000L;
+        if (nowInSeconds != currentDateGeneratedInSeconds) {
+            currentDate = FORMAT_RFC5322.format(new Date(nowInSeconds * 1000L));
+            currentDateGeneratedInSeconds = nowInSeconds;
         }
         return currentDate;
     }

--- a/java/org/apache/tomcat/util/http/FastHttpDateFormat.java
+++ b/java/org/apache/tomcat/util/http/FastHttpDateFormat.java
@@ -71,7 +71,7 @@ public final class FastHttpDateFormat {
     }
 
     /**
-     * Instant on which the currentDate object was generated. 
+     * Instant on which the currentDate object was generated.
      */
     private static volatile long currentDateGeneratedInSeconds = 0L;
 

--- a/java/org/apache/tomcat/util/http/FastHttpDateFormat.java
+++ b/java/org/apache/tomcat/util/http/FastHttpDateFormat.java
@@ -104,8 +104,10 @@ public final class FastHttpDateFormat {
      */
     public static String getCurrentDate() {
         long now = System.currentTimeMillis();
+        // Ignore millisecond part.
+        now -= now % 1000L;
         // Handle case where time moves backwards (e.g. system time corrected)
-        if (now - now%1000L != currentDateGenerated - currentDateGenerated%1000L) {
+        if (now != currentDateGenerated) {
             currentDate = FORMAT_RFC5322.format(new Date(now));
             currentDateGenerated = now;
         }

--- a/java/org/apache/tomcat/util/http/FastHttpDateFormat.java
+++ b/java/org/apache/tomcat/util/http/FastHttpDateFormat.java
@@ -106,7 +106,6 @@ public final class FastHttpDateFormat {
         long now = System.currentTimeMillis();
         // Ignore millisecond part.
         now -= now % 1000L;
-        // Handle case where time moves backwards (e.g. system time corrected)
         if (now != currentDateGenerated) {
             currentDate = FORMAT_RFC5322.format(new Date(now));
             currentDateGenerated = now;

--- a/java/org/apache/tomcat/util/http/FastHttpDateFormat.java
+++ b/java/org/apache/tomcat/util/http/FastHttpDateFormat.java
@@ -105,7 +105,7 @@ public final class FastHttpDateFormat {
     public static String getCurrentDate() {
         long now = System.currentTimeMillis();
         // Handle case where time moves backwards (e.g. system time corrected)
-        if (Math.abs(now - currentDateGenerated) > 1000) {
+        if (now - now%1000L != currentDateGenerated - currentDateGenerated%1000L) {
             currentDate = FORMAT_RFC5322.format(new Date(now));
             currentDateGenerated = now;
         }

--- a/test/org/apache/tomcat/util/http/TestFastHttpDateFormat.java
+++ b/test/org/apache/tomcat/util/http/TestFastHttpDateFormat.java
@@ -3,7 +3,7 @@ package org.apache.tomcat.util.http;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class TesterFastHttpDateFormat {
+public class TestFastHttpDateFormat {
     @Test
     public void testGetCurrentDateInSameSecond() {
         long now = System.currentTimeMillis();
@@ -13,14 +13,12 @@ public class TesterFastHttpDateFormat {
         }
         now = System.currentTimeMillis();
         String s1 = FastHttpDateFormat.getCurrentDate();
-        System.out.println("1st:" + System.currentTimeMillis() + ", " + s1);
         long lastMillisInSameSecond = now - now % 1000 + 900L;
         try {
             Thread.sleep(lastMillisInSameSecond - now);
         } catch (InterruptedException e) {
         }
         String s2 = FastHttpDateFormat.getCurrentDate();
-        System.out.println("2nd:" + System.currentTimeMillis() + ", " + s2);
         Assert.assertEquals("Two same RFC5322 format dates are expected.", s1, s2);
     }
 
@@ -34,7 +32,6 @@ public class TesterFastHttpDateFormat {
         }
         now = System.currentTimeMillis();
         String s1 = FastHttpDateFormat.getCurrentDate();
-        System.out.println("1st:" + System.currentTimeMillis() + ", " + s1);
         long firstMillisOfNextSecond = now - now % 1000 + 1100L;
         try {
             Thread.sleep(firstMillisOfNextSecond - now);
@@ -42,7 +39,6 @@ public class TesterFastHttpDateFormat {
         }
 
         String s2 = FastHttpDateFormat.getCurrentDate();
-        System.out.println("2nd:" + System.currentTimeMillis() + ", " + s2);
         Assert.assertFalse("Two different RFC5322 format dates are expected.", s1.equals(s2));
     }
 }

--- a/test/org/apache/tomcat/util/http/TesterFastHttpDateFormat.java
+++ b/test/org/apache/tomcat/util/http/TesterFastHttpDateFormat.java
@@ -1,0 +1,48 @@
+package org.apache.tomcat.util.http;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TesterFastHttpDateFormat {
+    @Test
+    public void testGetCurrentDateInSameSecond() {
+        long now = System.currentTimeMillis();
+        try {
+            Thread.sleep(1000L - now % 1000);
+        } catch (InterruptedException e) {
+        }
+        now = System.currentTimeMillis();
+        String s1 = FastHttpDateFormat.getCurrentDate();
+        System.out.println("1st:" + System.currentTimeMillis() + ", " + s1);
+        long lastMillisInSameSecond = now - now % 1000 + 900L;
+        try {
+            Thread.sleep(lastMillisInSameSecond - now);
+        } catch (InterruptedException e) {
+        }
+        String s2 = FastHttpDateFormat.getCurrentDate();
+        System.out.println("2nd:" + System.currentTimeMillis() + ", " + s2);
+        Assert.assertEquals("Two same RFC5322 format dates are expected.", s1, s2);
+    }
+
+    @Test
+    public void testGetCurrentDateNextToAnotherSecond() {
+        long now = System.currentTimeMillis();
+
+        try {
+            Thread.sleep(2000L - now % 1000 + 500L);
+        } catch (InterruptedException e) {
+        }
+        now = System.currentTimeMillis();
+        String s1 = FastHttpDateFormat.getCurrentDate();
+        System.out.println("1st:" + System.currentTimeMillis() + ", " + s1);
+        long firstMillisOfNextSecond = now - now % 1000 + 1100L;
+        try {
+            Thread.sleep(firstMillisOfNextSecond - now);
+        } catch (InterruptedException e) {
+        }
+
+        String s2 = FastHttpDateFormat.getCurrentDate();
+        System.out.println("2nd:" + System.currentTimeMillis() + ", " + s2);
+        Assert.assertFalse("Two different RFC5322 format dates are expected.", s1.equals(s2));
+    }
+}


### PR DESCRIPTION
FastHttpDateFormat#getCurrentDate() returns same string for two different second datetime.
For following date:

1st:1726041009036, Wed, 11 Sep 2024 07:50:09 GMT
2nd:1726041009940, Wed, 11 Sep 2024 07:50:09 GMT

1st:1726041011501, Wed, 11 Sep 2024 07:50:11 GMT
***2nd:1726041012101, Wed, 11 Sep 2024 07:50:11 GMT*** --it is incorrect.

Fix: check whether cached date and current date are in same second.