### PR TITLE
Adding connectionUploadTimeout default value to http.xml

### DIFF
--- a/webapps/docs/config/http.xml
+++ b/webapps/docs/config/http.xml
@@ -416,7 +416,8 @@
 
     <attribute name="connectionUploadTimeout" required="false">
       <p>Specifies the timeout, in milliseconds, to use while a data upload is
-      in progress. This only takes effect if
+      in progress. If not specified the default
+      value is 300000 (i.e. 300 seconds). This only takes effect if
       <strong>disableUploadTimeout</strong> is set to <code>false</code>.
       </p>
     </attribute>


### PR DESCRIPTION
Added default value for connectionUploadTimeout in the event that a value is not provided and disableUploadTimeout is set to false.