### PR TITLE
Reducing memory usage while evaluating reflective EL expressions

### DIFF
--- a/java/javax/el/Util.java
+++ b/java/javax/el/Util.java
@@ -227,6 +227,15 @@ class Util {
             paramTypes = getTypesFromValues(paramValues);
         }
 
+        if (paramTypes.length == 0) {
+            try {
+                Method method = clazz.getMethod(methodName, paramTypes);
+                return method;
+            } catch (NoSuchMethodException | SecurityException e) {
+                // fall through to broader, slower logic
+            }
+        }
+
         Method[] methods = getMethodsFromCache(clazz);
 
         List<Wrapper<Method>> wrappers = Wrapper.wrap(methods, methodName);

--- a/java/javax/el/Util.java
+++ b/java/javax/el/Util.java
@@ -42,6 +42,8 @@ class Util {
     private static final Class<?>[] EMPTY_CLASS_ARRAY = new Class<?>[0];
     private static final Object[] EMPTY_OBJECT_ARRAY = new Object[0];
 
+    private static final Map<String, WeakReference<Method[]>> METHODS_BY_CLASS_NAME = new ConcurrentHashMap<>();
+
     private static final boolean IS_SECURITY_ENABLED = (System.getSecurityManager() != null);
 
     private static final boolean GET_CLASSLOADER_USE_PRIVILEGED;
@@ -225,13 +227,35 @@ class Util {
             paramTypes = getTypesFromValues(paramValues);
         }
 
-        Method[] methods = clazz.getMethods();
+        Method[] methods = getMethodsFromCache(clazz);
 
         List<Wrapper<Method>> wrappers = Wrapper.wrap(methods, methodName);
 
         Wrapper<Method> result = findWrapper(context, clazz, wrappers, methodName, paramTypes, paramValues);
 
         return getMethod(clazz, base, result.unWrap());
+    }
+
+    /**
+     * Accesses cached copies of Class.getMethods() (when available) to avoid the JVM's expensive duplication of the
+     * Method[] and Method objects. Avoids ClassLoader memory leaks by keying off the class name (String) and keeping
+     * WeakReferences to the data.
+     * 
+     * @param clazz
+     * @return Method[]
+     */
+    private static Method[] getMethodsFromCache(Class<?> clazz) {
+        WeakReference<Method[]> weakRef = METHODS_BY_CLASS_NAME.get(clazz.getName());
+        Method[] methods;
+        // Check if cache contains a value - entry must exist, and weak ref must be
+        // populated
+        if (weakRef == null || (methods = weakRef.get()) == null) {
+            // no data found - either key is not present, or the weak ref is empty
+            methods = clazz.getMethods();
+            weakRef = new WeakReference<>(methods);
+            METHODS_BY_CLASS_NAME.put(clazz.getName(), weakRef);
+        }
+        return methods;
     }
 
     /*

--- a/test/javax/el/TestUtil.java
+++ b/test/javax/el/TestUtil.java
@@ -16,12 +16,46 @@
  */
 package javax.el;
 
+import java.lang.reflect.Method;
 import java.util.Date;
 
 import org.junit.Assert;
 import org.junit.Test;
 
 public class TestUtil {
+    public static class TestBean {
+        public int get1() {
+            return 1;
+        }
+
+        public int getN(Integer n) {
+            return n;
+        }
+    }
+
+    @Test
+    public void testFindMethodWithNoArgs() throws Exception {
+        Method method = Util.findMethod(null, TestBean.class, new TestBean(), "get1", new Class[0], new Object[0]);
+        Assert.assertEquals(TestBean.class.getMethod("get1"), method);
+    }
+
+    @Test
+    public void testFindMethodWithOneArg() throws Exception {
+        Method method = Util.findMethod(null, TestBean.class, new TestBean(), "getN", new Class[] { Integer.class },
+                new Object[] { 2 });
+        Assert.assertEquals(TestBean.class.getMethod("getN", new Class[] { Integer.class }), method);
+    }
+
+    @Test
+    public void testFindMethodNoSuchMethod() throws Exception {
+        try {
+            Util.findMethod(null, TestBean.class, new TestBean(), "getNonExistentMethod",
+                    new Class[] { Integer.class }, new Object[] { 2 });
+            Assert.fail();
+        } catch (MethodNotFoundException mnfe) {
+            // as expected
+        }
+    }
 
     @Test
     public void test01() {
@@ -53,4 +87,6 @@ public class TestUtil {
         processor.defineBean("string", "Not used. Any value is fine here");
         Assert.assertEquals("5", processor.eval("string.valueOf(5)"));
     }
+    
+    
 }

--- a/test/javax/el/TestUtil.java
+++ b/test/javax/el/TestUtil.java
@@ -31,6 +31,10 @@ public class TestUtil {
         public int getN(Integer n) {
             return n;
         }
+
+        private int privateMethodNoArgs() {
+            return 0;
+        }
     }
 
     @Test
@@ -44,6 +48,18 @@ public class TestUtil {
         Method method = Util.findMethod(null, TestBean.class, new TestBean(), "getN", new Class[] { Integer.class },
                 new Object[] { 2 });
         Assert.assertEquals(TestBean.class.getMethod("getN", new Class[] { Integer.class }), method);
+    }
+
+    @Test
+    public void testFindPrivateMethod() throws Exception {
+        // verifies that private methods are not located
+        try {
+            Util.findMethod(null, TestBean.class, new TestBean(), "privateMethodNoArgs",
+                    new Class[0], new Object[0]);
+            Assert.fail();
+        } catch (MethodNotFoundException mnfe) {
+            // success, sort of
+        }
     }
 
     @Test

--- a/test/org/apache/el/parser/TestELParserPerformance.java
+++ b/test/org/apache/el/parser/TestELParserPerformance.java
@@ -342,6 +342,7 @@ public class TestELParserPerformance {
         BeanClassA beanA = new BeanClassA();
         BeanClassB beanB = new BeanClassB();
         beanA.setBean(beanB);
+        beanA.setName("name");
         beanB.setName("name");
         beanA.setStringMap(new HashMap<>());
         beanA.setValList(new ArrayList<>(Arrays.asList("a", "b", "c")));

--- a/test/org/apache/el/parser/TestELParserPerformance.java
+++ b/test/org/apache/el/parser/TestELParserPerformance.java
@@ -17,6 +17,12 @@
 package org.apache.el.parser;
 
 import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
 
 import javax.el.ELContext;
 import javax.el.ELManager;
@@ -33,6 +39,119 @@ import org.apache.tomcat.util.collections.SynchronizedStack;
  * This is a relative performance test so it remains part of the standard test run.
  */
 public class TestELParserPerformance {
+    /**
+     * Bean class used to evaluate EL expressions with two or more complex types.
+     * Provides 10 methods.
+     */
+    public static class BeanClassA {
+        private BeanClassB bean;
+        private String name;
+        private Map<String, String> stringMap;
+        private List<?> valList;
+        private long valLong;
+
+        public BeanClassB getBean() {
+            return bean;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Map<String, String> getStringMap() {
+            return stringMap;
+        }
+
+        public List<?> getValList() {
+            return valList;
+        }
+
+        public long getValLong() {
+            return valLong;
+        }
+
+        public void setBean(BeanClassB bean) {
+            this.bean = bean;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public void setStringMap(Map<String, String> stringMap) {
+            this.stringMap = stringMap;
+        }
+
+        public void setValList(List<?> valList) {
+            this.valList = valList;
+        }
+
+        public void setValLong(long valLong) {
+            this.valLong = valLong;
+        }
+    }
+
+    /**
+     * Bean class used to evaluate EL expressions with two or more complex types. Provides 10 methods, plus those on the
+     * superclass.
+     */
+    public static class BeanClassB extends BeanClassA {
+        private String four;
+        private String one;
+        private String three;
+        private String two;
+        private String five;
+
+        public String getFive() {
+            return five;
+        }
+
+        public void setFive(String five) {
+            this.five = five;
+        }
+
+        public String getFour() {
+            return four;
+        }
+
+        public String getOne() {
+            return one;
+        }
+
+        public String getThree() {
+            return three;
+        }
+
+        public String getTwo() {
+            return two;
+        }
+
+        public void setFour(String four) {
+            this.four = four;
+        }
+
+        public void setOne(String one) {
+            this.one = one;
+        }
+
+        public void setThree(String three) {
+            this.three = three;
+        }
+
+        public void setTwo(String two) {
+            this.two = two;
+        }
+    }
+
+    /**
+     * Enum class used to evaluate expressions with enums.
+     */
+    private enum TestEnum {
+        ONE, TWO, THREE
+    }
+
+    private static final long DEFAULT_TEST_ITERATIONS = 1000000;
+
 
     /*
      * Test to explore if re-using Parser instances is faster.
@@ -96,7 +215,6 @@ public class TestELParserPerformance {
         Assert.assertTrue("Using new ElParser() was faster then using ELParser.ReInit", reinitTotalTime < newTotalTime);
     }
 
-
     /*
      * Ignored by default since this is an absolute test primarily for
      * https://bz.apache.org/bugzilla/show_bug.cgi?id=69338
@@ -142,7 +260,6 @@ public class TestELParserPerformance {
         System.out.println("");
     }
 
-
     /*
      * Ignored by default since this is an absolute test primarily for
      * https://bz.apache.org/bugzilla/show_bug.cgi?id=69338
@@ -172,5 +289,78 @@ public class TestELParserPerformance {
 
         }
         System.out.println("");
+    }
+
+    /**
+     * Utility method for running tasks provided by the test*() methods.
+     * @param c Callable to be executed.
+     * @param description Label to be displayed in the results.
+     * @return Arbitrary response data provided by the callable.
+     * @throws Exception
+     */
+    private Object runTest(Callable<Object> c, String description) throws Exception {
+
+        Object result = null;
+        for (int j = 0; j < 5; j++) {
+
+            System.gc();
+            long start = System.currentTimeMillis();
+
+            for (int i = 0; i < DEFAULT_TEST_ITERATIONS; i++) {
+                result = c.call();
+            }
+
+            long duration = System.currentTimeMillis() - start;
+            System.out.println(description + " duration=[" + duration + "ms] or "
+                    + (duration * 1000000 / DEFAULT_TEST_ITERATIONS + " ns each"));
+
+        }
+        System.out.println("Result: " + result);
+
+        return result;
+    }
+
+    /**
+     * Performance test of various expressions. This can be easily modified to explore the performance of other
+     * expressions.
+     *
+     * The operations tested in this method allocate many objects. For most consistent results, use runtime arguments
+     * such as these: -Xms3g -Xmx3g -XX:+UseParallelGC
+     *
+     * Ignored by default since this is an absolute test primarily for
+     * https://bz.apache.org/bugzilla/show_bug.cgi?id=69381
+     * 
+     * @throws Exception
+     */
+    @Ignore
+    @Test
+    public void testExpressions() throws Exception {
+
+        ELManager manager = new ELManager();
+        ELContext context = manager.getELContext();
+        ExpressionFactory factory = ELManager.getExpressionFactory();
+        BeanClassA beanA = new BeanClassA();
+        BeanClassB beanB = new BeanClassB();
+        beanA.setBean(beanB);
+        beanB.setName("name");
+        beanA.setStringMap(new HashMap<>());
+        beanA.setValList(new ArrayList<>(Arrays.asList("a", "b", "c")));
+
+        ValueExpression var = factory.createValueExpression(beanA, BeanClassA.class);
+        context.getVariableMapper().setVariable("beanA", var);
+
+        ValueExpression varB = factory.createValueExpression(beanB, BeanClassB.class);
+        context.getVariableMapper().setVariable("beanB", varB);
+
+        var = factory.createValueExpression(TestEnum.ONE, TestEnum.class);
+        context.getVariableMapper().setVariable("enumOne", var);
+
+        String[] expressions = new String[] { "${beanA.name}", "${beanA.getName()}", "${beanB.getName()}" };
+        for (String expression : expressions) {
+            runTest(() -> {
+                ValueExpression ve = factory.createValueExpression(context, expression, Object.class);
+                return ve.getValue(context);
+            }, expression);
+        }
     }
 }


### PR DESCRIPTION
This change fixes https://bz.apache.org/bugzilla/show_bug.cgi?id=69381 by caching the JVM-provided `Method[]`.  The OpenJDK compiler creates duplicate `Method` objects on every call to `Class.getMethods()`, which is an expensive task that is only made worse on complex classes that have more `Method`s.

ClassLoader leaks are avoided by keying off the class' name (`String`) and storing the `Method[]` in a `WeakReference<Method[]>`.  The cost of the concurrency is easily outweighed by the savings from not duplicating dozens of objects, as demonstrated from output in the modified `TestELParserPerformance` provided at the bottom of this PR body.

Key points from the data:
1. Non-reflective expressions are unaffected.
2. For a bean with 10 methods, this logic is 42% faster.
3. For a bean with 20 methods, this logic is 57% faster
4. The new code still scales by number of `Method`s, but the growth is far less (4% vs 40%).

Original:
```
${beanA.name} duration=[599ms] or 599 ns each
${beanA.name} duration=[337ms] or 337 ns each
${beanA.name} duration=[330ms] or 330 ns each
${beanA.name} duration=[331ms] or 331 ns each
${beanA.name} duration=[330ms] or 330 ns each
Result: name
${beanA.getName()} duration=[1586ms] or 1586 ns each
${beanA.getName()} duration=[1401ms] or 1401 ns each
${beanA.getName()} duration=[1477ms] or 1477 ns each
${beanA.getName()} duration=[1401ms] or 1401 ns each
${beanA.getName()} duration=[1398ms] or 1398 ns each
Result: name
${beanB.getName()} duration=[1921ms] or 1921 ns each
${beanB.getName()} duration=[1972ms] or 1972 ns each
${beanB.getName()} duration=[1969ms] or 1969 ns each
${beanB.getName()} duration=[1970ms] or 1970 ns each
${beanB.getName()} duration=[1974ms] or 1974 ns each
Result: name
```
Optimized:
```
${beanA.name} duration=[570ms] or 570 ns each
${beanA.name} duration=[336ms] or 336 ns each
${beanA.name} duration=[330ms] or 330 ns each
${beanA.name} duration=[330ms] or 330 ns each
${beanA.name} duration=[330ms] or 330 ns each
Result: name
${beanA.getName()} duration=[990ms] or 990 ns each
${beanA.getName()} duration=[807ms] or 807 ns each
${beanA.getName()} duration=[814ms] or 814 ns each
${beanA.getName()} duration=[815ms] or 815 ns each
${beanA.getName()} duration=[812ms] or 812 ns each
Result: name
${beanB.getName()} duration=[883ms] or 883 ns each
${beanB.getName()} duration=[848ms] or 848 ns each
${beanB.getName()} duration=[848ms] or 848 ns each
${beanB.getName()} duration=[848ms] or 848 ns each
${beanB.getName()} duration=[848ms] or 848 ns each
Result: name
```


