### PR TITLE
Add ParameterLimitValve to enforce request parameter limits for specific URLs

### DIFF
--- a/java/org/apache/catalina/valves/LocalStrings.properties
+++ b/java/org/apache/catalina/valves/LocalStrings.properties
@@ -171,3 +171,5 @@ stuckThreadDetectionValve.interrupted=Thread interrupted after the request is fi
 stuckThreadDetectionValve.notifyStuckThreadCompleted=Thread [{0}] (id=[{3}]) was previously reported to be stuck but has completed. It was active for approximately [{1}] milliseconds.{2,choice,0#|0< There is/are still [{2}] thread(s) that are monitored by this Valve and may be stuck.}
 stuckThreadDetectionValve.notifyStuckThreadDetected=Thread [{0}] (id=[{6}]) has been active for [{1}] milliseconds (since [{2}]) to serve the same request for [{4}] and may be stuck (configured threshold for this StuckThreadDetectionValve is [{5}] seconds). There is/are [{3}] thread(s) in total that are monitored by this Valve and may be stuck.
 stuckThreadDetectionValve.notifyStuckThreadInterrupted=Thread [{0}] (id=[{5}]) has been interrupted because it was active for [{1}] milliseconds (since [{2}]) to serve the same request for [{3}] and was probably stuck (configured interruption threshold for this StuckThreadDetectionValve is [{4}] seconds).
+
+parameterLimitValve.parameterLimitExceeded=Too many parameters for this URL: [{0}]

--- a/java/org/apache/catalina/valves/ParameterLimitValve.java
+++ b/java/org/apache/catalina/valves/ParameterLimitValve.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.catalina.valves;
+
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import jakarta.servlet.ServletException;
+
+import org.apache.catalina.connector.Request;
+import org.apache.catalina.connector.Response;
+
+
+/**
+ * This is a concrete implementation of {@link ValveBase} that enforces a limit on the number of HTTP request parameters
+ * allowed in POST requests. The features of this implementation include:
+ * <ul>
+ * <li>Global parameter limit that applies to all requests</li>
+ * <li>URL-specific parameter limits that can be defined using regular expressions</li>
+ * <li>Configurable through Tomcat's <code>server.xml</code> or <code>context.xml</code></li>
+ * </ul>
+ * <p>
+ * The global limit, specified by <code>maxGlobalParams</code>, applies to all requests unless a more specific
+ * URL pattern is matched. URL patterns and their corresponding limits can be configured via a regular expression
+ * mapping through the <code>urlPatternLimits</code> attribute.
+ * </p>
+ * <p>
+ * The Valve checks each incoming request and enforces the appropriate limit. If a request exceeds the allowed number
+ * of parameters, it returns a <code>400 Bad Request</code> response with a descriptive error message.
+ * </p>
+ * <p>
+ * Example configuration in <code>context.xml</code>:
+ * <pre>
+ * {@code
+ * <Context>
+ *     <Valve className="org.apache.catalina.valves.ParameterLimitValve"
+ *            maxGlobalParams="100"
+ *            urlPatternLimits="/api/.*=150,/admin/.*=50" />
+ * </Context>
+ * }
+ * </pre>
+ * <p>
+ * The configuration allows for flexible control over different sections of your application, such as applying higher
+ * limits for API endpoints and stricter limits for admin areas.
+ * </p>
+ *
+ * @author Dimitris Soumis
+ */
+
+public class ParameterLimitValve extends ValveBase {
+
+    /**
+     * Default global limit
+     */
+    private int maxGlobalParams = 1000;
+
+    /**
+     * Map for URL-specific limits
+     */
+    private final Map<Pattern, Integer> urlPatternLimits = new HashMap<>();
+
+    /**
+     * Set the global limit for the maximum number of request parameters allowed for any URL that does not match
+     * a specific URL pattern.
+     *
+     * @param maxGlobalParams The maximum number of parameters allowed globally
+     */
+
+    public void setMaxGlobalParams(int maxGlobalParams) {
+        if (maxGlobalParams > 0) {
+            this.maxGlobalParams = maxGlobalParams;
+        }
+    }
+
+    /**
+     * Set the mapping of URL patterns to their corresponding parameter limits. The format of the input string should
+     * be a comma-separated list of URL pattern and parameter limit pairs, where the pattern is a regular expression.
+     * <p>
+     * Example: <code>/api/.*=150,/admin/.*=50</code>
+     *
+     * @param urlPatternConfig A string containing URL pattern to parameter limit mappings, in the format "pattern=limit"
+     */
+
+    public void setUrlPatternLimits(String urlPatternConfig) {
+        String[] urlLimitPairs = urlPatternConfig.split(",");
+        for (String pair : urlLimitPairs) {
+            String[] urlLimit = pair.split("=");
+            Pattern pattern = Pattern.compile(urlLimit[0]);
+            int limit = Integer.parseInt(urlLimit[1]);
+            urlPatternLimits.put(pattern, Integer.valueOf(limit));
+        }
+    }
+
+    /**
+     * Invoke the next Valve in the sequence. Before invoking, check the number of parameters
+     * in the request. If the number exceeds the configured limits (either global or specific
+     * to a URL pattern), the request will be rejected with an HTTP 400 Bad Request error.
+     * If the request does not exceed the limits, it will be passed to the next Valve in the sequence.
+     *
+     * @param request  The servlet request to be processed
+     * @param response The servlet response to be created
+     *
+     * @exception IOException      if an input/output error occurs
+     * @exception ServletException if a servlet error occurs
+     */
+    @Override
+    public void invoke(Request request, Response response) throws IOException, ServletException {
+        String requestURI = request.getRequestURI();
+        Map<String, String[]> parameters = request.getParameterMap();
+        boolean matched = false;
+
+        // Iterate over the URL patterns and apply corresponding limits
+        for (Map.Entry<Pattern, Integer> entry : urlPatternLimits.entrySet()) {
+            Pattern pattern = entry.getKey();
+            int limit = entry.getValue().intValue();
+
+            if (pattern.matcher(requestURI).matches()) {
+                matched = true;
+                if (parameters.size() > limit) {
+                    response.sendError(Response.SC_BAD_REQUEST, sm.getString("parameterLimitValve.parameterLimitExceeded", requestURI));
+                    return;
+                }
+                break;
+            }
+        }
+
+        // If no URL pattern matched, apply the global parameter limit
+        if (!matched && parameters.size() > maxGlobalParams) {
+            response.sendError(Response.SC_BAD_REQUEST, sm.getString("parameterLimitValve.parameterLimitExceeded", requestURI));
+            return;
+        }
+
+        // Continue processing the request
+        getNext().invoke(request, response);
+    }
+}

--- a/test/org/apache/catalina/valves/TestParameterLimitValve.java
+++ b/test/org/apache/catalina/valves/TestParameterLimitValve.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.catalina.valves;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.servlet.ServletException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.catalina.connector.Request;
+import org.apache.catalina.connector.Response;
+import org.easymock.EasyMock;
+
+public class TestParameterLimitValve {
+
+    private ParameterLimitValve valve;
+    private Request request;
+    private Response response;
+    private ValveBase next;
+
+    @Before
+    public void setUp() {
+        valve = new ParameterLimitValve();
+        request = EasyMock.createMock(Request.class);
+        response = EasyMock.createMock(Response.class);
+        next = EasyMock.createMock(ValveBase.class);
+        valve.setNext(next);
+    }
+
+    @Test
+    public void testGlobalParameterLimitExceeded() throws IOException, ServletException {
+        valve.setMaxGlobalParams(2);
+
+        Map<String, String[]> parameters = new HashMap<>();
+        parameters.put("param1", new String[]{"value1"});
+        parameters.put("param2", new String[]{"value2"});
+        parameters.put("param3", new String[]{"value3"});
+
+        EasyMock.expect(request.getRequestURI()).andReturn("/some/uri");
+        EasyMock.expect(request.getParameterMap()).andReturn(parameters);
+        response.sendError(Response.SC_BAD_REQUEST, "Too many parameters for this URL: [/some/uri]");
+        EasyMock.expectLastCall();
+
+        EasyMock.replay(request, response);
+
+        valve.invoke(request, response);
+
+        EasyMock.verify(request, response);
+    }
+
+    @Test
+    public void testGlobalParameterLimitNotExceeded() throws IOException, ServletException {
+        valve.setMaxGlobalParams(3);
+
+        Map<String, String[]> parameters = new HashMap<>();
+        parameters.put("param1", new String[]{"value1"});
+        parameters.put("param2", new String[]{"value2"});
+
+        EasyMock.expect(request.getRequestURI()).andReturn("/some/uri");
+        EasyMock.expect(request.getParameterMap()).andReturn(parameters);
+        next.invoke(request, response);
+        EasyMock.expectLastCall();
+
+        EasyMock.replay(request, response, next);
+
+        valve.invoke(request, response);
+
+        EasyMock.verify(request, response, next);
+    }
+
+    @Test
+    public void testSpecificUrlPatternLimitExceeded() throws IOException, ServletException {
+        valve.setMaxGlobalParams(100);
+        valve.setUrlPatternLimits("/special/.*=2");
+
+        Map<String, String[]> parameters = new HashMap<>();
+        parameters.put("param1", new String[]{"value1"});
+        parameters.put("param2", new String[]{"value2"});
+        parameters.put("param3", new String[]{"value3"});
+
+        EasyMock.expect(request.getRequestURI()).andReturn("/special/endpoint");
+        EasyMock.expect(request.getParameterMap()).andReturn(parameters);
+        response.sendError(Response.SC_BAD_REQUEST, "Too many parameters for this URL: [/special/endpoint]");
+        EasyMock.expectLastCall();
+
+        EasyMock.replay(request, response);
+
+        valve.invoke(request, response);
+
+        EasyMock.verify(request, response);
+    }
+
+    @Test
+    public void testSpecificUrlPatternLimitNotExceeded() throws IOException, ServletException {
+        valve.setMaxGlobalParams(100);
+        valve.setUrlPatternLimits("/special/.*=3");
+
+        Map<String, String[]> parameters = new HashMap<>();
+        parameters.put("param1", new String[]{"value1"});
+        parameters.put("param2", new String[]{"value2"});
+
+        EasyMock.expect(request.getRequestURI()).andReturn("/special/endpoint");
+        EasyMock.expect(request.getParameterMap()).andReturn(parameters);
+        next.invoke(request, response);
+        EasyMock.expectLastCall();
+
+        EasyMock.replay(request, response, next);
+
+        valve.invoke(request, response);
+
+        EasyMock.verify(request, response, next);
+    }
+
+    @Test
+    public void testNoMatchingPatternWithGlobalLimit() throws IOException, ServletException {
+        valve.setMaxGlobalParams(2);
+
+        Map<String, String[]> parameters = new HashMap<>();
+        parameters.put("param1", new String[]{"value1"});
+        parameters.put("param2", new String[]{"value2"});
+
+        EasyMock.expect(request.getRequestURI()).andReturn("/other/endpoint");
+        EasyMock.expect(request.getParameterMap()).andReturn(parameters);
+        next.invoke(request, response);
+        EasyMock.expectLastCall();
+
+        EasyMock.replay(request, response, next);
+
+        valve.invoke(request, response);
+
+        EasyMock.verify(request, response, next);
+    }
+
+    @Test
+    public void testEmptyParameters() throws IOException, ServletException {
+        valve.setMaxGlobalParams(2);
+
+        Map<String, String[]> parameters = new HashMap<>();
+
+        EasyMock.expect(request.getRequestURI()).andReturn("/other/endpoint");
+        EasyMock.expect(request.getParameterMap()).andReturn(parameters);
+        next.invoke(request, response);
+        EasyMock.expectLastCall();
+
+        EasyMock.replay(request, response, next);
+
+        valve.invoke(request, response);
+
+        EasyMock.verify(request, response, next);
+    }
+}

--- a/webapps/docs/config/valve.xml
+++ b/webapps/docs/config/valve.xml
@@ -2672,6 +2672,51 @@
 
 </section>
 
+<section name="Parameter Limit Valve">
+
+  <subsection name="Introduction">
+
+    <p>The <strong>Parameter Limit Valve</strong> is used to limit the number of parameters allowed in HTTP requests.
+    The valve can be configured with a global parameter limit, which applies to all requests,
+    and specific limits for certain URL patterns.
+    Requests exceeding the defined parameter limits will result in an HTTP 400 Bad Request error.</p>
+
+  </subsection>
+
+  <subsection name="Attributes">
+
+    <p>The <strong>Parameter Limit Valve</strong> supports the following
+    configuration attributes:</p>
+
+    <attributes>
+
+      <attribute name="className" required="true">
+        <p>Java class name of the implementation to use.  This MUST be set to
+        <strong>org.apache.catalina.valves.ParameterLimitValve</strong>.</p>
+      </attribute>
+
+      <attribute name="maxGlobalParams" required="false">
+        <p>The maximum number of parameters allowed in any HTTP request.
+        If the number of parameters in a request exceeds this limit,
+        the request will be rejected with an HTTP 400 error.
+        The value must be an integer greater than zero.
+        Default value: <code>1000</code></p>
+      </attribute>
+
+      <attribute name="urlPatternLimits" required="false">
+        <p>A comma-separated list of URL patterns and their respective parameter limits.
+        Each entry should follow the format <code>urlPattern=limit</code>.
+        The valve will apply the limit defined for a URL pattern when a request matches that pattern.
+        If no pattern matches, the global limit will be used.
+        For example: <code>/api/.*=100,/admin/.*=50</code>.</p>
+      </attribute>
+
+    </attributes>
+
+  </subsection>
+
+</section>
+
 </body>
 
 


### PR DESCRIPTION
This is an effort of introducing Parameter Limit Valve to allow limiting the number of parameters in HTTP requests, but explicitly allowing more parameters for specific URLs.

It's worth to be noted that if the Parameter Limit Valve is configured, it operates independently of the Connector's maxParameterCount attribute. The Connector's maxParameterCount sets a global limit, while the Parameter Limit Valve offers additional flexibility by allowing different limits for specific URLs. However, if the maxParameterCount defined in the Connector is lower, it effectively overrides the valve by preventing large requests from ever reaching it.