### PR TITLE
enhanced http/2 early hints behavior

### DIFF
--- a/java/org/apache/coyote/http2/Stream.java
+++ b/java/org/apache/coyote/http2/Stream.java
@@ -611,13 +611,13 @@ class Stream extends AbstractNonZeroStream implements HeaderEmitter {
     final void writeEarlyHints() throws IOException {
         MimeHeaders headers = coyoteResponse.getMimeHeaders();
         String originalStatus = headers.getHeader(":status");
-        headers.setValue(":status").setString(String.valueOf(HttpServletResponse.SC_EARLY_HINTS));
+        headers.setValue(":status").setString(Integer.toString(HttpServletResponse.SC_EARLY_HINTS));
 
         try {
             MimeHeaders earlyHintsHeaders = new MimeHeaders();
             earlyHintsHeaders.duplicate(headers);
             earlyHintsHeaders.filter(HTTP_EARLY_HINTS_HEADERS);
-            earlyHintsHeaders.setValue(":status").setString(String.valueOf(HttpServletResponse.SC_EARLY_HINTS));
+            earlyHintsHeaders.setValue(":status").setString(Integer.toString(HttpServletResponse.SC_EARLY_HINTS));
             handler.writeHeaders(this, earlyHintsHeaders, false, Constants.DEFAULT_HEADERS_FRAME_SIZE);
             // to take advantage of the Early Hints feature, the server-think-time is needed between the Early Hints
             // headers and the final response. Therefore, we need emit early hints status and headers via flush.

--- a/test/org/apache/coyote/http2/TestStreamProcessor.java
+++ b/test/org/apache/coyote/http2/TestStreamProcessor.java
@@ -621,31 +621,37 @@ public class TestStreamProcessor extends Http2TestBase {
 
         parser.readFrame();
         long now = System.currentTimeMillis();
-        Assert.assertEquals("3-HeadersStart\n" + "3-Header-[:status]-[103]\n" +
-                "3-Header-[link]-[</style.css>; rel=preload; as=style]\n" + "3-HeadersEnd\n", output.getTrace());
+        Assert.assertEquals(
+                "3-HeadersStart\n" + "3-Header-[:status]-[103]\n" +
+                        "3-Header-[link]-[</style.css>; rel=preload; as=style]\n" + "3-HeadersEnd\n",
+                output.getTrace());
         output.clearTrace();
 
         parser.readFrame();
-        Assert.assertTrue("Server side think time after early hints > 50 ms expected.", (System.currentTimeMillis()-now)>50L);
+        Assert.assertTrue("Server side think time after early hints > 50 ms expected.",
+                (System.currentTimeMillis() - now) > 50L);
         now = System.currentTimeMillis();
 
-        Assert.assertEquals("3-HeadersStart\n" + "3-Header-[:status]-[103]\n" +
-                "3-Header-[content-security-policy]-[style-src: self;]\n" +
-                "3-Header-[link]-[</main.js>; rel=preload; as=script]\n" +
-                "3-Header-[link]-[</image.png>; rel=preload; as=image]\n" +
-                "3-HeadersEnd\n", output.getTrace());
+        Assert.assertEquals(
+                "3-HeadersStart\n" + "3-Header-[:status]-[103]\n" +
+                        "3-Header-[link]-[</style.css>; rel=preload; as=style]\n" +
+                        "3-Header-[content-security-policy]-[style-src: self;]\n" +
+                        "3-Header-[link]-[</main.js>; rel=preload; as=script]\n" +
+                        "3-Header-[link]-[</image.png>; rel=preload; as=image]\n" + "3-HeadersEnd\n",
+                output.getTrace());
         output.clearTrace();
 
         parser.readFrame();
-        Assert.assertTrue("Server side think time after early hints > 50 ms expected.", (System.currentTimeMillis()-now)>50L);
+        Assert.assertTrue("Server side think time after early hints > 50 ms expected.",
+                (System.currentTimeMillis() - now) > 50L);
         now = System.currentTimeMillis();
         parser.readFrame();
         Assert.assertEquals("3-HeadersStart\n" + "3-Header-[:status]-[200]\n" +
+                "3-Header-[link]-[</style.css>; rel=preload; as=style]\n" +
                 "3-Header-[content-security-policy]-[style-src: self;]\n" +
                 "3-Header-[link]-[</main.js>; rel=preload; as=script]\n" +
-                "3-Header-[link]-[</style.css>; rel=preload; as=style]\n" +
-                "3-Header-[content-type]-[text/plain;charset=UTF-8]\n" +
-                "3-Header-[content-length]-[2]\n" +
+                "3-Header-[link]-[</image.png>; rel=preload; as=image]\n" +
+                "3-Header-[content-type]-[text/plain;charset=UTF-8]\n" + "3-Header-[content-length]-[2]\n" +
                 "3-Header-[date]-[" + DEFAULT_DATE + "]\n" + "3-HeadersEnd\n" + "3-Body-2\n" + "3-EndOfStream\n",
                 output.getTrace());
     }
@@ -674,10 +680,6 @@ public class TestStreamProcessor extends Http2TestBase {
                 Thread.sleep(100); // simulate server side think time
             } catch (InterruptedException e) {
             }
-
-            resp.addHeader("Content-Security-Policy","style-src: self;");
-            resp.addHeader("Link", "</main.js>; rel=preload; as=script");
-            resp.addHeader("Link", "</style.css>; rel=preload; as=style");
 
             resp.setCharacterEncoding(StandardCharsets.UTF_8);
             resp.setContentType("text/plain");


### PR DESCRIPTION
automatically flush when earlyHints called, to enable the possibility of server-think-time  (programmatic code in web app) between the Early Hints headers and the final response.  Speeding up page loads is the main goal of Early hints feature, and the "server think-time" is the key.