### PR TITLE
webdav lock and unlock: ensure response must not be cached

### DIFF
--- a/java/org/apache/catalina/servlets/WebdavServlet.java
+++ b/java/org/apache/catalina/servlets/WebdavServlet.java
@@ -581,8 +581,10 @@ public class WebdavServlet extends DefaultServlet implements PeriodicEventListen
         } else if (method.equals(METHOD_MOVE)) {
             doMove(req, resp);
         } else if (method.equals(METHOD_LOCK)) {
+            disableCacheable(resp);
             doLock(req, resp);
         } else if (method.equals(METHOD_UNLOCK)) {
+            disableCacheable(resp);
             doUnlock(req, resp);
         } else {
             // DefaultServlet processing
@@ -776,6 +778,20 @@ public class WebdavServlet extends DefaultServlet implements PeriodicEventListen
         }
 
         return methodsAllowed.toString();
+    }
+    
+    /**
+     * Explicitly prevent the response from being cached by middle tier, e.g., <type>ExpiresFilter</type>, http server, or
+     * proxy server, browser.
+     * @param resp The HTTP Servlet response
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc7234">RFC 7234</a>
+     */
+    protected void disableCacheable(HttpServletResponse resp) {
+        resp.setHeader("Cache-Control", "no-cache, no-store, max-age=0"); // HTTP 1.1
+        /*
+         * Typically other components follow 'Expires' header.
+         */
+        resp.setDateHeader("Expires", 0);
     }
 
 

--- a/test/org/apache/catalina/servlets/TestWebdavServletRfcSection.java
+++ b/test/org/apache/catalina/servlets/TestWebdavServletRfcSection.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.catalina.servlets;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.util.UUID;
+
+import org.apache.catalina.Context;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestWebdavServletRfcSection extends WebdavServletRfcSectionBase {
+
+    @Test
+    public void testCopyAndWiteFile() throws Exception {
+        Context ctx = prepareContext("testCopyAndWiteFile");
+        prepareWebdav(ctx, true, false);
+        prepareExpirePolicy(ctx);
+
+        String collection1 = UUID.randomUUID().toString();
+        Assert.assertTrue(new File(getWebappAbsolutePath(), collection1).mkdir());
+        String collection11 = UUID.randomUUID().toString();
+        Assert.assertTrue("Failed to mkdir of ",
+                new File(getWebappAbsolutePath() + File.separator + collection1, collection11).mkdir());
+
+        String collection12 = UUID.randomUUID().toString();
+        Assert.assertTrue("Failed to mkdir of ",
+                new File(getWebappAbsolutePath() + File.separator + collection1, collection12).mkdir());
+
+        String file111 = "file111.txt";
+        try (FileWriter fw = new FileWriter(new File(
+                getWebappAbsolutePath() + File.separator + collection1 + File.separator + collection11, file111))) {
+            fw.write("file111.txt-v1");
+        }
+
+        getTomcatInstance().start();
+
+        WebdavClient client = new WebdavClient();
+        client.setPort(getPort());
+        String srcUri = "/" + collection1 + "/" + collection11 + "/" + file111;
+        String file121 = "file121.txt";
+        String destUri = "/" + collection1 + "/" + collection12 + "/" + file121;
+
+        String lockOwner = "Owner_Rfc_testCopyAndWiteFile";
+        /*
+         * copy single file
+         */
+        String exclusiveLockToken01 = client.lockResource("/" + collection1 + "/" + collection12, lockOwner, true,
+                "infinity", "Unexpected response", null);
+        String srcContent = client.getResource(srcUri, "Unexpected response",
+                r -> r.getStatusCode() >= 200 && r.getStatusCode() < 300);
+        client.copyResource(srcUri, destUri, true, exclusiveLockToken01, "Unexpected response",
+                r -> r.getStatusCode() >= 200 && r.getStatusCode() < 300);
+        String destContentV0 = client.getResource(destUri, "Unexpected response",
+                r -> r.getStatusCode() >= 200 && r.getStatusCode() < 300);
+        Assert.assertEquals("dest file content check.", srcContent, destContentV0);
+
+        String etagValue = matchHeaders(client.getResponseHeaders(), h -> h.toLowerCase().startsWith("etag")).get(0)
+                .substring("etag: ".length());
+
+        /* write content with token and ETag */
+        String dstContent = srcContent + "\r\nfile121.txt-v2";
+        client.putResource(destUri, "text/plain", dstContent, "(<" + exclusiveLockToken01 + "> [" + etagValue + "])",
+                "Unexpected response", null);
+        Assert.assertEquals("dest file content check.", dstContent,
+                client.getResource(destUri, "Unexpected response", null));
+        /* write content with token (and absence of ETag) */
+        dstContent += "\r\nnfile121.txt-v3";
+        client.putResource(destUri, "text/plain", dstContent, "(<" + exclusiveLockToken01 + ">)", "Unexpected response",
+                null);
+        Assert.assertEquals("dest file content check.", dstContent,
+                client.getResource(destUri, "Unexpected response", null));
+
+        client.unlockResource(destUri, exclusiveLockToken01, "Unexpected response", null);
+
+        /*
+         * copy collection, and modify file content.
+         */
+        srcUri = "/" + collection1 + "/" + collection11;
+        String colleciton13 = UUID.randomUUID().toString();
+        destUri = "/" + collection1 + "/" + colleciton13;
+        client.copyResource(srcUri, destUri, true, null, "Unexpected response",
+                r -> r.getStatusCode() >= 200 && r.getStatusCode() < 300);
+        dstContent = client.getResource(destUri + "/" + file111, "Unexpected response", null);
+        Assert.assertEquals("dest file content check.", srcContent, dstContent);
+        etagValue = matchHeaders(client.getResponseHeaders(), h -> h.toLowerCase().startsWith("etag")).get(0)
+                .substring("etag: ".length());
+        dstContent += "\r\nv2";
+        Assert.assertNotNull(etagValue);
+
+        destUri = "/" + collection1 + "/" + colleciton13 + "/" + file111;
+        exclusiveLockToken01 = client.lockResource(destUri, lockOwner, true, "infinity", "Unexpected response", null);
+        client.putResource(destUri, "text/plain", dstContent, "(<" + exclusiveLockToken01 + "> [" + etagValue + "])",
+                "Unexpected response", null);
+        Assert.assertEquals("dest file content check.", dstContent,
+                client.getResource(destUri, "Unexpected response", null));
+    }
+
+    /**
+     * WebDAV clients can be good citizens by using a lock / retrieve / write /unlock sequence of operations (at least
+     * by default) whenever they interact with a WebDAV server that supports locking.
+     * 
+     * @throws Exception
+     */
+    // @Test
+    public void testWriteFileByLockCollection() throws Exception {
+        Context ctx = prepareContext("testWriteFileByLockCollection");
+        prepareWebdav(ctx, true, false);
+        prepareExpirePolicy(ctx);
+
+        String collection1 = UUID.randomUUID().toString();
+        Assert.assertTrue(new File(getWebappAbsolutePath(), collection1).mkdir());
+        String collection11 = UUID.randomUUID().toString();
+        Assert.assertTrue("Failed to mkdir of ",
+                new File(getWebappAbsolutePath() + File.separator + collection1, collection11).mkdir());
+
+        getTomcatInstance().start();
+
+        WebdavClient client = new WebdavClient();
+        client.setPort(getPort());
+        /*
+         * 1. lock collection exclusively.
+         */
+        String exclusiveLockToken01 = client.lockResource("/" + collection1, "biz01_exclusive_01", true, "infinity",
+                "Unexpected status code.", null);
+        String file111 = "file111.txt";
+        /* 1.1 Unable write without ifHeader of lock */
+        client.putResource("/" + collection1 + "/" + collection11 + "/" + file111, "text/plain", "README_v1", null,
+                "Unexpected status code.", c -> WebdavStatus.SC_LOCKED == c.getStatusCode());
+        /* 1.2 Unable acquire for a shared lock on sub resource */
+        String sharedLockToken01 = client.lockResource("/" + collection1 + "/" + collection11, "biz01_shared_01", false,
+                "infinity", "Unexpected status code.", c -> WebdavStatus.SC_LOCKED == c.getStatusCode());
+        Assert.assertNull(sharedLockToken01);
+
+        /* 1.3 Write content with exclusive lock */
+        client.putResource("/" + collection1 + "/" + collection11 + "/" + file111, "text/plain", "README_v1",
+                "(<" + exclusiveLockToken01 + ">)", "Unexpected status code.", null);
+        client.unlockResource("/" + collection1 + "/" + collection11 + "/" + file111, exclusiveLockToken01,
+                "Unexpected status code.", c -> c.isResponse204());
+        // verify lock removed entirely: try to acquire a shared lock
+        sharedLockToken01 = client.lockResource("/" + collection1 + "/" + collection11, "biz01_shared_01", true,
+                "infinity", "Unexpected status code.", null);
+        Assert.assertNotNull("SharedLock successfully expected.", sharedLockToken01);
+        /* Cleanup */
+        client.unlockResource("/" + collection1 + "/" + collection11, sharedLockToken01, "Unexpected status code.",
+                c -> c.isResponse204());
+    }
+
+    /**
+     * WebDAV clients can be good citizens by using a lock / retrieve / write /unlock sequence of operations (at least
+     * by default) whenever they interact with a WebDAV server that supports locking.
+     * 
+     * @throws Exception
+     */
+    // @Test
+    public void testWriteFileByLockSingleResource() throws Exception {
+        Context ctx = prepareContext("testWriteFileByLockSingleResource");
+        prepareWebdav(ctx, true, false);
+        prepareExpirePolicy(ctx);
+
+        String collection1 = UUID.randomUUID().toString();
+        Assert.assertTrue(new File(getWebappAbsolutePath(), collection1).mkdir());
+        String collection11 = UUID.randomUUID().toString();
+        Assert.assertTrue("Failed to mkdir of ",
+                new File(getWebappAbsolutePath() + File.separator + collection1, collection11).mkdir());
+
+        getTomcatInstance().start();
+
+        WebdavClient client = new WebdavClient();
+        client.setPort(getPort());
+
+        /*
+         * 2. lock a single file
+         */
+        String file112 = "file112.txt";
+        String sharedLockToken01 = client.lockResource("/" + collection1 + "/" + collection11 + "/" + file112,
+                "biz01_shared_01", false, "0", "Unexpected status code.", null);
+        client.putResource("/" + collection1 + "/" + collection11 + "/" + file112, "text/plain", "README_v1",
+                "(<" + sharedLockToken01 + ">)", "Unexpected status code.", null);
+        String sharedLockToken02 = client.lockResource("/" + collection1 + "/" + collection11 + "/" + file112,
+                "biz01_shared_02", false, "0", "Unexpected status code.", null);
+        client.putResource("/" + collection1 + "/" + collection11 + "/" + file112, "text/plain", "README_v2",
+                "(<" + sharedLockToken02 + ">)", "Unexpected status code.", null);
+        // Check file content
+        Assert.assertEquals("Content check", "README_v2", client
+                .getResource("/" + collection1 + "/" + collection11 + "/" + file112, "2xx status expected.", null));
+    }
+}

--- a/test/org/apache/catalina/servlets/TestWebdavServletRfcSection_9_10.java
+++ b/test/org/apache/catalina/servlets/TestWebdavServletRfcSection_9_10.java
@@ -1,0 +1,556 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.catalina.servlets;
+
+import java.io.File;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.apache.catalina.Context;
+import org.apache.catalina.startup.SimpleHttpClient;
+import org.junit.Assert;
+import org.junit.Test;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+public class TestWebdavServletRfcSection_9_10 extends WebdavServletRfcSectionBase {
+    /**
+     * 9.10. LOCK Method
+     * <p>
+     * The following sections describe the LOCK method, which is used to take out a lock of any access type and to
+     * refresh an existing lock. These sections on the LOCK method describe only those semantics that are specific to
+     * the LOCK method and are independent of the access type of the lock being requested. Any resource that supports
+     * the LOCK method MUST, at minimum, support the XML request and response formats defined herein. This method is
+     * neither idempotent nor safe (see Section 9.1 of [RFC2616]). Responses to this method MUST NOT be cached.
+     */
+    @Test
+    public void testRfc_9_10() throws Exception {
+        Context ctx = prepareContext("rfc_9_10");
+        prepareWebdav(ctx, true, false);
+        prepareExpirePolicy(ctx);
+
+        String newDir = UUID.randomUUID().toString();
+        Assert.assertTrue(new File(getWebappAbsolutePath(), newDir).mkdir());
+
+        getTomcatInstance().start();
+
+        String mappedUrl = "/" + newDir;
+
+        WebdavClient client = new WebdavClient();
+        client.setPort(getPort());
+
+        String lockOwner = "Owner_Rfc_9_10";
+        /* Lock on a mapped url */
+        client.lockResource(mappedUrl, lockOwner, true, "0", "Unexpected status code.",
+                c -> c.isResponse200() || WebdavStatus.SC_CREATED == c.getStatusCode());
+        Assert.assertTrue(client.getResponseBody().contains("opaquelocktoken:"));
+        /* Check cache */
+        if (client.isResponseCacheable()) {
+            Assert.fail(
+                    "9.10. LOCK Method - Responses to this method MUST NOT be cached - Please check cache-control, expires, and etag");
+        }
+    }
+
+    /**
+     * 9.10.1. Creating a Lock on an Existing Resource
+     * <p>
+     * A LOCK request to an existing resource will create a lock on the resource identified by the Request-URI, provided
+     * the resource is not already locked with a conflicting lock. The resource identified in the Request-URI becomes
+     * the root of the lock. LOCK method requests to create a new lock MUST have an XML request body. The server MUST
+     * preserve the information provided by the client in the 'owner' element in the LOCK request. The LOCK request MAY
+     * have a Timeout header.
+     * <p>
+     * When a new lock is created, the LOCK response:
+     * <p>
+     * o MUST contain a body with the value of the DAV:lockdiscovery property in a prop XML element. This MUST contain
+     * the full information about the lock just granted, while information about other (shared) locks is OPTIONAL.
+     * <p>
+     * o MUST include the Lock-Token response header with the token associated with the new lock.
+     */
+    @Test
+    public void testRfc_9_10_1() throws Exception {
+        Context ctx = prepareContext("rfc_9_10_1");
+        prepareWebdav(ctx, true, false);
+
+        String newDir = UUID.randomUUID().toString();
+        Assert.assertTrue(new File(getWebappAbsolutePath(), newDir).mkdir());
+
+        getTomcatInstance().start();
+
+        String mappedUrl = "/" + newDir;
+        WebdavClient client = new WebdavClient();
+        client.setPort(getPort());
+
+        String lockOwner = "Owner_Rfc_9_10_1";
+        /* Lock on a mapped url */
+        client.lockResource(mappedUrl, lockOwner, true, "infinity", "Unexpected status coude.",
+                c -> c.isResponse200() || c.isResponse204());
+        Assert.assertEquals(HttpServletResponse.SC_OK, client.getStatusCode());
+        Assert.assertTrue(client.getResponseBody().contains("opaquelocktoken:"));
+
+        Assert.assertTrue(
+                "9.10.1. Creating a Lock on an Existing Resource - MUST contain a body with the value of the DAV:lockdiscovery property in a prop XML element",
+                client.getResponseBody().contains(":lockdiscovery"));
+        Assert.assertTrue(
+                "9.10.1. Creating a Lock on an Existing Resource - MUST contain the full information about the lock just granted",
+                client.getResponseBody().contains(":owner") && client.getResponseBody().contains(lockOwner));
+    }
+
+    /**
+     * 9.10.2. Refreshing Locks
+     */
+//    @Test
+    public void testRfc_9_10_2() throws Exception {
+        Context ctx = prepareContext("rfc_9_10_2");
+        prepareWebdav(ctx, true, false);
+        String newDir = UUID.randomUUID().toString();
+        Assert.assertTrue(new File(getWebappAbsolutePath(), newDir).mkdir());
+
+        getTomcatInstance().start();
+        String mappedUrl = "/" + newDir;
+        WebdavClient client = new WebdavClient();
+        client.setPort(getPort());
+
+        String lockOwner = "Owner_Rfc_9_10_2";
+
+        /* Lock on a mapped url */
+        String lockToken = client.lockResource(mappedUrl, lockOwner, true, null, "Unexpected status coude.",
+                c -> c.isResponse200() || c.isResponse204());
+        Thread.sleep(1000L);
+        /**
+         * Refreshing
+         */
+        /*
+         * This request MUST NOT have a body and it MUST specify which lock to refresh by using the 'If' header with a
+         * single lock token (only one lock may be refreshed at a time).
+         */
+        /* Negative case: With wrong lock token */
+        client.refreshResourceLock(mappedUrl, "(<"+lockToken+"z>)", "9.10.2. Refreshing Locks - This request MUST NOT have a body and it MUST specify which lock to refresh by using the 'If' header with a single lock token (only one lock may be refreshed at a time).",r->r.getStatusCode()>=400);
+        /* Negative case: With body */
+        String lockBody = buildLockBody(true, lockOwner);
+        client.setRequest(new String[] { "LOCK " + mappedUrl + " HTTP/1.1" + SimpleHttpClient.CRLF +
+                "Host: localhost:" + getPort() + SimpleHttpClient.CRLF + "Content-Length: " + lockBody.length() +
+                SimpleHttpClient.CRLF + "Connection: Close" + SimpleHttpClient.CRLF + "If: (<" + lockToken + ">)" +
+                SimpleHttpClient.CRLF + SimpleHttpClient.CRLF + lockBody });
+
+        client.connect();
+        client.processRequest(true);
+        Assert.assertTrue(
+                "9.10.2. Refreshing Locks - This request MUST NOT have a body and it MUST specify which lock to refresh by using the 'If' header with a single lock token (only one lock may be refreshed at a time).",
+                client.getStatusCode() >= 400);
+
+        /*
+         * Positive case
+         */
+        client.refreshResourceLock(mappedUrl, "(<" + lockToken + ">)", "Unexpected status coude.",
+                c -> c.isResponse200());
+        /*
+         * The Lock-Token header is not returned in the response for a successful refresh LOCK request, but the LOCK
+         * response body MUST contain the new value for the DAV:lockdiscovery property.
+         */
+        Assert.assertTrue("9.10.2. Refreshing Locks - MUST contain the new value for the DAV:lockdiscovery property",
+                client.getResponseBody().contains(":lockdiscovery"));
+
+        /* A server MUST ignore the Depth header on a LOCK refresh. */
+        /*
+         * see rfc4918 - 10.2. Depth Header
+         * 
+         * Depth = "Depth" ":" ("0" | "1" | "infinity")
+         */
+        client.setRequest(new String[] { "LOCK " + mappedUrl + " HTTP/1.1" + SimpleHttpClient.CRLF +
+                "Host: localhost:" + getPort() + SimpleHttpClient.CRLF + "Connection: Close" + SimpleHttpClient.CRLF +
+                "If: (<" + lockToken + ">)" + SimpleHttpClient.CRLF + "Depth: infinity" + SimpleHttpClient.CRLF +
+                SimpleHttpClient.CRLF });
+
+        client.connect();
+        client.processRequest(true);
+        Assert.assertEquals(HttpServletResponse.SC_OK, client.getStatusCode());
+        Assert.assertTrue("", client.getResponseBody().contains(lockToken));
+        Assert.assertTrue("9.10.2. Refreshing Locks - MUST contain the new value for the DAV:lockdiscovery property",
+                client.getResponseBody().contains(":lockdiscovery"));
+        /* Depth: 0 */
+        client.setRequest(new String[] {
+                "LOCK " + mappedUrl + " HTTP/1.1" + SimpleHttpClient.CRLF + "Host: localhost:" + getPort() +
+                        SimpleHttpClient.CRLF + "Connection: Close" + SimpleHttpClient.CRLF + "If: (<" + lockToken +
+                        ">)" + SimpleHttpClient.CRLF + "Depth: 0" + SimpleHttpClient.CRLF + SimpleHttpClient.CRLF });
+
+        client.connect();
+        client.processRequest(true);
+        Assert.assertEquals(HttpServletResponse.SC_OK, client.getStatusCode());
+        /* Depth: 1 */
+        client.setRequest(new String[] {
+                "LOCK " + mappedUrl + " HTTP/1.1" + SimpleHttpClient.CRLF + "Host: localhost:" + getPort() +
+                        SimpleHttpClient.CRLF + "Connection: Close" + SimpleHttpClient.CRLF + "If: (<" + lockToken +
+                        ">)" + SimpleHttpClient.CRLF + "Depth: 1" + SimpleHttpClient.CRLF + SimpleHttpClient.CRLF });
+
+        client.connect();
+        client.processRequest(true);
+        Assert.assertEquals("9.10.2. Refreshing Locks - Depth header `1` is invalid for LOCK.", WebdavStatus.SC_BAD_REQUEST, client.getStatusCode());
+        /* Depth: 2 */
+        client.setRequest(new String[] {
+                "LOCK " + mappedUrl + " HTTP/1.1" + SimpleHttpClient.CRLF + "Host: localhost:" + getPort() +
+                        SimpleHttpClient.CRLF + "Connection: Close" + SimpleHttpClient.CRLF + "If: (<" + lockToken +
+                        ">)" + SimpleHttpClient.CRLF + "Depth: 2" + SimpleHttpClient.CRLF + SimpleHttpClient.CRLF });
+
+        client.connect();
+        client.processRequest(true);
+        Assert.assertEquals("9.10.2. Refreshing Locks - Depth header `2` is invalid.", WebdavStatus.SC_BAD_REQUEST, client.getStatusCode());
+        /* Depth: Hello, world */
+        client.setRequest(new String[] { "LOCK " + mappedUrl + " HTTP/1.1" + SimpleHttpClient.CRLF +
+                "Host: localhost:" + getPort() + SimpleHttpClient.CRLF + "Connection: Close" + SimpleHttpClient.CRLF +
+                "If: (<" + lockToken + ">)" + SimpleHttpClient.CRLF + "Depth: Hello, world" + SimpleHttpClient.CRLF +
+                SimpleHttpClient.CRLF });
+
+        client.connect();
+        client.processRequest(true);
+        Assert.assertEquals("9.10.2. Refreshing Locks - Depth header `Hello, world` is invalid.", WebdavStatus.SC_BAD_REQUEST, client.getStatusCode());
+    }
+
+    /**
+     * 9.10.3. Depth and Locking
+     * <p>
+     * The Depth header may be used with the LOCK method. Values other than 0 or infinity MUST NOT be used with the
+     * Depth header on a LOCK method. All resources that support the LOCK method MUST support the Depth header.
+     * <p>
+     * A Depth header of value 0 means to just lock the resource specified by the Request-URI.
+     * <p>
+     * If the Depth header is set to infinity, then the resource specified in the Request-URI along with all its
+     * members, all the way down the hierarchy, are to be locked. A successful result MUST return a single lock token.
+     * Similarly, if an UNLOCK is successfully executed on this token, all associated resources are unlocked. Hence,
+     * partial success is not an option for LOCK or UNLOCK. Either the entire hierarchy is locked or no resources are
+     * locked.
+     * <p>
+     * If the lock cannot be granted to all resources, the server MUST return a Multi-Status response with a 'response'
+     * element for at least one resource that prevented the lock from being granted, along with a suitable status code
+     * for that failure (e.g., 403 (Forbidden) or 423 (Locked)). Additionally, if the resource causing the failure was
+     * not the resource requested, then the server SHOULD include a 'response' element for the Request-URI as well, with
+     * a 'status' element containing 424 Failed Dependency.
+     * <p>
+     * If no Depth header is submitted on a LOCK request, then the request MUST act as if a "Depth:infinity" had been
+     * submitted.
+     */
+//    @Test
+    public void testRfc_9_10_3() throws Exception {
+        Context ctx = prepareContext("rfc_9_10_3");
+        prepareWebdav(ctx, true, false);
+
+        String dir1 = UUID.randomUUID().toString();
+        Assert.assertTrue(new File(getWebappAbsolutePath(), dir1).mkdir());
+        String dir11 = UUID.randomUUID().toString();
+        Assert.assertTrue(new File(getWebappAbsolutePath() + File.separator + dir1, dir11).mkdir());
+        String dir2 = UUID.randomUUID().toString();
+        Assert.assertTrue(new File(getWebappAbsolutePath(), dir2).mkdir());
+        String dir3 = UUID.randomUUID().toString();
+        Assert.assertTrue(new File(getWebappAbsolutePath(), dir3).mkdir());
+
+        getTomcatInstance().start();
+        WebdavClient client = new WebdavClient();
+        client.setPort(getPort());
+
+        String mappedUrl1 = "/" + dir1;
+        String mappedUrl11 = "/" + dir1 + "/" + dir11;
+        String mapperUrl2 = "/" + dir2;
+        String mapperUrl3 = "/" + dir3;
+
+        String lockOwner = "Owner_Rfc_9_10_3";
+        String lockToken1, lockToken11, lockToken2, lockToken3;
+        /*
+         * see rfc4918 - 10.2. Depth Header
+         * 
+         * Depth = "Depth" ":" ("0" | "1" | "infinity")
+         */
+        /*
+         * Invalid Depth header request:Values other than 0 or infinity MUST NOT be used
+         */
+        lockToken1 = client.lockResource(mappedUrl1, lockOwner, true, "-1",
+                "9.10.3. Depth and Locking - The Depth header may be used with the LOCK method. Values other than 0 or infinity MUST NOT used with the Depth header on a LOCK method. 4xx status coude expected",
+                c -> c.getStatusCode() >= 400 && c.getStatusCode() < 500);
+        Assert.assertNull(lockToken1);
+
+        lockToken1 = client.lockResource(mappedUrl1, lockOwner, true, "1",
+                "9.10.3. Depth and Locking - The Depth header may be used with the LOCK method. Values other than 0 or infinity MUST NOT used with the Depth header on a LOCK method. 4xx status coude expected",
+                c -> c.getStatusCode() >= 400 && c.getStatusCode() < 500);
+        Assert.assertNull(lockToken1);
+
+        lockToken1 = client.lockResource(mappedUrl1, lockOwner, true, "2",
+                "9.10.3. Depth and Locking - The Depth header may be used with the LOCK method. Values other than 0 or infinity MUST NOT used with the Depth header on a LOCK method. 4xx status coude expected",
+                c -> c.getStatusCode() >= 400 && c.getStatusCode() < 500);
+        Assert.assertNull(lockToken1);
+
+
+        /*
+         * If no Depth header is submitted on a LOCK request, then the request MUST act as if a "Depth:infinity" had
+         * been submitted.
+         */
+        lockToken1 = client.lockResource(mappedUrl1, lockOwner, true, null, "2xx status coude expected",
+                c -> c.getStatusCode() < 300);
+        // Check sub dir is locked
+        lockToken11 = client.lockResource(mappedUrl11, lockOwner, true, "0",
+                WebdavStatus.SC_LOCKED + " status coude expected", c -> c.getStatusCode() == WebdavStatus.SC_LOCKED);
+        Assert.assertNull("9.10.3. Depth and Locking - parent resource has been locked.", lockToken11);
+
+
+        Assert.assertNotNull(lockToken1);
+        lockToken2 = client.lockResource(mapperUrl2, lockOwner, true, "infinity", "2xx status coude expected",
+                c -> c.getStatusCode() < 300);
+        Assert.assertNotNull(lockToken2);
+        lockToken3 = client.lockResource(mapperUrl3, lockOwner, true, "0", "2xx status coude expected",
+                c -> c.getStatusCode() < 300);
+        Assert.assertNotNull(lockToken3);
+
+        client.unlockResource(mappedUrl1, lockToken1, "Unexpected", c -> c.getStatusCode() < 300);
+
+
+        /* Lock response Multi-Status response */
+        lockToken11 = client.lockResource(mappedUrl11, lockOwner, true, "0", "2xx status coude expected",
+                c -> c.getStatusCode() < 300);
+        Assert.assertNotNull(lockToken11);
+
+        lockToken1 = client.lockResource(mappedUrl1, lockOwner + "-Copy", true, "infinity",
+                "9.10.3. Depth and Locking - the server MUST return a Multi-Status response with a 'response element for at least one resource that prevented the lock from being granted",
+                c -> {
+                    String body = client.getResponseBody();
+                    return c.getStatusCode() == 207 && body.contains(dir11) && body.contains(dir1) &&
+                            body.contains(WebdavStatus.SC_FAILED_DEPENDENCY + "") &&
+                            body.contains(WebdavStatus.SC_LOCKED + "");
+                });
+
+        Assert.assertNull(lockToken1);
+
+    }
+
+    /**
+     * 9.10.4. Locking Unmapped URLs
+     * <p>
+     * A successful LOCK method MUST result in the creation of an empty resource that is locked (and that is not a
+     * collection) when a resource did not previously exist at that URL. Later on, the lock may go away but the empty
+     * resource remains. Empty resources MUST then appear in PROPFIND responses including that URL in the response
+     * scope. A server MUST respond successfully to a GET request to an empty resource, either by using a 204 No Content
+     * response, or by using 200 OK with a Content-Length header indicating zero length
+     */
+    @Test
+    public void testRfc_9_10_4() throws Exception {
+        // Locking Unmapped URLs
+        Context ctx = prepareContext("rfc_9_10_4");
+        prepareWebdav(ctx, true, false);
+
+        getTomcatInstance().start();
+        WebdavClient client = new WebdavClient();
+        client.setPort(getPort());
+
+        String unmappedUrl = "/" + UUID.randomUUID().toString();
+
+        String lockOwner = "Owner_Rfc_9_10_4";
+
+        /* Lock on a not exist file */
+        /*
+         * 7.3. Write Locks and Unmapped URLs o The response MUST indicate that a resource was created, by use of the
+         * "201 Created" response code (a LOCK request to an existing resource instead will result in 200 OK). The body
+         * must still include the DAV:lockdiscovery property, as with a LOCK request to an existing resource.
+         */
+        String lockToken = client.lockResource(unmappedUrl, lockOwner, true, "0", "Unsupported status code.",
+                c -> c.getStatusCode() == WebdavStatus.SC_CREATED);
+
+        Assert.assertNotNull(lockToken);
+        Assert.assertTrue(client.getResponseBody().contains("opaquelocktoken:"));
+        Assert.assertTrue(client.getResponseBody().contains("lockdiscovery"));
+
+        /* lock go away - Unlock it */
+        client.unlockResource(unmappedUrl, lockToken, "Unexpected status code.",
+                c -> HttpServletResponse.SC_OK == c.getStatusCode() ||
+                        HttpServletResponse.SC_NO_CONTENT == c.getStatusCode());
+
+        client.setRequest(
+                new String[] { "PROPFIND / HTTP/1.1" + SimpleHttpClient.CRLF + "Host: localhost:" + getPort() +
+                        SimpleHttpClient.CRLF + "Connection: Close" + SimpleHttpClient.CRLF + SimpleHttpClient.CRLF });
+        client.connect();
+        client.processRequest(true);
+        Assert.assertTrue(
+                "9.10.4. Locking Unmapped URLs - Empty resources MUST then appear in PROPFIND responses including that URL in the response scope.",
+                client.getResponseBody().contains(unmappedUrl));
+
+        client.setRequest(new String[] {
+                "GET " + unmappedUrl + " HTTP/1.1" + SimpleHttpClient.CRLF + "Host: localhost:" + getPort() +
+                        SimpleHttpClient.CRLF + "Connection: Close" + SimpleHttpClient.CRLF + SimpleHttpClient.CRLF });
+        client.connect();
+        client.processRequest(true);
+        int rc;
+        rc = client.getStatusCode();
+        Assert.assertTrue(
+                "9.10.4. Locking Unmapped URLs - A server MUST respond successfully to a GET request to an empty resource, either by using a 204 No Content response, or by using 200 OK with a Content-Length header indicating zero length",
+                WebdavStatus.SC_OK == rc || WebdavStatus.SC_NO_CONTENT == rc);
+        if (rc == WebdavStatus.SC_OK) {
+            // Check content length zero
+            boolean zeroContentLengthHeaderFound = false;
+            for (String header : client.getResponseHeaders()) {
+                if (header.equalsIgnoreCase("Content-Length: 0")) {
+                    zeroContentLengthHeaderFound = true;
+                }
+            }
+            Assert.assertTrue(
+                    "9.10.4. Locking Unmapped URLs - A server MUST respond successfully to a GET request to an empty resource, either by using a 204 No Content response, or by using 200 OK with a Content-Length header indicating zero length",
+                    zeroContentLengthHeaderFound);
+        }
+
+    }
+
+    /**
+     * 9.10.5. Lock Compatibility Table
+     * <p>
+     * The table below describes the behavior that occurs when a lock request is made on a resource.
+     * <p>
+     * 
+     * <pre>
+     * +--------------------------+----------------+-------------------+
+     * | Current State            | Shared Lock OK | Exclusive Lock OK |
+     * +--------------------------+----------------+-------------------+
+     * | None                     | True           | True              |
+     * | Shared Lock              | True           | False             |
+     * | Exclusive Lock           | False          | False*            |
+     * +--------------------------+----------------+-------------------+
+     * </pre>
+     * 
+     * Legend: True = lock may be granted. False = lock MUST NOT be granted. *=It is illegal for a principal to request
+     * the same lock twice. The current lock state of a resource is given in the leftmost column, and lock requests are
+     * listed in the first row. The intersection of a row and column gives the result of a lock request. For example, if
+     * a shared lock is held on a resource, and an exclusive lock is requested, the table entry is "false", indicating
+     * that the lock must not be granted.
+     */
+    @Test
+    public void testRfc_9_10_5() throws Exception {
+        Context ctx = prepareContext("rfc_9_10_5");
+        prepareWebdav(ctx, true, false);
+
+        String collection1 = UUID.randomUUID().toString();
+        Assert.assertTrue(new File(getWebappAbsolutePath(), collection1).mkdir());
+        String collection11 = UUID.randomUUID().toString();
+        Assert.assertTrue("Failed to mkdir of ",
+                new File(getWebappAbsolutePath() + File.separator + collection1, collection11).mkdir());
+
+        String collection12 = UUID.randomUUID().toString();
+        Assert.assertTrue("Failed to mkdir of ",
+                new File(getWebappAbsolutePath() + File.separator + collection1, collection12).mkdir());
+
+        String collection13 = UUID.randomUUID().toString();
+        Assert.assertTrue("Failed to mkdir of ",
+                new File(getWebappAbsolutePath() + File.separator + collection1, collection13).mkdir());
+
+        getTomcatInstance().start();
+        WebdavClient client = new WebdavClient();
+        client.setPort(getPort());
+
+        String lockOwner = "Owner_Rfc_9_10_5";
+        String sharedLockToken11, sharedLockToken11c, sharedLockToken12;
+        String exclusiveLockToken11, exclusiveLockToken12, exclusiveLockToken12c;
+
+        String resourceUri = "/" + collection1 + "/" + collection11;
+
+        sharedLockToken11 = client.lockResource(resourceUri, lockOwner + "_shared11", false, "infinity",
+                "Unexpected response", r -> r.isResponse200() || r.isResponse201());
+
+        // 9.10.5. Lock Compatibility Table - True = lock may be granted.
+        // That is, second shared lock request on a Shared-Locked resource: may be or may be not granted.
+        sharedLockToken11c =
+                client.lockResource(resourceUri, lockOwner + "_shared11c", false, "infinity", "Unexpected response",
+                        r -> r.isResponse200() || r.isResponse201() || WebdavStatus.SC_LOCKED == r.getStatusCode());
+        if (Objects.isNull(sharedLockToken11c)) {
+            Assert.assertEquals(WebdavStatus.SC_LOCKED, client.getStatusCode());
+        }
+
+        // 9.10.5. Lock Compatibility Table - False = lock MUST NOT be granted.
+        // Exclusive lock request on a Shared-Locked resource: MUST not be granted
+        exclusiveLockToken11 = client.lockResource(resourceUri, lockOwner + "_exclusive11", true, "infinity",
+                "Unexpected response", r -> WebdavStatus.SC_LOCKED == r.getStatusCode());
+        Assert.assertNull(
+                "9.10.5. Lock Compatibility Table - MUST NOT grant exclusive lock on a resource having shared lock.",
+                exclusiveLockToken11);
+
+        resourceUri = "/" + collection1 + "/" + collection12;
+        exclusiveLockToken12 = client.lockResource(resourceUri, lockOwner + "_exclusive12", true, "infinity",
+                "Unexpected response", r -> r.isResponse200() || r.isResponse201());
+        sharedLockToken12 = client.lockResource(resourceUri, lockOwner + "_shared12", false, "infinity",
+                "Unexpected response", r -> WebdavStatus.SC_LOCKED == r.getStatusCode());
+        Assert.assertNull(
+                "9.10.5. Lock Compatibility Table - MUST NOT grant shared lock on a resource having exclusive lock.",
+                exclusiveLockToken11);
+        exclusiveLockToken12c =
+                client.lockResource(resourceUri, lockOwner + "_exclusive12", true, "infinity", "Unexpected response",
+                        r -> r.isResponse200() || r.isResponse201() || WebdavStatus.SC_LOCKED == r.getStatusCode());
+        if (Objects.isNull(exclusiveLockToken12c)) {
+            Assert.assertEquals(WebdavStatus.SC_LOCKED, client.getStatusCode());
+        }
+    }
+
+    /**
+     * 9.10.6. LOCK Responses
+     * <p>
+     */
+    @Test
+    public void testRfc_9_10_6() throws Exception {
+        Context ctx = prepareContext("rfc_9_10_6");
+        prepareWebdav(ctx, true, false);
+
+        String collection1 = UUID.randomUUID().toString();
+        Assert.assertTrue(new File(getWebappAbsolutePath(), collection1).mkdir());
+        String collection11 = UUID.randomUUID().toString();
+        Assert.assertTrue("Failed to mkdir of ",
+                new File(getWebappAbsolutePath() + File.separator + collection1, collection11).mkdir());
+
+        String collection12 = UUID.randomUUID().toString();
+        Assert.assertTrue("Failed to mkdir of ",
+                new File(getWebappAbsolutePath() + File.separator + collection1, collection12).mkdir());
+
+        String collection13 = UUID.randomUUID().toString();
+        Assert.assertTrue("Failed to mkdir of ",
+                new File(getWebappAbsolutePath() + File.separator + collection1, collection13).mkdir());
+
+        getTomcatInstance().start();
+        WebdavClient client = new WebdavClient();
+        client.setPort(getPort());
+
+        String lockOwner = "Owner_Rfc_9_10_6";
+
+        String resourceUri = "/" + collection1 + "/" + collection11;
+
+        /* 200 */
+        String sharedLockToken11 = client.lockResource(resourceUri, lockOwner + "_shared11", false, "infinity",
+                "9.10.6. LOCK Responses - 200 (OK)", r -> r.isResponse200());
+        Assert.assertNotNull(sharedLockToken11);
+        /* 201 */
+        resourceUri = "/" + collection1 + "/" + collection12 + "/EMPTY_RESOURCE.html";// Empty resource
+        String sharedLockToken121 = client.lockResource(resourceUri, lockOwner + "_shared11", false, "infinity",
+                "9.10.6. LOCK Responses - 201 (Created)", r -> WebdavStatus.SC_CREATED == r.getStatusCode());
+        Assert.assertNotNull("9.10.6. LOCK Responses - 201 (Created)", sharedLockToken11);
+
+        /* 409 */
+        resourceUri = "/" + collection1 + "/" + collection12 + "/409/EMPTY_RESOURCE.html";
+        String sharedLockToken1221 = client.lockResource(resourceUri, lockOwner + "_shared11", false, "infinity",
+                "9.10.6.  LOCK Responses - 409 (Conflict) - A resource cannot be created at the destination until one or more intermediate collections have been created. The server MUST NOT create those intermediate collections automatically.",
+                r -> WebdavStatus.SC_CONFLICT == r.getStatusCode());
+        Assert.assertNull(
+                "9.10.6.  LOCK Responses - 409 (Conflict) - A resource cannot be created at the destination until one or more intermediate collections have been created. The server MUST NOT create those intermediate collections automatically.",
+                sharedLockToken1221);
+
+        /* 423:see rfc 9_10_5 */
+        /* 412 */
+        resourceUri = "/" + collection1 + "/" + collection13;
+        client.refreshResourceLock(resourceUri, "(<" + sharedLockToken11 + ">)",
+                "9.10.6. LOCK Responses - 412 (Precondition Failed)",
+                r -> WebdavStatus.SC_PRECONDITION_FAILED == r.getStatusCode());
+    }
+
+}

--- a/test/org/apache/catalina/servlets/TestWebdavServletRfcSection_9_11.java
+++ b/test/org/apache/catalina/servlets/TestWebdavServletRfcSection_9_11.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.catalina.servlets;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.util.UUID;
+
+import org.apache.catalina.Context;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestWebdavServletRfcSection_9_11 extends WebdavServletRfcSectionBase {
+    /**
+     * 9.11. UNLOCK Method
+     * <p>
+     * The UNLOCK method removes the lock identified by the lock token in the Lock-Token request header. The Request-URI
+     * MUST identify a resource within the scope of the lock.
+     * <p>
+     * Note that use of the Lock-Token header to provide the lock token is not consistent with other state-changing
+     * methods, which all require an If header with the lock token. Thus, the If header is not needed to provide the
+     * lock token. Naturally, when the If header is present, it has its normal meaning as a conditional header.
+     * <p>
+     * For a successful response to this method, the server MUST delete the lock entirely.
+     * <p>
+     * If all resources that have been locked under the submitted lock token cannot be unlocked, then the UNLOCK request
+     * MUST fail.
+     * <p>
+     * A successful response to an UNLOCK method does not mean that the resource is necessarily unlocked. It means that
+     * the specific lock corresponding to the specified token no longer exists.
+     * <p>
+     * Any DAV-compliant resource that supports the LOCK method MUST support the UNLOCK method. This method is
+     * idempotent, but not safe (see Section 9.1 of [RFC2616]). Responses to this method MUST NOT be cached.
+     */
+    @Test
+    public void testRfc_9_11() throws Exception {
+        Context ctx = prepareContext("rfc_9_11");
+        prepareWebdav(ctx, true, false);
+        prepareExpirePolicy(ctx);
+
+        String collection1 = UUID.randomUUID().toString();
+        Assert.assertTrue(new File(getWebappAbsolutePath(), collection1).mkdir());
+        String collection11 = UUID.randomUUID().toString();
+        Assert.assertTrue("Failed to mkdir of ",
+                new File(getWebappAbsolutePath() + File.separator + collection1, collection11).mkdir());
+
+        String collection12 = UUID.randomUUID().toString();
+        Assert.assertTrue("Failed to mkdir of ",
+                new File(getWebappAbsolutePath() + File.separator + collection1, collection12).mkdir());
+        String collection121 = UUID.randomUUID().toString();
+        Assert.assertTrue("Failed to mkdir of ",
+                new File(getWebappAbsolutePath() + File.separator + collection1 + File.separator + collection12,
+                        collection121).mkdir());
+        String collection13 = UUID.randomUUID().toString();
+        Assert.assertTrue("Failed to mkdir of ",
+                new File(getWebappAbsolutePath() + File.separator + collection1, collection13).mkdir());
+        String file121 = "file121_readme.txt";
+        try (FileWriter fw = new FileWriter(getWebappAbsolutePath() + File.separator + collection1 + File.separator +
+                collection12 + File.separator + file121)) {
+            fw.write("file121_readme.txt-v1");
+            fw.flush();
+        }
+        getTomcatInstance().start();
+
+        WebdavClient client = new WebdavClient();
+        client.setPort(getPort());
+
+        String lockOwner = "Owner_Rfc_9_11";
+        /* Lock on a mapped url */
+        String lockToken = client.lockResource("/" + collection1 + "/" + collection11, lockOwner, true,
+                client.DEPTH_INFINITY, "Unexpected response", null);
+        Assert.assertNotNull(lockToken);
+
+        /*
+         * The Request-URI MUST identify a resource within the scope of the lock.
+         */
+        client.unlockResource("/" + collection1 + "/" + collection12, lockToken,
+                "9.11. UNLOCK Method - try unlock resource out of scope, 4xx status code expected.",
+                r -> r.getStatusCode() >= 400 && r.getStatusCode() < 500);
+
+        /* Unlock with wrong token */
+        client.unlockResource("/" + collection1 + "/" + collection11, "WrongToken",
+                "9.11. UNLOCK Method - try unlock with a wrong lock token, 4xx status code expected.",
+                r -> r.getStatusCode() >= 400 && r.getStatusCode() < 500);
+        // client.unlockResource("/" + collection1 + "/" + collection11, "PREFIX_"+lockToken+"_SUFFIX",
+        // "9.11. UNLOCK Method - try unlock with a wrong lock token, 4xx status code expected.",
+        // r -> r.getStatusCode() >= 400 && r.getStatusCode() < 500);
+        // TODO: FIXME: enable above case.
+        client.unlockResource("/" + collection1 + "/" + collection11, lockToken, "Unexpected response", null);
+
+        /**
+         * For a successful response to this method, the server MUST delete the lock entirely.
+         * <p>
+         * assume dir /xx/c1/c11/c111 exists:
+         * 
+         * <pre>
+         * 1. Lock /xx/c1, receive t1; 
+         * 2. unlock /xx/c1/c11 with t1; 
+         * expect: t1 removed entirely, and token on /xx/c1 must be removed entirely.
+         * </pre>
+         */
+        lockToken = client.lockResource("/" + collection1 + "/" + collection12, lockOwner, true, client.DEPTH_INFINITY,
+                "Unexpected response", null);
+        client.unlockResource("/" + collection1 + "/" + collection12 + "/" + collection121, lockToken,
+                "Unexpected response", null);
+        /* Retry unlock */
+        client.unlockResource("/" + collection1 + "/" + collection12, lockToken, "Unexpected response",
+                r -> WebdavStatus.SC_CONFLICT == r.getStatusCode());
+
+        String anotherLockToken =
+                client.lockResource("/" + collection1 + "/" + collection12, lockOwner, true, client.DEPTH_INFINITY,
+                        "Unexpected response", r -> r.isResponse200() || WebdavStatus.SC_CREATED == r.getStatusCode());
+
+        Assert.assertNotNull(
+                "9.11. UNLOCK Method - previous unlock should remove lock entirely, a NotNull token expected",
+                anotherLockToken);
+
+        /**
+         * If all resources that have been locked under the submitted lock token cannot be unlocked, then the UNLOCK
+         * request MUST fail.
+         */
+        // Get file121
+        client.getResource("/" + collection1 + "/" + collection12 + "/" + file121, "Unexpected response", null);
+        String etagValue = matchHeaders(client.getResponseHeaders(), h -> h.toLowerCase().startsWith("etag")).get(0)
+                .substring("etag: ".length());
+        client.unlockResource("/" + collection1 + "/" + collection12, anotherLockToken,
+                "<http://localhost:" + getPort() + "/" + collection1 + "/" + collection12 + "/" + file121 + "> (<" +
+                        anotherLockToken + "> [" + "wrongETagValue" + "])",
+                "9.11. UNLOCK Method - UNLOCK fail expected due to 'If' header mismatch, ",
+                r -> WebdavStatus.SC_PRECONDITION_FAILED == r.getStatusCode());
+        String wrongETagValue = "PREFIX_" + etagValue + "_SUFFIX";
+        client.unlockResource("/" + collection1 + "/" + collection12, anotherLockToken,
+                "<http://localhost:" + getPort() + "/" + collection1 + "/" + collection12 + "/" + file121 + "> (<" +
+                        anotherLockToken + "> [" + wrongETagValue + "])",
+                "9.11. UNLOCK Method - UNLOCK fail expected due to 'If' header mismatch, ",
+                r -> WebdavStatus.SC_PRECONDITION_FAILED == r.getStatusCode());
+
+        client.getResource("/" + collection1 + "/" + collection12 + "/" + file121, "Unexpected response", null);
+        Assert.assertTrue(client.isResponseCacheable());
+        etagValue = matchHeaders(client.getResponseHeaders(), h -> h.toLowerCase().startsWith("etag")).get(0)
+                .substring("etag: ".length());
+        client.unlockResource("/" + collection1 + "/" + collection12, anotherLockToken,
+                "<http://localhost:" + getPort() + "/" + collection1 + "/" + collection12 + "/" + file121 + "> (<" +
+                        anotherLockToken + "> [" + etagValue + "])",
+                "9.11. UNLOCK Method - UNLOCK SC_NO_CONTENT expected.",
+                r -> WebdavStatus.SC_NO_CONTENT == r.getStatusCode());
+
+        /* Responses to this method MUST NOT be cached. */
+        if(client.isResponseCacheable()) {
+            Assert.fail(
+                    "9.11. UNLOCK Method - Responses to this method MUST NOT be cached - Please check cache-control, expires, and etag");
+        }
+
+    }
+
+    /**
+     * 9.11.1. Status Codes
+     * <p>
+     */
+//    @Test
+    public void testRfc_9_11_1() throws Exception {
+        Context ctx = prepareContext("rfc_9_11_1");
+        prepareWebdav(ctx, true, false);
+        prepareExpirePolicy(ctx);
+
+        String collection1 = UUID.randomUUID().toString();
+        Assert.assertTrue(new File(getWebappAbsolutePath(), collection1).mkdir());
+        String collection11 = UUID.randomUUID().toString();
+        Assert.assertTrue("Failed to mkdir of ",
+                new File(getWebappAbsolutePath() + File.separator + collection1, collection11).mkdir());
+
+        getTomcatInstance().start();
+
+        WebdavClient client = new WebdavClient();
+        client.setPort(getPort());
+
+        String lockOwner = "Owner_Rfc_9_11";
+        /* Lock on a mapped url */
+        String lockToken = client.lockResource("/" + collection1 + "/" + collection11, lockOwner, true,
+                client.DEPTH_INFINITY, "Unexpected response", null);
+        Assert.assertNotNull(lockToken);
+        // 400
+        client.unlockResource("/" + collection1 + "/" + collection11, null,
+                "400 (Bad Request) - No lock token was provided.", r -> r.isResponse400());
+        // 403
+
+    }
+}

--- a/test/org/apache/catalina/servlets/WebdavServletRfcSectionBase.java
+++ b/test/org/apache/catalina/servlets/WebdavServletRfcSectionBase.java
@@ -1,0 +1,473 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.catalina.servlets;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import org.apache.catalina.Context;
+import org.apache.catalina.Wrapper;
+import org.apache.catalina.filters.ExpiresFilter;
+import org.apache.catalina.startup.SimpleHttpClient;
+import org.apache.catalina.startup.Tomcat;
+import org.apache.catalina.startup.TomcatBaseTest;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.tomcat.util.descriptor.web.FilterDef;
+import org.apache.tomcat.util.descriptor.web.FilterMap;
+import org.apache.tomcat.util.http.FastHttpDateFormat;
+import org.junit.Assert;
+
+public class WebdavServletRfcSectionBase extends TomcatBaseTest {
+
+    protected class WebdavClient extends SimpleHttpClient {
+        final String DEFAULT_MESSAGE_OF_RESPONSE_PREDICATION = "Unexpected response";
+
+        final Predicate<WebdavClient> DEFAULT_SC_PREDICATE = c -> c.getStatusCode() >= 200 && c.getStatusCode() < 300;
+
+        public WebdavClient() {
+            super();
+            this.setPort(WebdavServletRfcSectionBase.this.getPort());
+        }
+
+        /**
+         * Copy resource from srcUri to destUri
+         * 
+         * @param srcUri
+         * @param destUri
+         * @param overwrite
+         * @param message   if unacceptable response received.
+         * @param predicate to check acceptable response
+         * 
+         * @throws Exception
+         */
+        public void copyResource(String srcUri, String destUri, boolean overwrite, String lockToken, String message,
+                Predicate<WebdavClient> predicate) throws Exception {
+            StringBuffer buf = new StringBuffer();
+            buf.append("COPY " + srcUri + " HTTP/1.1" + CRLF + "Host: localhost:" + getPort() + CRLF + "Destination: " +
+                    "http://localhost:" + getPort() + destUri + CRLF + "Overwrite: " + (overwrite ? "T" : "F") + CRLF);
+            if (StringUtils.isNotEmpty(lockToken)) {
+                buf.append("Lock-Token: <" + lockToken + ">").append(CRLF);
+            }
+            buf.append(CRLF);
+            setRequest(new String[] { buf.toString() });
+            connect();
+            processRequest(true);
+            if (Objects.isNull(message)) {
+                message = DEFAULT_MESSAGE_OF_RESPONSE_PREDICATION;
+            }
+            if (predicate == null) {
+                predicate = DEFAULT_SC_PREDICATE;
+            }
+            if (predicate.test(this)) {
+                return;
+            } else {
+                throw new AssertionError(
+                        message + ", Failed to copyResource, actual status code was " + getStatusCode());
+            }
+        }
+        /**
+         * Gets content of specific resource.
+         * @param uri
+         * @param message
+         * @param predicate
+         * @return
+         * @throws Exception
+         */
+        protected String getResource(String uri, String message, Predicate<WebdavClient> predicate) throws Exception {
+            StringBuffer buf = new StringBuffer();
+            buf.append("GET " + uri + " HTTP/1.1" + CRLF + "Host: localhost:" + getPort() + CRLF + "Connection: Close" +
+                    CRLF + CRLF);
+            setRequest(new String[] { buf.toString() });
+            connect();
+            processRequest(true);
+            if (Objects.isNull(message)) {
+                message = DEFAULT_MESSAGE_OF_RESPONSE_PREDICATION;
+            }
+            if (predicate == null) {
+                predicate = DEFAULT_SC_PREDICATE;
+            }
+            if (predicate.test(this)) {
+                return getResponseBody();
+            } else {
+                throw new AssertionError(message + ", actual status code was " + getStatusCode());
+            }
+        }
+
+        @Override
+        public boolean isResponseBodyOK() {
+            return true;
+        }
+
+        final String DEPTH_INFINITY = "infinity";
+
+        /**
+         * Make a lock call and returns lock token.
+         * 
+         * @param uri       relative uri of target resource, start with splash '/'
+         * @param lockOwner identifier
+         * @param exclusive <code>true</code> - exclusive, <code>false</code> - shared.
+         * @param depth     of lock, only 0, infinity, or empty is supported.
+         * @param message   if predication failed
+         * @param predicate test result. If <code>null</code>, then default status code predication used.
+         * 
+         * @return lock token of successful response. <code>null</code> or throws exception if failed.
+         * 
+         * @throws Exception
+         */
+        protected String lockResource(String uri, String lockOwner, boolean exclusive, String depth, String message,
+                Predicate<WebdavClient> predicate) throws Exception {
+
+            String lockBody = buildLockBody(exclusive, lockOwner);
+            StringBuffer buf = new StringBuffer();
+            buf.append("LOCK " + uri + " HTTP/1.1" + CRLF + "Host: localhost:" + getPort() + CRLF);
+            if ("0".equals(depth)) {
+                buf.append("Depth: 0").append(CRLF);
+            } else if ("infinity".equals(depth) || StringUtils.isEmpty(depth)) {
+                buf.append("Depth: infinity").append(CRLF);
+            } else {
+                // Unsupported value
+                buf.append("Depth: ").append(depth).append(CRLF);
+                predicate = predicate.and(c -> c.getStatusCode() >= 400 && c.getStatusCode() < 500);
+            }
+            buf.append("Content-Length: " + lockBody.length() + CRLF + "Connection: Close" + CRLF + CRLF + lockBody);
+            /* Lock on a mapped url */
+            setRequest(new String[] { buf.toString() });
+
+            connect(600000,600000);
+            processRequest(true);
+            if (Objects.isNull(message)) {
+                message = DEFAULT_MESSAGE_OF_RESPONSE_PREDICATION;
+            }
+            if (predicate == null) {
+                predicate = DEFAULT_SC_PREDICATE;
+            }
+            if (predicate.test(this)) {
+                return parseLockToken();
+            } else {
+                throw new AssertionError(message + ", actual status code was " + getStatusCode());
+            }
+        }
+
+        /**
+         * Parse lock token from client headers.
+         * 
+         * @return valid lock token. returns <code>null</code> if not found.
+         */
+        protected String parseLockToken() {
+            String lockToken = null;
+            /* Lock-Token: <${lock_tocken}> */
+            final String ltPrefix = "Lock-Token: <";
+            final String ltSuffix = ">";
+            for (String header : getResponseHeaders()) {
+                if (header.startsWith(ltPrefix)) {
+                    lockToken = header.substring(ltPrefix.length(), header.length() - ltSuffix.length());
+                }
+            }
+            return lockToken;
+        }
+
+        /**
+         * @param uri
+         * @param contentType
+         * @param content
+         * @param ifHeaderValue
+         * @param message
+         * @param predicate
+         * 
+         * @throws Exception
+         */
+        protected void putResource(String uri, String contentType, String content, String ifHeaderValue, String message,
+                Predicate<WebdavClient> predicate) throws Exception {
+            Objects.requireNonNull(content);
+            StringBuffer buf = new StringBuffer();
+            buf.append("PUT " + uri + " HTTP/1.1" + CRLF + "Host: localhost:" + getPort() + CRLF + "Content-Length: " +
+                    content.length() + CRLF);
+            if (StringUtils.isNotEmpty(contentType)) {
+                buf.append("Content-Type: " + contentType).append(CRLF);
+            }
+            if (StringUtils.isNotEmpty(ifHeaderValue)) {
+                buf.append("If: " + ifHeaderValue + CRLF);
+            }
+            buf.append("Connection: Close" + CRLF + CRLF + content);
+            setRequest(new String[] { buf.toString() });
+            connect();
+            processRequest(true);
+            if (Objects.isNull(message)) {
+                message = DEFAULT_MESSAGE_OF_RESPONSE_PREDICATION;
+            }
+            if (predicate == null) {
+                predicate = DEFAULT_SC_PREDICATE;
+            }
+            if (predicate.test(this)) {
+                return;
+            } else {
+                throw new AssertionError(message + ", actual status code was " + getStatusCode());
+            }
+        }
+
+        /**
+         * Refresh a lock.
+         * 
+         * @param uri
+         * @param lockOwner
+         * @param exclusive
+         * @param ifToken
+         * @param message   if unacceptable response received.
+         * @param predicate to check acceptable response
+         * 
+         * @throws Exception
+         */
+        protected void refreshResourceLock(String uri, String ifHeaderValue, String message,
+                Predicate<WebdavClient> predicate) throws Exception {
+            /* Lock on a mapped url */
+            Objects.requireNonNull(ifHeaderValue);
+            setRequest(new String[] { "LOCK " + uri + " HTTP/1.1" + CRLF + "Host: localhost:" + getPort() + CRLF +
+                    "Connection: Close" + CRLF + "If: " + ifHeaderValue + CRLF + CRLF });
+            connect();
+            processRequest(true);
+            if (Objects.isNull(message)) {
+                message = DEFAULT_MESSAGE_OF_RESPONSE_PREDICATION;
+            }
+            if (predicate == null) {
+                predicate = DEFAULT_SC_PREDICATE;
+            }
+            if (predicate.test(this)) {
+                return;
+            } else {
+                throw new AssertionError(message + ", actual status code was " + getStatusCode());
+            }
+        }
+
+        /**
+         * Make a unlock call
+         * 
+         * @param uri       relative uri of target resource, start with splash '/'
+         * @param lockToken owner received via lock previous
+         * @param client    of http impl.
+         * @param message   if unacceptable response received.
+         * @param predicate to check acceptable response
+         * 
+         * @throws Exception
+         */
+        protected void unlockResource(String uri, String lockToken, String message, Predicate<WebdavClient> predicate)
+                throws Exception {
+            if (StringUtils.isEmpty(lockToken)) {
+                setRequest(new String[] { "UNLOCK " + uri + " HTTP/1.1" + CRLF + "Host: localhost:" + getPort() + CRLF +
+                        "Connection: Close" + CRLF + CRLF });
+            } else {
+                setRequest(new String[] { "UNLOCK " + uri + " HTTP/1.1" + CRLF + "Host: localhost:" + getPort() + CRLF +
+                        "Connection: Close" + CRLF + "Lock-Token: <" + lockToken + ">" + CRLF + CRLF });
+            }
+            connect();
+            processRequest(true);
+            if (Objects.isNull(message)) {
+                message = DEFAULT_MESSAGE_OF_RESPONSE_PREDICATION;
+            }
+            if (predicate == null) {
+                predicate = DEFAULT_SC_PREDICATE;
+            }
+            if (predicate.test(this)) {
+                return;
+            } else {
+                throw new AssertionError(message + ", Failed to unlock(lockToken=" + lockToken +
+                        "), actual status code was " + getStatusCode());
+            }
+        }
+
+        /**
+         * Make a unlock call
+         * 
+         * @param uri       relative uri of target resource, start with splash '/'
+         * @param lockToken owner received via lock previous
+         * @param client    of http impl.
+         * @param message   if unacceptable response received.
+         * @param predicate to check acceptable response
+         * 
+         * @throws Exception
+         */
+        protected void unlockResource(String uri, String lockToken, String ifHeaderValue, String message,
+                Predicate<WebdavClient> predicate) throws Exception {
+
+            setRequest(new String[] { "UNLOCK " + uri + " HTTP/1.1" + CRLF + "Host: localhost:" + getPort() + CRLF +
+                    "Connection: Close" + CRLF + "Lock-Token: <" + lockToken + ">" + CRLF + "If: " + ifHeaderValue +
+                    "" + CRLF + CRLF });
+            connect();
+            processRequest(true);
+            if (Objects.isNull(message)) {
+                message = DEFAULT_MESSAGE_OF_RESPONSE_PREDICATION;
+            }
+            if (predicate == null) {
+                predicate = DEFAULT_SC_PREDICATE;
+            }
+            if (predicate.test(this)) {
+                return;
+            } else {
+                throw new AssertionError(message + ", Failed to unlock(lockToken=" + lockToken +
+                        "), actual status code was " + getStatusCode());
+            }
+        }
+
+        protected void mkcolResource(String destUri, String message, Predicate<WebdavClient> expect) throws Exception {
+            setRequest(new String[] {
+                    "MKCOL " + destUri + " HTTP/1.1" + CRLF + "Host: localhost:" + getPort() + CRLF + CRLF + CRLF });
+            connect();
+            processRequest(true);
+            if (Objects.isNull(message)) {
+                message = DEFAULT_MESSAGE_OF_RESPONSE_PREDICATION;
+            }
+            if (expect == null) {
+                expect = DEFAULT_SC_PREDICATE;
+            }
+            if (expect.test(this)) {
+                return;
+            } else {
+                throw new AssertionError(
+                        message + ", Failed to mkcol on'" + destUri + "', actual status code was " + getStatusCode());
+            }
+        }
+
+        /**
+         * Checks whether response is ready for enable cache.
+         * 
+         * @return
+         */
+        protected boolean isResponseCacheable() {
+            for (String header : getResponseHeaders()) {
+                String lowerHeader = header.toLowerCase();
+                if (lowerHeader.startsWith("cache-control")) {
+                    if (!lowerHeader.contains("no-store")) {
+                        // middle tier may enable cache.
+                        return true;
+                    }
+                    int firstIndexOf = lowerHeader.indexOf("max-age=");
+                    if (firstIndexOf >= 0 && !lowerHeader.endsWith("max-age=0") &&
+                            !lowerHeader.contains("max-age=0,")) {
+                        // defines max-age>0
+                        return true;
+                    }
+                } else if (lowerHeader.startsWith("expires")) {
+                    if (lowerHeader.length() > "expires: ".length()) {
+                        String expireAt = header.substring("Expires: ".length());
+                        long ts = FastHttpDateFormat.parseDate(expireAt);
+                        if (ts > 1000L + System.currentTimeMillis()) {
+                            return true;
+                        }
+                    }
+                } else if (lowerHeader.startsWith("etag:")) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    private File tempWebapp = null;
+
+    protected String buildLockBody(boolean isExclusive, String owner) {
+        StringBuffer buf = new StringBuffer();
+        buf.append("<?xml version=\"1.0\" encoding=\"utf-8\" ?>");
+        buf.append("<D:lockinfo xmlns:D='DAV:'>");
+        buf.append("<D:lockscope>");
+        if (isExclusive) {
+            buf.append("<D:exclusive/>");
+        } else {
+            buf.append("<D:shared/>");
+        }
+        buf.append("</D:lockscope>");
+        buf.append("<D:locktype><D:write/></D:locktype>");
+        buf.append("<D:owner>").append(owner).append("</D:owner>");
+        buf.append("</D:lockinfo>");
+        return buf.toString();
+    }
+
+    protected String getWebappAbsolutePath() {
+        return tempWebapp.getAbsolutePath();
+    }
+
+    /**
+     * Look up for specific header lines
+     * 
+     * @param headers a list of source header lines.
+     * @param tester  a predicate
+     * 
+     * @return matched header lines
+     */
+    protected List<String> matchHeaders(List<String> headers, Predicate<String> tester) {
+        Objects.requireNonNull(headers);
+        Objects.requireNonNull(tester);
+        List<String> matched = new ArrayList<String>();
+        for (String headerLine : headers) {
+            if (tester.test(headerLine)) {
+                matched.add(headerLine);
+            }
+        }
+        return matched;
+    }
+
+    protected Context prepareContext(String ctxDirName) {
+        Tomcat tomcat = getTomcatInstance();
+
+        // Create a temp webapp that can be safely written to
+        tempWebapp = new File(getTemporaryDirectory(), ctxDirName);
+        Assert.assertTrue("Failed to mkdirs on " + tempWebapp.getAbsolutePath() + ".", tempWebapp.mkdirs());
+        Context ctxt = tomcat.addContext("", tempWebapp.getAbsolutePath());
+        return ctxt;
+    }
+
+    protected void prepareExpirePolicy(Context ctx) {
+        Objects.requireNonNull(ctx);
+        FilterDef filterDef = new FilterDef();
+        filterDef.addInitParameter("ExpiresDefault", "access plus 1 month");
+        filterDef.addInitParameter("ExpiresByType text/html", "access plus 1 month 15 days 2 hours");
+        filterDef.addInitParameter("ExpiresByType application/xml", "access plus 1 month 15 days 2 hours");
+        filterDef.addInitParameter("ExpiresByType image/gif", "modification plus 5 hours 3 minutes");
+        filterDef.addInitParameter("ExpiresByType image/jpg", "A10000");
+        filterDef.addInitParameter("ExpiresByType video/mpeg", "M20000");
+        filterDef.addInitParameter("ExpiresExcludedResponseStatusCodes", "304, 503");
+        filterDef.setFilter(new ExpiresFilter());
+        filterDef.setFilterClass(ExpiresFilter.class.getName());
+        filterDef.setFilterName(ExpiresFilter.class.getName());
+
+        ctx.addFilterDef(filterDef);
+
+        FilterMap filterMap = new FilterMap();
+        filterMap.setFilterName(ExpiresFilter.class.getName());
+        filterMap.addURLPatternDecoded("*");
+
+        ctx.addFilterMap(filterMap);
+    }
+
+    /**
+     * Prepare a temp webapp for webdav
+     * 
+     * @param listings
+     * @param readonly
+     * 
+     * @throws Exception
+     */
+    protected void prepareWebdav(Context ctx, boolean listings, boolean readonly) throws Exception {
+        Objects.requireNonNull(ctx);
+        Wrapper webdavServlet = Tomcat.addServlet(ctx, "webdav", new WebdavServlet());
+        webdavServlet.addInitParameter("listings", listings ? "true" : "false");
+        webdavServlet.addInitParameter("secret", "foo");
+        webdavServlet.addInitParameter("readonly", readonly ? "true" : "false");
+        ctx.addServletMappingDecoded("/*", "webdav");
+    }
+}


### PR DESCRIPTION
Make sure that Responses of lock / unlock methods MUST NOT be cached, per rfc4918. 
see #disableCacheable()
testcase added.