### PR TITLE
RateLimitFilter - enhance exposeHeaders to support "ietf rate limit h…

### DIFF
--- a/java/org/apache/catalina/util/FastRateLimiter.java
+++ b/java/org/apache/catalina/util/FastRateLimiter.java
@@ -18,6 +18,7 @@
 package org.apache.catalina.util;
 
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import jakarta.servlet.FilterConfig;
 
@@ -27,6 +28,26 @@ import org.apache.tomcat.util.threads.ScheduledThreadPoolExecutor;
  * A RateLimiter that compromises accuracy for speed in order to provide maximum throughput.
  */
 public class FastRateLimiter implements RateLimiter {
+
+    private static AtomicInteger index = new AtomicInteger();
+
+    public FastRateLimiter() {
+        super();
+        // initial policy name, can be rewritten by setPolicyName()
+        this.policyName = "fast-"+index.incrementAndGet();
+    }
+
+    private String policyName;
+
+    @Override
+    public String getPolicyName() {
+        return policyName;
+    }
+
+    @Override
+    public void setPolicyName(String name) {
+        this.policyName = name;
+    }
 
     TimeBucketCounter bucketCounter;
 

--- a/java/org/apache/catalina/util/RateLimiter.java
+++ b/java/org/apache/catalina/util/RateLimiter.java
@@ -65,4 +65,45 @@ public interface RateLimiter {
      * @param filterConfig The FilterConfig used to configure the associated filter
      */
     void setFilterConfig(FilterConfig filterConfig);
+
+    /**
+     * Sets policy name, otherwise auto-generated name used
+     * @param name of rate limit policy
+     */
+    void setPolicyName(String name);
+
+    /**
+     * @return name of RateLimit policy
+     */
+    String getPolicyName();
+
+    /**
+     * @return full representation of current policy
+     * @see <a href=
+     *          "https://www.ietf.org/archive/id/draft-ietf-httpapi-ratelimit-headers-08.html#name-ratelimit-policy-field">name-ratelimit-policy-field</a>
+     */
+    default String getPolicy() {
+        // enclose policy name with double quotes. e.g. "fixed-01";q=3000;w=60
+        return "\"" + getPolicyName() + "\";q=" + getRequests() + ";w=" + getDuration();
+    }
+
+    class RateLimitItem {
+        private String policyName;
+        private int remaining;
+
+        /**
+         * @param policyName specifying the RateLimit policy name.
+         * @param remaining usage in runtime.
+         */
+        public RateLimitItem(String policyName, int remaining) {
+            this.policyName = policyName;
+            this.remaining = remaining;
+        }
+
+        @Override
+        public String toString() {
+            // enclose policy name with double quotes. e.g. "fixed-01";r=30
+            return "\"" + policyName + "\";r=" + remaining;
+        }
+    }
 }

--- a/test/org/apache/catalina/filters/TestRateLimitFilter.java
+++ b/test/org/apache/catalina/filters/TestRateLimitFilter.java
@@ -39,8 +39,7 @@ import org.apache.tomcat.util.descriptor.web.FilterMap;
 
 public class TestRateLimitFilter extends TomcatBaseTest {
 
-    @Test
-    public void testRateLimitWith4Clients() throws Exception {
+    private void testRateLimitWith4Clients(boolean exposeHeaders, boolean enforce) throws Exception {
 
         int bucketRequests = 40;
         int bucketDuration = 4;
@@ -48,6 +47,8 @@ public class TestRateLimitFilter extends TomcatBaseTest {
         FilterDef filterDef = new FilterDef();
         filterDef.addInitParameter("bucketRequests", String.valueOf(bucketRequests));
         filterDef.addInitParameter("bucketDuration", String.valueOf(bucketDuration));
+        filterDef.addInitParameter("enforce", String.valueOf(enforce));
+        filterDef.addInitParameter("exposeHeaders", String.valueOf(exposeHeaders));
 
         Tomcat tomcat = getTomcatInstance();
         Context root = tomcat.addContext("", TEMP_DIR);
@@ -83,10 +84,46 @@ public class TestRateLimitFilter extends TomcatBaseTest {
         Assert.assertEquals(200, tc2.results[49]); // only 25 requests made, all allowed
 
         Assert.assertEquals(200, tc3.results[allowedRequests - 1]); // first allowedRequests allowed
-        Assert.assertEquals(429, tc3.results[allowedRequests]); // subsequent requests dropped
 
         Assert.assertEquals(200, tc4.results[allowedRequests - 1]); // first allowedRequests allowed
-        Assert.assertEquals(429, tc4.results[allowedRequests]); // subsequent requests dropped
+        if (enforce) {
+            Assert.assertEquals(429, tc3.results[allowedRequests]); // subsequent requests dropped
+            Assert.assertEquals(429, tc4.results[allowedRequests]); // subsequent requests dropped
+        }
+        if (exposeHeaders) {
+            Assert.assertTrue(tc3.rlpHeader[24].contains("q=" + allowedRequests));
+            Assert.assertTrue(tc3.rlpHeader[allowedRequests].contains("q=" + allowedRequests));
+            if (enforce) {
+                Assert.assertTrue(tc3.rlHeader[24].contains("r="));
+                Assert.assertFalse(tc3.rlHeader[24].contains("r=0"));
+                Assert.assertTrue(tc3.rlHeader[allowedRequests].contains("r=0"));
+            }
+        } else {
+            Assert.assertTrue(tc3.rlpHeader[24] == null);
+            Assert.assertTrue(tc3.rlHeader[24] == null);
+            Assert.assertTrue(tc3.rlpHeader[allowedRequests] == null);
+            Assert.assertTrue(tc3.rlHeader[allowedRequests] == null);
+        }
+    }
+
+    @Test
+    public void testExposeHeaderAndRerferenceRateLimitWith4Clients() throws Exception {
+        testRateLimitWith4Clients(true, false);
+    }
+
+    @Test
+    public void testUnexposeHeaderAndRerferenceRateLimitWith4Clients() throws Exception {
+        testRateLimitWith4Clients(false, false);
+    }
+
+    @Test
+    public void testExposeHeaderAndEnforceRateLimitWith4Clients() throws Exception {
+        testRateLimitWith4Clients(true, true);
+    }
+
+    @Test
+    public void testUnexposeHeaderAndEnforceRateLimitWith4Clients() throws Exception {
+        testRateLimitWith4Clients(false, true);
     }
 
     private RateLimitFilter testRateLimitFilter(FilterDef filterDef, Context root) throws ServletException {
@@ -118,6 +155,8 @@ public class TestRateLimitFilter extends TomcatBaseTest {
         int sleep;
 
         int[] results;
+        volatile String[] rlpHeader;
+        volatile String[] rlHeader;
 
         TestClient(RateLimitFilter filter, FilterChain filterChain, String ip, int requests, int rps) {
             this.filter = filter;
@@ -126,6 +165,8 @@ public class TestRateLimitFilter extends TomcatBaseTest {
             this.requests = requests;
             this.sleep = 1000 / rps;
             this.results = new int[requests];
+            this.rlpHeader = new String[requests];
+            this.rlHeader = new String[requests];
             super.setDaemon(true);
             super.start();
         }
@@ -140,8 +181,10 @@ public class TestRateLimitFilter extends TomcatBaseTest {
                     response.setRequest(request);
                     filter.doFilter(request, response, filterChain);
                     results[i] = response.getStatus();
-                    System.out.printf("%s %s: %s %d\n", ip, Instant.now(), Integer.valueOf(i + 1),
-                            Integer.valueOf(response.getStatus()));
+                    rlpHeader[i] = response.getHeader(RateLimitFilter.HEADER_RATE_LIMIT_POLICY);
+                    rlHeader[i] = response.getHeader(RateLimitFilter.HEADER_RATE_LIMIT);
+                    System.out.printf("%s %s: %s %d, Policy:%s, Current:%s\n", ip, Instant.now(), Integer.valueOf(i + 1),
+                            Integer.valueOf(response.getStatus()),rlpHeader[i],rlHeader[i]);
                     sleep(sleep);
                 }
             } catch (Exception ex) {

--- a/webapps/docs/config/filter.xml
+++ b/webapps/docs/config/filter.xml
@@ -989,6 +989,10 @@ FINE: Request "/docs/config/manager.html" with response status "200"
     how to handle the request based on other information that it has, e.g. allow
     more requests to certain users based on roles, etc.</p>
 
+    <p>The <code>exposeHeaders</code> allows output runtime information of rate
+    limiter via response header, is disabled by default, only for http-api or
+    debugging purpose.</p>
+
     <p><strong>WARNING:</strong> if Tomcat is behind a reverse proxy then you must
     make sure that the Rate Limit Filter sees the client IP address, so if for
     example you are using the <a href="#Remote_IP_Filter">Remote IP Filter</a>,
@@ -1031,6 +1035,12 @@ FINE: Request "/docs/config/manager.html" with response status "200"
         org.apache.catalina.filters.RateLimitFilter.Count to retrieve
         the number of Requests made from that IP within the time window.
         Default is <code>true</code>.</p>
+      </attribute>
+
+      <attribute name="exposeHeaders" required="false">
+        <p>Set to true to expose runtime information of rate limiter to
+        http response header, only for http-api or debugging purpose.
+        Default is <code>false</code>.</p>
       </attribute>
 
       <attribute name="rateLimitClassName" required="false">


### PR DESCRIPTION
smaller PR from #767 .
comply draft-ietf-httpapi-ratelimit-headers. enhance exposeHeaders parameter, true to output rate limit header fields.

update testcase.