### PR TITLE
Fix: evict cached MBean when bean descriptor content changed to ensure ManagedBean#getMBeanInfo result is correct.

### DIFF
--- a/java/org/apache/tomcat/util/modeler/AttributeInfo.java
+++ b/java/org/apache/tomcat/util/modeler/AttributeInfo.java
@@ -120,19 +120,10 @@ public class AttributeInfo extends FeatureInfo {
 
     // --------------------------------------------------------- Public Methods
 
-
-    /**
-     * Create and return a <code>ModelMBeanAttributeInfo</code> object that
-     * corresponds to the attribute described by this instance.
-     * @return the attribute info
-     */
-    MBeanAttributeInfo createAttributeInfo() {
-        // Return our cached information (if any)
-        if (info == null) {
-            info = new MBeanAttributeInfo(getName(), getType(), getDescription(),
-                            isReadable(), isWriteable(), false);
-        }
-        return (MBeanAttributeInfo)info;
+    @Override
+    protected MBeanAttributeInfo buildMBeanInfo() {
+        return new MBeanAttributeInfo(getName(), getType(), getDescription(),
+                isReadable(), isWriteable(), false);
     }
 
     // -------------------------------------------------------- Private Methods
@@ -162,6 +153,4 @@ public class AttributeInfo extends FeatureInfo {
         sb.append(name.substring(1));
         return sb.toString();
     }
-
-
 }

--- a/java/org/apache/tomcat/util/modeler/BaseAttributeFilter.java
+++ b/java/org/apache/tomcat/util/modeler/BaseAttributeFilter.java
@@ -136,7 +136,7 @@ public class BaseAttributeFilter implements NotificationFilter {
             return false;
         }
         synchronized (names) {
-            if (names.size() < 1) {
+            if (names.isEmpty()) {
                 return true;
             } else {
                 return names.contains(acn.getAttributeName());

--- a/java/org/apache/tomcat/util/modeler/FeatureInfo.java
+++ b/java/org/apache/tomcat/util/modeler/FeatureInfo.java
@@ -23,18 +23,17 @@ import javax.management.MBeanFeatureInfo;
 
 
 /**
- * <p>Convenience base class for <code>AttributeInfo</code> and
- * <code>OperationInfo</code> classes that will be used to collect configuration
+ * <p>Convenience base class that will be used to collect configuration
  * information for the <code>ModelMBean</code> beans exposed for management.</p>
- *
+ * <p>The feature described can be an attribute, an operation, a
+ * parameter, or a notification.
  * @author Craig R. McClanahan
  */
-public class FeatureInfo implements Serializable {
+public abstract class FeatureInfo implements Serializable {
     private static final long serialVersionUID = -911529176124712296L;
 
     protected String description = null;
     protected String name = null;
-    protected MBeanFeatureInfo info = null;
 
     // all have type except Constructor
     protected String type = null;
@@ -51,6 +50,7 @@ public class FeatureInfo implements Serializable {
 
     public void setDescription(String description) {
         this.description = description;
+        afterNodeChanged();
     }
 
 
@@ -64,6 +64,7 @@ public class FeatureInfo implements Serializable {
 
     public void setName(String name) {
         this.name = name;
+        afterNodeChanged();
     }
 
     /**
@@ -75,7 +76,35 @@ public class FeatureInfo implements Serializable {
 
     public void setType(String type) {
         this.type = type;
+        afterNodeChanged();
     }
 
+    /**
+     * Always builds a new instance of concrete {@link MBeanFeatureInfo} describes current {@link FeatureInfo} object.
+     * @return instance of {@link MBeanFeatureInfo}, describes current concrete {@link FeatureInfo} object.
+     */
+    protected abstract MBeanFeatureInfo buildMBeanInfo();
+    
+    private transient MBeanFeatureInfo infoCache = null;
 
+    /**
+     * Retrieves the latest MBean exposed management purpose.
+     * 
+     * @return latest mbean exposed for management, from cache if exists.
+     */
+    protected final MBeanFeatureInfo getLatestMBeanInfo() {
+        if (infoCache == null) {
+            infoCache = buildMBeanInfo();
+        }
+        return infoCache;
+    }
+    
+    /**
+     * Callback when {@link FeatureInfo} node change occurs.
+     * 
+     */
+    protected void afterNodeChanged() {
+        // clear MBean info cache.
+        infoCache = null;
+    }
 }

--- a/java/org/apache/tomcat/util/modeler/ManagedBean.java
+++ b/java/org/apache/tomcat/util/modeler/ManagedBean.java
@@ -19,13 +19,10 @@ package org.apache.tomcat.util.modeler;
 
 import java.lang.reflect.Method;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.management.AttributeNotFoundException;
 import javax.management.DynamicMBean;
@@ -33,7 +30,6 @@ import javax.management.InstanceNotFoundException;
 import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanConstructorInfo;
 import javax.management.MBeanException;
-import javax.management.MBeanFeatureInfo;
 import javax.management.MBeanInfo;
 import javax.management.MBeanNotificationInfo;
 import javax.management.MBeanOperationInfo;

--- a/java/org/apache/tomcat/util/modeler/OperationInfo.java
+++ b/java/org/apache/tomcat/util/modeler/OperationInfo.java
@@ -21,10 +21,7 @@ import java.util.Locale;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import javax.management.MBeanFeatureInfo;
 import javax.management.MBeanOperationInfo;
 import javax.management.MBeanParameterInfo;
 

--- a/java/org/apache/tomcat/util/modeler/ParameterInfo.java
+++ b/java/org/apache/tomcat/util/modeler/ParameterInfo.java
@@ -16,7 +16,6 @@
  */
 package org.apache.tomcat.util.modeler;
 
-
 import javax.management.MBeanParameterInfo;
 
 
@@ -37,19 +36,10 @@ public class ParameterInfo extends FeatureInfo {
     public ParameterInfo() {
         super();
     }
-
-    /**
-     * Create and return a <code>MBeanParameterInfo</code> object that
-     * corresponds to the parameter described by this instance.
-     * @return a parameter info
-     */
-    public MBeanParameterInfo createParameterInfo() {
-
-        // Return our cached information (if any)
-        if (info == null) {
-            info = new MBeanParameterInfo
+    
+    @Override
+    protected MBeanParameterInfo buildMBeanInfo() {
+        return new MBeanParameterInfo
                 (getName(), getType(), getDescription());
-        }
-        return (MBeanParameterInfo)info;
     }
 }

--- a/test/org/apache/tomcat/util/modeler/TestManagedBean.java
+++ b/test/org/apache/tomcat/util/modeler/TestManagedBean.java
@@ -1,0 +1,89 @@
+package org.apache.tomcat.util.modeler;
+
+import java.util.stream.Stream;
+
+import javax.management.MBeanInfo;
+
+import org.apache.coyote.Response;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestManagedBean {
+    private ManagedBean managedBean = null;
+
+    @Before
+    public void setUp() throws Exception {
+        managedBean = new ManagedBean();
+
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void testGetMBeanInfo() {
+
+        MBeanInfo mbeanInfo = managedBean.getMBeanInfo();
+        Assert.assertTrue(Stream.of(mbeanInfo.getAttributes()).filter(m -> m.getType().equals(Response.class.getName()))
+                .count() == 0);
+        Assert.assertTrue(Stream.of(mbeanInfo.getOperations()).count() == 0);
+        Assert.assertTrue(Stream.of(mbeanInfo.getNotifications()).count() == 0);
+
+        AttributeInfo attr = new AttributeInfo();
+        attr.setGetMethod("getResponse");
+        attr.setName("response");
+        attr.setReadable(true);
+        attr.setWriteable(false);
+        attr.setType(Response.class.getName());
+        managedBean.addAttribute(attr);
+        mbeanInfo = managedBean.getMBeanInfo();
+        Assert.assertEquals(1,
+                Stream.of(mbeanInfo.getAttributes()).filter(m -> m.getType().equals(Response.class.getName())).count());
+
+        OperationInfo op = new OperationInfo();
+        op.setImpact("info");
+        op.setType("getter");
+        op.setReturnType(Response.class.getName());
+        op.setName("getResponse");
+        managedBean.addOperation(op);
+
+        op = new OperationInfo();
+        op.setImpact("action");
+        op.setType("setter");
+        op.setReturnType(Void.TYPE.getName());
+        op.setName("setResponse");
+        managedBean.addOperation(op);
+        mbeanInfo = managedBean.getMBeanInfo();
+        Assert.assertEquals("attr: response expected.", 1,
+                Stream.of(mbeanInfo.getAttributes()).filter(m -> m.getType().equals(Response.class.getName())).count());
+        Assert.assertEquals("ops: getResponse expected.", 1,
+                Stream.of(mbeanInfo.getOperations()).filter(
+                        m -> Response.class.getName().equals(m.getReturnType()) && "getResponse".equals(m.getName()))
+                        .count());
+        Assert.assertEquals("ops: setResponse expected.", 1,
+                Stream.of(mbeanInfo.getOperations())
+                        .filter(m -> Void.TYPE.getName().equals(m.getReturnType()) && "setResponse".equals(m.getName()))
+                        .count());
+
+        NotificationInfo notify = new NotificationInfo();
+        notify.setName("NotifyOfTomcat");
+        managedBean.addNotification(notify);
+        mbeanInfo = managedBean.getMBeanInfo();
+        Assert.assertEquals("attr: response expected.", 1,
+                Stream.of(mbeanInfo.getAttributes()).filter(m -> m.getType().equals(Response.class.getName())).count());
+        Assert.assertEquals("ops: getResponse expected.", 1,
+                Stream.of(mbeanInfo.getOperations()).filter(
+                        m -> Response.class.getName().equals(m.getReturnType()) && "getResponse".equals(m.getName()))
+                        .count());
+        Assert.assertEquals("ops: setResponse expected.", 1,
+                Stream.of(mbeanInfo.getOperations())
+                        .filter(m -> Void.TYPE.getName().equals(m.getReturnType()) && "setResponse".equals(m.getName()))
+                        .count());
+        Assert.assertEquals("notify: NotifyOfTomcat expected", 1,
+                Stream.of(mbeanInfo.getNotifications()).filter(m -> "NotifyOfTomcat".equals(m.getName())).count());
+    }
+
+}

--- a/test/org/apache/tomcat/util/modeler/TestOperationInfo.java
+++ b/test/org/apache/tomcat/util/modeler/TestOperationInfo.java
@@ -1,0 +1,99 @@
+package org.apache.tomcat.util.modeler;
+
+import javax.management.MBeanOperationInfo;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestOperationInfo {
+
+    private OperationInfo operationInfo = null;
+
+    @Before
+    public void setUp() throws Exception {
+        operationInfo = new OperationInfo();
+        operationInfo.setDescription("DescOfOperation");
+        operationInfo.setImpact("Unknow");
+        operationInfo.setName("NameOfOperation");
+        operationInfo.setReturnType("ReturnTypeUnkown");
+        operationInfo.setRole("UntrustedRole");
+        operationInfo.setType("Operation");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void testSetImpact() {
+        operationInfo.setImpact("Unkown");
+        MBeanOperationInfo operationBean = (MBeanOperationInfo) operationInfo.getLatestMBeanInfo();
+        Assert.assertEquals("Unkown".toUpperCase(), operationInfo.getImpact());
+        Assert.assertEquals(MBeanOperationInfo.UNKNOWN, operationBean.getImpact());
+
+        operationInfo.setImpact("ACTION");
+        operationBean = (MBeanOperationInfo) operationInfo.getLatestMBeanInfo();
+        Assert.assertEquals("ACTION", operationInfo.getImpact());
+        Assert.assertEquals(MBeanOperationInfo.ACTION, operationBean.getImpact());
+
+        operationInfo.setImpact("ACTION_INFO");
+        operationBean = (MBeanOperationInfo) operationInfo.getLatestMBeanInfo();
+        Assert.assertEquals("ACTION_INFO", operationInfo.getImpact());
+        Assert.assertEquals(MBeanOperationInfo.ACTION_INFO, operationBean.getImpact());
+
+        operationInfo.setImpact("INFO");
+        operationBean = (MBeanOperationInfo) operationInfo.getLatestMBeanInfo();
+        Assert.assertEquals("INFO", operationInfo.getImpact());
+        Assert.assertEquals(MBeanOperationInfo.INFO, operationBean.getImpact());
+
+        operationInfo.setImpact("info");
+        operationBean = (MBeanOperationInfo) operationInfo.getLatestMBeanInfo();
+        Assert.assertEquals("info".toUpperCase(), operationInfo.getImpact());
+        Assert.assertEquals(MBeanOperationInfo.INFO, operationBean.getImpact());
+
+        operationInfo.setImpact(null);
+        operationBean = (MBeanOperationInfo) operationInfo.getLatestMBeanInfo();
+        Assert.assertEquals(null, operationInfo.getImpact());
+        Assert.assertEquals(MBeanOperationInfo.UNKNOWN, operationBean.getImpact());
+
+    }
+
+    @Test
+    public void testSetRole() {
+        operationInfo.setRole("UntrustedRole");
+        Assert.assertEquals("UntrustedRole", operationInfo.getRole());
+
+        operationInfo.setRole("getter");
+        Assert.assertEquals("getter", operationInfo.getRole());
+
+        operationInfo.setRole("constructor");
+        Assert.assertEquals("constructor", operationInfo.getRole());
+    }
+
+    @Test
+    public void testSetReturnType() {
+        operationInfo.setReturnType(String.class.getName());
+        MBeanOperationInfo operationBean = (MBeanOperationInfo) operationInfo.getLatestMBeanInfo();
+        Assert.assertEquals(String.class.getName(), operationInfo.getReturnType());
+        Assert.assertEquals(String.class.getName(), operationBean.getReturnType());
+
+        operationInfo.setReturnType(Void.TYPE.getName());
+        operationBean = (MBeanOperationInfo) operationInfo.getLatestMBeanInfo();
+        Assert.assertEquals(Void.TYPE.getName(), operationInfo.getReturnType());
+        Assert.assertEquals(Void.TYPE.getName(), operationBean.getReturnType());
+
+        operationInfo.setReturnType(TestOperationInfo.class.getName());
+        operationBean = (MBeanOperationInfo) operationInfo.getLatestMBeanInfo();
+        Assert.assertEquals(TestOperationInfo.class.getName(), operationInfo.getReturnType());
+        Assert.assertEquals(TestOperationInfo.class.getName(), operationBean.getReturnType());
+
+        operationInfo.setReturnType(null);
+        operationBean = (MBeanOperationInfo) operationInfo.getLatestMBeanInfo();
+        Assert.assertEquals("void", operationInfo.getReturnType());
+        Assert.assertEquals("void", operationBean.getReturnType());
+
+    }
+
+}


### PR DESCRIPTION
1. ensure evict cache for each modification like returnType, name, desc, addAttribute etc. 
2. code refactoring.
3. testcase added.