### PR TITLE
BZ 69477: Wrong 'allowedInternalProxies' param name in the Remote IP Filter documentation 

### DIFF
--- a/webapps/docs/config/filter.xml
+++ b/webapps/docs/config/filter.xml
@@ -1450,7 +1450,13 @@ FINE: Request "/docs/config/manager.html" with response status "200"
          <param-name>protocolHeader</param-name>
          <param-value>x-forwarded-proto</param-value>
        </init-param>
-     </filter>]]></source>
+     </filter>
+
+     <filter-mapping>
+       <filter-name>RemoteIpFilter</filter-name>
+       <url-pattern>/*</url-pattern>
+       <dispatcher>REQUEST</dispatcher>
+     </filter-mapping>]]></source>
     <p>Request values:</p>
     <table class="defaultTable">
       <tr>
@@ -1525,7 +1531,13 @@ FINE: Request "/docs/config/manager.html" with response status "200"
          <param-name>trustedProxies</param-name>
          <param-value>proxy1|proxy2</param-value>
        </init-param>
-     </filter>]]></source>
+     </filter>
+
+     <filter-mapping>
+       <filter-name>RemoteIpFilter</filter-name>
+       <url-pattern>/*</url-pattern>
+       <dispatcher>REQUEST</dispatcher>
+     </filter-mapping>]]></source>
     <p>Request values:</p>
     <table class="defaultTable">
       <tr>
@@ -1579,7 +1591,13 @@ FINE: Request "/docs/config/manager.html" with response status "200"
          <param-name>trustedProxies</param-name>
          <param-value>proxy1|proxy2</param-value>
        </init-param>
-     </filter>]]></source>
+     </filter>
+
+     <filter-mapping>
+       <filter-name>RemoteIpFilter</filter-name>
+       <url-pattern>/*</url-pattern>
+       <dispatcher>REQUEST</dispatcher>
+     </filter-mapping>]]></source>
     <p>Request values:</p>
     <table class="defaultTable">
       <tr>
@@ -1636,7 +1654,13 @@ FINE: Request "/docs/config/manager.html" with response status "200"
          <param-name>trustedProxies</param-name>
          <param-value>proxy1|proxy2</param-value>
        </init-param>
-     </filter>]]></source>
+     </filter>
+
+     <filter-mapping>
+       <filter-name>RemoteIpFilter</filter-name>
+       <url-pattern>/*</url-pattern>
+       <dispatcher>REQUEST</dispatcher>
+     </filter-mapping>]]></source>
     <p>Request values:</p>
     <table class="defaultTable">
       <tr>

--- a/webapps/docs/config/filter.xml
+++ b/webapps/docs/config/filter.xml
@@ -1435,7 +1435,7 @@ FINE: Request "/docs/config/manager.html" with response status "200"
        <filter-name>RemoteIpFilter</filter-name>
        <filter-class>org.apache.catalina.filters.RemoteIpFilter</filter-class>
        <init-param>
-         <param-name>allowedInternalProxies</param-name>
+         <param-name>internalProxies</param-name>
          <param-value>192\.168\.0\.10|192\.168\.0\.11</param-value>
        </init-param>
        <init-param>
@@ -1510,7 +1510,7 @@ FINE: Request "/docs/config/manager.html" with response status "200"
        <filter-name>RemoteIpFilter</filter-name>
        <filter-class>org.apache.catalina.filters.RemoteIpFilter</filter-class>
        <init-param>
-         <param-name>allowedInternalProxies</param-name>
+         <param-name>internalProxies</param-name>
          <param-value>192\.168\.0\.10|192\.168\.0\.11</param-value>
        </init-param>
        <init-param>
@@ -1564,7 +1564,7 @@ FINE: Request "/docs/config/manager.html" with response status "200"
        <filter-name>RemoteIpFilter</filter-name>
        <filter-class>org.apache.catalina.filters.RemoteIpFilter</filter-class>
        <init-param>
-         <param-name>allowedInternalProxies</param-name>
+         <param-name>internalProxies</param-name>
          <param-value>192\.168\.0\.10|192\.168\.0\.11</param-value>
        </init-param>
        <init-param>
@@ -1621,7 +1621,7 @@ FINE: Request "/docs/config/manager.html" with response status "200"
        <filter-name>RemoteIpFilter</filter-name>
        <filter-class>org.apache.catalina.filters.RemoteIpFilter</filter-class>
        <init-param>
-         <param-name>allowedInternalProxies</param-name>
+         <param-name>internalProxies</param-name>
          <param-value>192\.168\.0\.10|192\.168\.0\.11</param-value>
        </init-param>
        <init-param>


### PR DESCRIPTION
https://bz.apache.org/bugzilla/show_bug.cgi?id=69477

I have detected that the 'allowedInternalProxies' param name in the Remote IP Filter documentation here https://tomcat.apache.org/tomcat-11.0-doc/config/filter.html#Remote_IP_Filter is incorrect.

See correction in the first commit e716e7a2536c571e6bc8ddc5628133bb325e4ab8

I have also added some missing filter-mapping sections in some of the RemoteIpFilter examples

Thank you