### PR TITLE
BZ69355: RateLimitFilter2 with FixedWindowRateLimiter

### DIFF
--- a/java/org/apache/catalina/filters/LocalStrings_zh_CN.properties
+++ b/java/org/apache/catalina/filters/LocalStrings_zh_CN.properties
@@ -53,6 +53,7 @@ httpHeaderSecurityFilter.clickjack.invalid=为防点击挟持的响应消息头�
 httpHeaderSecurityFilter.committed=在进入HttpHeaderSecurityFilter的时候响应消息已经提交导致不能添加响应消息头
 
 rateLimitFilter.initialized=RateLimitFilter [{0}] 初始值是每 [{2}] 秒 [{1}] 个请求。实际值是每 [{4}] 秒 [{3}]。 [{5}]。
+rateLimitFilter.maxRequestsExceeded=[{0}] 来自于 [{2}] 的请求数 [{1}] 已超过阈值每 [{4}] 秒 [{3}] 。
 
 remoteCidrFilter.invalid=为[{0}]提供的配置无效。有关详细信息，请参阅以前的消息。
 remoteCidrFilter.noRemoteIp=客户端没有 IP 地址，请求被拒绝。

--- a/java/org/apache/catalina/filters/RateLimitFilter2.java
+++ b/java/org/apache/catalina/filters/RateLimitFilter2.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.catalina.filters;
+
+import java.io.IOException;
+import java.util.concurrent.ScheduledExecutorService;
+
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.GenericFilter;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.catalina.util.FixedWindowRateLimiter;
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
+import org.apache.tomcat.util.res.StringManager;
+import org.apache.tomcat.util.threads.ScheduledThreadPoolExecutor;
+
+/**
+ * <p>
+ * Servlet filter that can help mitigate Denial of Service (DoS) and Brute Force attacks by limiting the number of a
+ * requests that are allowed from a single IP address within a time window (also referred to as a time bucket), e.g. 300
+ * Requests per 60 seconds.
+ * </p>
+ * <p>
+ * The filter works by incrementing a counter in a time bucket for each IP address, and if the counter exceeds the
+ * allowed limit then further requests from that IP are dropped with a &quot;429 Too many requests&quot; response until
+ * the bucket time ends and a new bucket starts.
+ * </p>
+ * <p>
+ * The {@link RateLimitFilter2} provides an exact request limiter via {@link FixedWindowRateLimiter}. For example, a
+ * configuration of 100 Requests per 60 seconds, has the real exact values of 100 Requests per 60 seconds.
+ * </p>
+ * <p>
+ * <strong>Accuracy</strong> of request limitation control is the most important feature comparing with previous
+ * {@link RateLimitFilter}.
+ * </p>
+ * <p>
+ * It is common to set up different restrictions for different URIs. For example, a login page or authentication script
+ * is typically expected to get far less requests than the rest of the application, so you can add a filter definition
+ * that would allow only 5 requests per 15 seconds and map those URIs to it.
+ * </p>
+ * <p>
+ * You can set <code>enforce</code> to <code>false</code> to disable the termination of requests that exceed the allowed
+ * limit. Then your application code can inspect the Request Attribute
+ * <code>org.apache.catalina.filters.RateLimitFilter.Count</code> and decide how to handle the request based on other
+ * information that it has, e.g. allow more requests to certain users based on roles, etc.
+ * </p>
+ * <p>
+ * <strong>WARNING:</strong> if Tomcat is behind a reverse proxy then you must make sure that the Rate Limit Filter sees
+ * the client IP address, so if for example you are using the <a href="#Remote_IP_Filter">Remote IP Filter</a>, then the
+ * filter mapping for the Rate Limit Filter must come <em>after</em> the mapping of the Remote IP Filter to ensure that
+ * each request has its IP address resolved before the Rate Limit Filter is applied. Failure to do so will count
+ * requests from different IPs in the same bucket and will result in a self inflicted DoS attack.
+ * </p>
+ * 
+ * @author Chenjp
+ */
+public class RateLimitFilter2 extends GenericFilter {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * default duration in seconds
+     */
+    public static final int DEFAULT_BUCKET_DURATION = 60;
+
+    /**
+     * default number of requests per duration
+     */
+    public static final int DEFAULT_BUCKET_REQUESTS = 300;
+
+    /**
+     * default value for enforce
+     */
+    public static final boolean DEFAULT_ENFORCE = true;
+
+    /**
+     * default enable expose rate limit information response headers
+     */
+    public static final boolean DEFAULT_EXPOSE_HEADERS = true;
+
+    /**
+     * default status code to return if requests per duration exceeded
+     */
+    public static final int DEFAULT_STATUS_CODE = 429;
+
+    /**
+     * default status message to return if requests per duration exceeded
+     */
+    public static final String DEFAULT_STATUS_MESSAGE = "Too many requests";
+
+    /**
+     * request attribute that will contain the number of requests per duration
+     */
+    public static final String RATE_LIMIT_ATTRIBUTE_COUNT = "org.apache.catalina.filters.RateLimitFilter.Count";
+
+    /**
+     * init-param to set the bucket duration in seconds
+     */
+    public static final String PARAM_BUCKET_DURATION = "bucketDuration";
+
+    /**
+     * init-param to set the bucket number of requests
+     */
+    public static final String PARAM_BUCKET_REQUESTS = "bucketRequests";
+
+    /**
+     * init-param to set the enforce flag
+     */
+    public static final String PARAM_ENFORCE = "enforce";
+
+    /**
+     * init-param to set enable expose header
+     */
+    public static final String PARAM_EXPOSE_HEADERS = "exposeHeaders";
+    /**
+     * init-param to set a custom status code if requests per duration exceeded
+     */
+    public static final String PARAM_STATUS_CODE = "statusCode";
+
+    /**
+     * init-param to set a custom status message if requests per duration exceeded
+     */
+    public static final String PARAM_STATUS_MESSAGE = "statusMessage";
+
+    private int bucketRequests = DEFAULT_BUCKET_REQUESTS;
+
+    private int bucketDuration = DEFAULT_BUCKET_DURATION;
+
+    private boolean enforce = DEFAULT_ENFORCE;
+
+    private int statusCode = DEFAULT_STATUS_CODE;
+
+    private String statusMessage = DEFAULT_STATUS_MESSAGE;
+
+    public static final String HEADER_WINDOW_SECOND = "X-RateLimit-Window-Second";
+    
+    public static final String HEADER_WINDOW_REQUESTS = "X-RateLimit-Window-NrOfRequests";
+    
+    public static final String HEADER_REMAINING = "X-RateLimit-NrOfRemaining";
+
+    public static final String HEADER_CURRENT = "X-RateLimit-NrOfCurrent";
+
+    private boolean exposeHeaders = DEFAULT_EXPOSE_HEADERS;
+
+    private transient Log log = LogFactory.getLog(RateLimitFilter2.class);
+
+    private static final StringManager sm = StringManager.getManager(RateLimitFilter.class);
+
+
+    @Override
+    public void init() throws ServletException {
+
+        FilterConfig config = getFilterConfig();
+
+        String param;
+        param = config.getInitParameter(PARAM_BUCKET_DURATION);
+        if (param != null) {
+            bucketDuration = Integer.parseInt(param);
+        }
+
+        param = config.getInitParameter(PARAM_BUCKET_REQUESTS);
+        if (param != null) {
+            bucketRequests = Integer.parseInt(param);
+        }
+
+        param = config.getInitParameter(PARAM_ENFORCE);
+        if (param != null) {
+            enforce = Boolean.parseBoolean(param);
+        }
+
+        param = config.getInitParameter(PARAM_EXPOSE_HEADERS);
+        if (param != null) {
+            exposeHeaders = Boolean.parseBoolean(param);
+        }
+
+        param = config.getInitParameter(PARAM_STATUS_CODE);
+        if (param != null) {
+            statusCode = Integer.parseInt(param);
+        }
+
+        param = config.getInitParameter(PARAM_STATUS_MESSAGE);
+        if (param != null) {
+            statusMessage = param;
+        }
+        ScheduledExecutorService executorService = (ScheduledExecutorService) getServletContext()
+                .getAttribute(ScheduledThreadPoolExecutor.class.getName());
+        if (executorService == null) {
+            executorService = new java.util.concurrent.ScheduledThreadPoolExecutor(1);
+        }
+
+        rateLimiter = new FixedWindowRateLimiter(bucketDuration, bucketRequests, enforce, executorService);
+
+        log.info(sm.getString("rateLimitFilter.initialized", super.getFilterName(), Integer.valueOf(bucketRequests),
+                Integer.valueOf(bucketDuration), bucketRequests, bucketDuration,
+                (!enforce ? "Not " : "") + "enforcing"));
+    }
+
+    private transient FixedWindowRateLimiter rateLimiter = null;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        String ipAddr = request.getRemoteAddr();
+        int reqCount = rateLimiter.increment(ipAddr);
+        request.setAttribute(RATE_LIMIT_ATTRIBUTE_COUNT, Integer.valueOf(reqCount));
+
+        if (exposeHeaders) {
+            ((HttpServletResponse) response).setIntHeader(HEADER_WINDOW_SECOND, bucketDuration);
+            ((HttpServletResponse) response).setIntHeader(HEADER_WINDOW_REQUESTS, bucketRequests);
+            if (enforce) {
+                int remaining = (reqCount < 0 || reqCount > bucketRequests) ? -1 : (bucketRequests - reqCount);
+                ((HttpServletResponse) response).setIntHeader(HEADER_REMAINING, remaining);
+            } else {
+                ((HttpServletResponse) response).setIntHeader(HEADER_CURRENT, reqCount);
+            }
+        }
+        
+        if (enforce && (reqCount > bucketRequests)) {
+
+            ((HttpServletResponse) response).sendError(statusCode, statusMessage);
+            log.warn(sm.getString("rateLimitFilter.maxRequestsExceeded", super.getFilterName(), reqCount, ipAddr,
+                    bucketRequests, bucketDuration));
+
+            return;
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    @Override
+    public void destroy() {
+        rateLimiter.destroy();
+        super.destroy();
+    }
+
+
+}

--- a/java/org/apache/catalina/storeconfig/LoaderSF.java
+++ b/java/org/apache/catalina/storeconfig/LoaderSF.java
@@ -44,9 +44,7 @@ public class LoaderSF extends StoreFactoryBase {
             }
         } else {
             if (log.isWarnEnabled()) {
-                if (log.isWarnEnabled()) {
-                    log.warn(sm.getString("factory.storeNoDescriptor", aElement.getClass()));
-                }
+                log.warn(sm.getString("factory.storeNoDescriptor", aElement.getClass()));
             }
         }
     }

--- a/java/org/apache/catalina/util/FixedWindowRateLimiter.java
+++ b/java/org/apache/catalina/util/FixedWindowRateLimiter.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.catalina.util;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
+import org.apache.tomcat.util.res.StringManager;
+
+
+/**
+ * This class maintains a thread safe hash map that has an identifier key, and an value of runtime
+ * {@link LimiterRuntimeEntry}. Each time the {@link #incrementAndGet(String)} method or {@link #tryAcquire(String)} is
+ * called, it adds the key if it does not exist. A maintenance thread cleans up items whose fixed window is obsolete.
+ * 
+ * @author Chenjp
+ */
+public class FixedWindowRateLimiter {
+    private static final Log log = LogFactory.getLog(FixedWindowRateLimiter.class);
+    private static final StringManager sm = StringManager.getManager(TimeBucketCounter.class);
+
+    private final long windowUnit;
+    private final long windowUnitInMillis;
+    private final int accessTimesThreshold;
+    private final boolean enforce;
+
+    private final ScheduledExecutorService executorService;
+
+    /**
+     * Map to hold the buckets
+     */
+    private final ConcurrentHashMap<String,LimiterRuntimeEntry> map = new ConcurrentHashMap<>();
+
+    /**
+     * The future allowing control of the background processor.
+     */
+    private ScheduledFuture<?> maintenanceFuture;
+
+    private ScheduledFuture<?> monitorFuture;
+
+    /**
+     * Creates a new FixedWindowRateLimiter with the specified lifetime.
+     * 
+     * @param fixedWindowInSecond    seconds of fixed window duration, e.g. for 1 minute pass 60
+     * @param requestNumberThreshold request threshold inner the fixed window.
+     * @param enforce                termination indicator when request number exceeds nrOfRequestsThreshold.
+     * @param executorService        the executor service which will be used to run the maintenance.
+     */
+    public FixedWindowRateLimiter(int fixedWindowInSecond, int nrOfRequestsThreshold, boolean enforce,
+            ScheduledExecutorService executorService) {
+        this.windowUnit = fixedWindowInSecond;
+        this.windowUnitInMillis = fixedWindowInSecond * 1000L;
+        this.accessTimesThreshold = nrOfRequestsThreshold;
+        this.enforce = enforce;
+        this.executorService = executorService;
+        monitorFuture = executorService.scheduleWithFixedDelay(new MaintenanceMonitor(), 0, 180, TimeUnit.SECONDS);
+    }
+
+    /**
+     * @param identifier target key of the {@link FixedWindowRateLimiter} effect on. 
+     * 
+     * @return the increased nrOfRequests. Value <code>1</code> returned if newWindow start.  
+     */
+    public int increment(String identifier) {
+        return map.computeIfAbsent(identifier, v -> new LimiterRuntimeEntry(windowUnit)).incrementAndGet();
+    }
+
+    /**
+     * Attempts to acquire for an access permit.
+     * 
+     * @param identifier target key of the {@link FixedWindowRateLimiter} effect on. 
+     * 
+     * @return a negative value on failure of <tt>enforce and rate exceeded</tt>; a positive value indicates access
+     *             times inner current fixed window. The returned value may exceed <tt>threshold</tt> only when
+     *             <tt>enforce</tt> is <tt>false</tt>.
+     */
+    public int tryAcquire(String identifier) {
+        return map.computeIfAbsent(identifier, v -> new LimiterRuntimeEntry(windowUnit))
+                .tryAcquire(accessTimesThreshold, enforce);
+    }
+
+    public void destroy() {
+        // Stop our thread
+        if (monitorFuture != null) {
+            monitorFuture.cancel(true);
+            monitorFuture = null;
+        }
+        if (maintenanceFuture != null) {
+            maintenanceFuture.cancel(true);
+            maintenanceFuture = null;
+        }
+        map.clear();
+    }
+
+    static class LimiterRuntimeEntry {
+        protected final long windowUnitInMillis;
+        /**
+         * Access time counter inner same fixed windowTimestamp / windowUnitInMillis.
+         */
+        protected AtomicInteger requestsCounter;
+        private final Object lock = new Object();
+        private volatile boolean rateExceed = false;
+        private volatile long windowTimestamp;
+
+        /**
+         * @param windowUnit           in seconds.
+         * @param accessTimesThreshold of requests.
+         * @param enforce              request termination indicator when
+         */
+        LimiterRuntimeEntry(long windowUnit) {
+            this.windowUnitInMillis = windowUnit * 1000L;
+            this.requestsCounter = new AtomicInteger();
+            this.rateExceed = false;
+        }
+
+        /**
+         * Increases and returns the number of requests occur within the same latest window.
+         * 
+         * @return the nrOfRequests occur within the same latest window.
+         */
+        public int incrementAndGet() {
+            long now = System.currentTimeMillis();
+            if (now - windowTimestamp >= windowUnitInMillis) {
+                // new window start.
+                long newWindowTimestamp = now - now % windowUnitInMillis;
+                synchronized (lock) {
+                    if (windowTimestamp != newWindowTimestamp) {
+                        windowTimestamp = newWindowTimestamp;
+                        rateExceed = false;
+                        requestsCounter.set(1);
+                        return 1;
+                    }
+                }
+            }
+            return requestsCounter.incrementAndGet();
+        }
+
+        /**
+         * Attempts to acquire for an access permit. Decide to take control information as arguments instead of fields
+         * to minimize memory cost.
+         * 
+         * @param nrOfRequestsThreshold limitation effected when <code>enforce</code> is <code>true</code>.
+         * @param enforce               termination indicator when request number exceeds nrOfRequestsThreshold.
+         * 
+         * @return a negative value on failure of <tt>enforce and rate exceeded</tt>; a positive value indicates access
+         *             times inner current fixed window. The returned value may exceed <tt>threshold</tt> only when
+         *             <tt>enforce</tt> is <tt>false</tt>.
+         */
+        public int tryAcquire(final int nrOfRequestsThreshold, final boolean enforce) {
+            if (!enforce) {
+                return incrementAndGet();
+            }
+            long now = System.currentTimeMillis();
+            if (now - windowTimestamp >= windowUnitInMillis) {
+                // new window start.
+                long newWindowTimestamp = now - now % windowUnitInMillis;
+                synchronized (lock) {
+                    if (windowTimestamp != newWindowTimestamp) {
+                        windowTimestamp = newWindowTimestamp;
+                        rateExceed = false;
+                        requestsCounter.set(1);
+                        return 1;
+                    }
+                }
+            }
+            int acquire;
+            if (rateExceed) {
+                acquire = -1;
+            } else {
+                int currentAccessTimes = requestsCounter.incrementAndGet();
+                if (currentAccessTimes > nrOfRequestsThreshold) {
+                    rateExceed = true;
+                    acquire = -1;
+                } else {
+                    acquire = currentAccessTimes;
+                }
+            }
+            return acquire;
+        }
+    }
+
+    /**
+     * Maintainer to cleanup rate limiter entries in runtime.
+     */
+    private class Maintenance implements Runnable {
+        @Override
+        public void run() {
+            // window time stamp older than 4 fixed windows ago(roughly.), regarded as obsoleted.
+            final long obsoleteWindowInMillis = System.currentTimeMillis() - (windowUnitInMillis << 2);
+            map.values().removeIf(e -> e.windowTimestamp < obsoleteWindowInMillis);
+        }
+    }
+
+    /**
+     * Maintainer scheduler monitor.
+     */
+    private class MaintenanceMonitor implements Runnable {
+        @Override
+        public void run() {
+            if ((maintenanceFuture == null || maintenanceFuture.isDone())) {
+                if (maintenanceFuture != null && maintenanceFuture.isDone()) {
+                    // There was an error executing the scheduled task, get it and log it
+                    try {
+                        maintenanceFuture.get();
+                    } catch (InterruptedException | ExecutionException e) {
+                        log.error(sm.getString("timebucket.maintenance.error"), e);
+                    }
+                }
+                maintenanceFuture = executorService.scheduleWithFixedDelay(new Maintenance(), 0, 60, TimeUnit.SECONDS);
+            }
+        }
+    }
+
+}

--- a/test/org/apache/catalina/filters/TestRateLimitFilter.java
+++ b/test/org/apache/catalina/filters/TestRateLimitFilter.java
@@ -60,7 +60,8 @@ public class TestRateLimitFilter extends TomcatBaseTest {
         long sleepTime = rateLimitFilter.bucketCounter.getMillisUntilNextBucket();
         System.out.printf("Sleeping %d millis for the next time bucket to start\n", Long.valueOf(sleepTime));
         Thread.sleep(sleepTime);
-
+        
+        long nowInNano = System.nanoTime();
         TestClient tc1 = new TestClient(rateLimitFilter, filterChain, "10.20.20.5", 200, 5);
         TestClient tc2 = new TestClient(rateLimitFilter, filterChain, "10.20.20.10", 200, 10);
 
@@ -75,7 +76,7 @@ public class TestRateLimitFilter extends TomcatBaseTest {
             Thread.sleep(100);
             count++;
         }
-
+        System.out.println("Elapsed nano time:"+(System.nanoTime() - nowInNano));
         Assert.assertEquals(200, tc1.results[24]); // only 25 requests made, all allowed
 
         Assert.assertEquals(200, tc2.results[49]); // only 25 requests made, all allowed

--- a/test/org/apache/catalina/filters/TestRateLimitFilter2.java
+++ b/test/org/apache/catalina/filters/TestRateLimitFilter2.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.catalina.filters;
+
+import java.io.IOException;
+import java.time.Instant;
+
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+
+import org.apache.catalina.Context;
+import org.apache.catalina.filters.TestRemoteIpFilter.MockFilterChain;
+import org.apache.catalina.filters.TestRemoteIpFilter.MockHttpServletRequest;
+import org.apache.catalina.startup.Tomcat;
+import org.apache.catalina.startup.TomcatBaseTest;
+import org.apache.tomcat.unittest.TesterResponse;
+import org.apache.tomcat.util.descriptor.web.FilterDef;
+import org.apache.tomcat.util.descriptor.web.FilterMap;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestRateLimitFilter2 extends TomcatBaseTest {
+
+    private void testRateLimitWith1Clients(boolean exposeHeaders,boolean enforce) throws Exception {
+
+        int bucketRequests = 40;
+        int bucketDuration = 4;
+
+        FilterDef filterDef = new FilterDef();
+        filterDef.addInitParameter(RateLimitFilter2.PARAM_BUCKET_REQUESTS, String.valueOf(bucketRequests));
+        filterDef.addInitParameter(RateLimitFilter2.PARAM_BUCKET_DURATION, String.valueOf(bucketDuration));
+        filterDef.addInitParameter(RateLimitFilter2.PARAM_ENFORCE, String.valueOf(enforce));
+        filterDef.addInitParameter(RateLimitFilter2.PARAM_EXPOSE_HEADERS, String.valueOf(exposeHeaders));
+
+        Tomcat tomcat = getTomcatInstance();
+        Context root = tomcat.addContext("", TEMP_DIR);
+        tomcat.start();
+
+        MockFilterChain filterChain = new MockFilterChain();
+        RateLimitFilter2 rateLimitFilter = testRateLimitFilter(filterDef, root);
+        long now = System.currentTimeMillis();
+        long nowInSecond = now / 1000;
+        long sleepTime = (nowInSecond / bucketDuration + 1L) * bucketDuration * 1000 - now;
+        System.out.printf("Sleeping %d millis for the next time bucket to start\n", Long.valueOf(sleepTime));
+        Thread.sleep(sleepTime);
+
+
+        TestClient tc1 = new TestClient(rateLimitFilter, filterChain, "10.20.20.5", 200, 5); // TPS: 5
+        TestClient tc2 = new TestClient(rateLimitFilter, filterChain, "10.20.20.10", 200, 10); // TPS: 10
+
+        TestClient tc3 = new TestClient(rateLimitFilter, filterChain, "10.20.20.20", 200, 20); // TPS: 20
+        TestClient tc4 = new TestClient(rateLimitFilter, filterChain, "10.20.20.40", 200, 40); // TPS: 40
+
+        // Sleep for up to 5s for clients to complete
+        int count = 0;
+        while (count < 100 && (tc1.results[24] == 0 || tc2.results[49] == 0 || tc3.results[bucketRequests - 1] == 0 ||
+                tc3.results[bucketRequests] == 0 || tc4.results[bucketRequests - 1] == 0 ||
+                tc4.results[bucketRequests] == 0)) {
+            Thread.sleep(100);
+            count++;
+        }
+        Assert.assertEquals(200, tc1.results[24]); // only 25 requests made in 5 seconds, all allowed
+        
+        Assert.assertEquals(200, tc2.results[49]); // only 50 requests made in 5 seconds, all allowed
+
+        Assert.assertEquals(200, tc3.results[39]); // first allowedRequests allowed
+        
+        if (enforce) {
+            Assert.assertEquals(429, tc3.results[40]); // subsequent requests dropped
+        } else {
+            Assert.assertEquals(200, tc3.results[40]);
+        }
+        
+        Assert.assertEquals(200, tc4.results[39]); // first allowedRequests allowed
+        
+        if (enforce) {
+            Assert.assertEquals(enforce ? 429 : 200, tc4.results[40]); // subsequent requests dropped
+        } else {
+            Assert.assertEquals(200, tc4.results[40]);
+        }
+        
+        if(exposeHeaders) {
+            Assert.assertEquals(bucketDuration, tc1.durationHeader[24]);
+            if(enforce) {
+                Assert.assertTrue(tc1.remainingHeader[24]>=0);
+                Assert.assertEquals(Integer.MIN_VALUE,tc1.currentHeader[24]);
+                
+                Assert.assertEquals(-1, tc3.remainingHeader[40]);
+                Assert.assertEquals(Integer.MIN_VALUE, tc3.currentHeader[40]);
+            } else {
+                Assert.assertEquals(Integer.MIN_VALUE,tc1.remainingHeader[24]);
+                Assert.assertTrue(tc1.currentHeader[24]>0);
+                
+                Assert.assertEquals(Integer.MIN_VALUE, tc3.remainingHeader[40]);
+                Assert.assertTrue(tc3.currentHeader[40]>bucketDuration);
+            }
+        } else {
+            Assert.assertEquals(Integer.MIN_VALUE, tc1.durationHeader[24]);
+            Assert.assertEquals(Integer.MIN_VALUE, tc1.remainingHeader[24]);
+            Assert.assertEquals(Integer.MIN_VALUE, tc1.currentHeader[24]);
+        }
+    }
+
+    @Test
+    public void testExposeHeaderAndRerferenceRateLimitWith4Clients() throws Exception {
+        testRateLimitWith1Clients(true,false);
+    }
+    @Test
+    public void testUnexposeHeaderAndRerferenceRateLimitWith4Clients() throws Exception {
+        testRateLimitWith1Clients(false,false);
+    }
+    @Test
+    public void testExposeHeaderAndEnforceRateLimitWith4Clients() throws Exception {
+        testRateLimitWith1Clients(true,true);
+    }
+    @Test
+    public void testUnexposeHeaderAndEnforceRateLimitWith4Clients() throws Exception {
+        testRateLimitWith1Clients(false,true);
+    }
+    private RateLimitFilter2 testRateLimitFilter(FilterDef filterDef, Context root) throws ServletException {
+
+        RateLimitFilter2 rateLimitFilter = new RateLimitFilter2();
+        filterDef.setFilterClass(RateLimitFilter2.class.getName());
+        filterDef.setFilter(rateLimitFilter);
+        filterDef.setFilterName(RateLimitFilter2.class.getName());
+        root.addFilterDef(filterDef);
+
+        FilterMap filterMap = new FilterMap();
+        filterMap.setFilterName(RateLimitFilter2.class.getName());
+        filterMap.addURLPatternDecoded("*");
+        root.addFilterMap(filterMap);
+
+        FilterConfig filterConfig = TesterFilterConfigs.generateFilterConfig(filterDef);
+
+        rateLimitFilter.init(filterConfig);
+
+        return rateLimitFilter;
+    }
+
+    static class TestClient extends Thread {
+        RateLimitFilter2 filter;
+        FilterChain filterChain;
+        String ip;
+
+        int requests;
+        int sleep;
+
+        int[] results;
+        int[] durationHeader;
+        int[] remainingHeader;
+        int[] currentHeader;
+
+        TestClient(RateLimitFilter2 filter, FilterChain filterChain, String ip, int requests, int rps) {
+            this.filter = filter;
+            this.filterChain = filterChain;
+            this.ip = ip;
+            this.requests = requests;
+            this.sleep = 1000 / rps;
+            this.results = new int[requests];
+            this.durationHeader = new int[requests];
+            this.remainingHeader = new int[requests];
+            this.currentHeader = new int[requests];
+            super.setDaemon(true);
+            super.start();
+        }
+
+        @Override
+        public void run() {
+            try {
+                for (int i = 0; i < requests; i++) {
+                    MockHttpServletRequest request = new MockHttpServletRequest();
+                    request.setRemoteAddr(ip);
+                    TesterResponse response = new TesterResponseWithStatus();
+                    response.setRequest(request);
+                    filter.doFilter(request, response, filterChain);
+                    results[i] = response.getStatus();
+
+                    durationHeader[i] =
+                            tryParseIntHeader(response, RateLimitFilter2.HEADER_WINDOW_SECOND, Integer.MIN_VALUE);
+                    remainingHeader[i] =
+                            tryParseIntHeader(response, RateLimitFilter2.HEADER_REMAINING, Integer.MIN_VALUE);
+                    currentHeader[i] = tryParseIntHeader(response, RateLimitFilter2.HEADER_CURRENT, Integer.MIN_VALUE);
+
+                    System.out.printf("%s %s: %s %d\n", ip, Instant.now(), Integer.valueOf(i + 1),
+                            Integer.valueOf(response.getStatus()));
+                    sleep(sleep);
+                }
+            } catch (Exception ex) {
+                ex.printStackTrace();
+            }
+        }
+
+        protected int tryParseIntHeader(TesterResponse resp, String header, int defaultValue) {
+            try {
+                return Integer.parseInt(resp.getHeader(header));
+            } catch (NumberFormatException e) {
+                return defaultValue;
+            }
+        }
+    }
+
+    static class TesterResponseWithStatus extends TesterResponse {
+
+        int status = 200;
+        String message = "OK";
+
+        @Override
+        public void sendError(int status, String message) throws IOException {
+            this.status = status;
+            this.message = message;
+        }
+
+        @Override
+        public int getStatus() {
+            return status;
+        }
+    }
+
+}


### PR DESCRIPTION
Implements an exact limiter filter as announced via ```FixedWindowRateLimiter```. Initial configurations of ```RateLimitFilter2` is backward compatible with previous filter(RateLimitFilter), and adds an extra option `exposeHeaders` (default true to enable).

Testcase added.
