### PR TITLE
send 416 error to overlapping ranges request

### DIFF
--- a/java/org/apache/catalina/servlets/DefaultServlet.java
+++ b/java/org/apache/catalina/servlets/DefaultServlet.java
@@ -1242,7 +1242,7 @@ public class DefaultServlet extends HttpServlet {
             }
             // see rfc9110 #status.416
             for (long[] e : rangeContext) {
-                if (Long.min(end, e[1]) - Long.max(start, e[0]) >= 0) {
+                if (Long.min(end, e[1]) >= Long.max(start, e[0])) {
                     // overlapping ranges: [10,30] intersect with [15,25]; [10,30] intersect with [5,15]
                     return false;
                 }

--- a/java/org/apache/catalina/servlets/DefaultServlet.java
+++ b/java/org/apache/catalina/servlets/DefaultServlet.java
@@ -1241,9 +1241,14 @@ public class DefaultServlet extends HttpServlet {
                 return false;
             }
             // see rfc9110 #status.416
-            for (long[] e : rangeContext) {
-                if (Long.min(end, e[1]) >= Long.max(start, e[0])) {
-                    // overlapping ranges: [10,30] intersect with [15,25]; [10,30] intersect with [5,15]
+            // invalid if range entries is overlap (equivalent to intersection is not empty).
+            for (long[] r : rangeContext) {
+                long s2 = r[0];
+                long e2 = r[1];
+                // Given [s1,e1] and [s2,e2]: if intersection is empty, then { s1>e2 || s2>e1 }
+                // logically equivalent to: If not { s1>e2 || s2>e1 }, then intersection is not empty.
+                if (start <= e2 && s2 <= end) {
+                    // isOverlap
                     return false;
                 }
             }

--- a/test/org/apache/catalina/servlets/TestDefaultServletRangeRequests.java
+++ b/test/org/apache/catalina/servlets/TestDefaultServletRangeRequests.java
@@ -63,6 +63,9 @@ public class TestDefaultServletRangeRequests extends TomcatBaseTest {
         parameterSets.add(new Object[] { "bytes=b-10", null, Integer.valueOf(416), "", "*/" + len });
         // Invalid ranges (out of range)
         parameterSets.add(new Object[] { "bytes=1000-2000", null, Integer.valueOf(416), "", "*/" + len });
+        // Invalid overlapping ranges
+        parameterSets.add(new Object[] { "bytes=1-100, 30-50", null, Integer.valueOf(416), "", "*/" + len });
+        parameterSets.add(new Object[] { "bytes=1-100, 90-150", null, Integer.valueOf(416), "", "*/" + len });
         // Invalid no equals
         parameterSets.add(new Object[] { "bytes 1-10", null, Integer.valueOf(416), "", "*/" + len });
         parameterSets.add(new Object[] { "bytes1-10", null, Integer.valueOf(416), "", "*/" + len });


### PR DESCRIPTION
request ranges validation - overlap detection added.

* invalid ranges - overlapping:
```
D:\git\github.com>curl http://localhost:55464/index.html -i -H "Range: bytes=10-40,35-50"
HTTP/1.1 416
Accept-Ranges: bytes
Content-Range: bytes */957
Content-Type: text/html;charset=utf-8
Content-Language: zh-CN
Content-Length: 753
Date: Tue, 19 Nov 2024 03:03:56 GMT
```
* valid ranges:
```
D:\git\github.com>curl http://localhost:55464/index.html -i -H "Range: bytes=10-40,50-60"
HTTP/1.1 206
Accept-Ranges: bytes
ETag: W/"957-1724403887512"
Last-Modified: Fri, 23 Aug 2024 09:04:47 GMT
Content-Type: multipart/byteranges; boundary=CATALINA_MIME_BOUNDARY
Content-Length: 194
Date: Tue, 19 Nov 2024 03:04:39 GMT


--CATALINA_MIME_BOUNDARY
Content-Range: bytes 10-40/957

censed to the Apache Software F
--CATALINA_MIME_BOUNDARY
Content-Range: bytes 50-60/957

 (ASF) unde
--CATALINA_MIME_BOUNDARY--
```