### PR TITLE
Unit test ensuring that the Expires and Date headers use GMT

### DIFF
--- a/test/org/apache/catalina/authenticator/TestFormAuthenticatorA.java
+++ b/test/org/apache/catalina/authenticator/TestFormAuthenticatorA.java
@@ -18,8 +18,12 @@ package org.apache.catalina.authenticator;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.StringTokenizer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
@@ -40,6 +44,7 @@ import org.apache.tomcat.util.descriptor.web.LoginConfig;
 import org.apache.tomcat.util.descriptor.web.SecurityCollection;
 import org.apache.tomcat.util.descriptor.web.SecurityConstraint;
 import org.apache.tomcat.websocket.server.WsContextListener;
+import org.apache.tomcat.util.buf.ByteChunk;
 
 /*
  * Test FORM authentication for sessions that do and do not use cookies.
@@ -213,6 +218,38 @@ public class TestFormAuthenticatorA extends TomcatBaseTest {
 
         Assert.assertTrue(!originalSessionId.equals(newSessionId));
         client.reset();
+    }
+
+
+    /*
+     * Test to ensure that the Expir and 
+     */
+    @Test
+    public void testDateAndExpireHeadersUseGMT() throws Exception {
+        Tomcat tomcat = getTomcatInstance();
+
+        File appDir = new File(getBuildDirectory(), "webapps/examples");
+        Context ctxt  = tomcat.addWebapp(null, "/examples", appDir.getAbsolutePath());
+        FormAuthenticator form = new FormAuthenticator();
+        form.setSecurePagesWithPragma(true);
+        ctxt.getPipeline().addValve(form);
+        tomcat.start();
+
+        Map<String,List<String>> responseHeaders = new HashMap();
+        ByteChunk bc = new ByteChunk();
+        String path = "http://localhost:" + getPort() + "/examples/jsp/security/protected/index.jsp";
+        int rc = getUrl(path, bc, responseHeaders);
+        Assert.assertTrue(String.format("Expecting 200, but got ", rc), rc == 200);
+        String expiresDate = responseHeaders.get("Expires").get(0).toString();
+
+        String ExpectedDateFormatRegx = "^[A-za-z]{3}, \\d{2} \\w{3} \\d{4} \\d{2}:\\d{2}:\\d{2} GMT$";
+        Pattern pattern = Pattern.compile(ExpectedDateFormatRegx);
+        Matcher matcher = pattern.matcher((CharSequence)expiresDate);
+        Assert.assertTrue("Expires header date not in expected format", matcher.matches());
+
+        String Date = responseHeaders.get("Date").get(0).toString();
+        matcher = pattern.matcher((CharSequence)Date);
+        Assert.assertTrue("Date header not in expected format", matcher.matches());
     }
 
 


### PR DESCRIPTION
This Unit test makes sure that the expires and date headers are consistent and both use GMT, as per the bug report https://bz.apache.org/bugzilla/show_bug.cgi?id=62476