### PR TITLE
Report HTTP/2 header parsing errors earlier

### DIFF
--- a/java/org/apache/coyote/http2/Http2Parser.java
+++ b/java/org/apache/coyote/http2/Http2Parser.java
@@ -289,6 +289,9 @@ class Http2Parser {
 
         swallowPayload(streamId, FrameType.HEADERS.getId(), padLength, true, buffer);
 
+        // Validate the headers so far
+        hpackDecoder.getHeaderEmitter().validateHeaders();
+
         if (Flags.isEndOfHeaders(flags)) {
             onHeadersComplete(streamId);
         } else {
@@ -467,6 +470,9 @@ class Http2Parser {
 
         readHeaderPayload(streamId, payloadSize, buffer);
 
+        // Validate the headers so far
+        hpackDecoder.getHeaderEmitter().validateHeaders();
+
         if (endOfHeaders) {
             headersCurrentStream = -1;
             onHeadersComplete(streamId);
@@ -633,10 +639,6 @@ class Http2Parser {
                     Http2Error.COMPRESSION_ERROR);
         }
 
-        // Delay validation (and triggering any exception) until this point
-        // since all the headers still have to be read if a StreamException is
-        // going to be thrown.
-        hpackDecoder.getHeaderEmitter().validateHeaders();
 
         synchronized (output) {
             output.headersEnd(streamId);


### PR DESCRIPTION
We found that the 10.0.x branch is also affected by CVE-2024-24549(https://github.com/advisories/GHSA-7w75-32cg-r6g2), but it has not been fixed yet. Therefore, we have created this patch for 10.0.x based on the fixes applied in other branches.