### PR TITLE
Reject Range-Request if those ranges are not strictly in ascending order

### DIFF
--- a/java/org/apache/catalina/servlets/DefaultServlet.java
+++ b/java/org/apache/catalina/servlets/DefaultServlet.java
@@ -1251,7 +1251,7 @@ public class DefaultServlet extends HttpServlet {
             }
             // See https://www.rfc-editor.org/rfc/rfc9110.html#status.416
             // No good reason for ranges to overlap or not listed in ascending order, so always reject
-            for (int i=0;i<entryIndex;i++) {
+            for (int i = 0; i < entryIndex; i++) {
                 long s2 = rangeContext[i][0];
                 long e2 = rangeContext[i][1];
                 // Given valid [s1,e1] and [s2,e2]
@@ -1263,12 +1263,12 @@ public class DefaultServlet extends HttpServlet {
                     // isOverlap
                     return false;
                 }
-                if (start<=e2) {
+                if (start <= e2) {
                     // ranges that are not listed in ascending order
                     return false;
                 }
             }
-            rangeContext[entryIndex++] = new long[] {start,end};
+            rangeContext[entryIndex++] = new long[] { start, end };
         }
         return true;
     }

--- a/java/org/apache/catalina/servlets/DefaultServlet.java
+++ b/java/org/apache/catalina/servlets/DefaultServlet.java
@@ -1240,7 +1240,8 @@ public class DefaultServlet extends HttpServlet {
     }
 
     private static boolean validate(Ranges ranges, long length) {
-        List<long[]> rangeContext = new ArrayList<>();
+        long[][] rangeContext = new long[ranges.getEntries().size()][];
+        int entryIndex = 0;
         for (Ranges.Entry range : ranges.getEntries()) {
             long start = getStart(range, length);
             long end = getEnd(range, length);
@@ -1249,10 +1250,10 @@ public class DefaultServlet extends HttpServlet {
                 return false;
             }
             // See https://www.rfc-editor.org/rfc/rfc9110.html#status.416
-            // No good reason for ranges to overlap so always reject
-            for (long[] r : rangeContext) {
-                long s2 = r[0];
-                long e2 = r[1];
+            // No good reason for ranges to overlap or not listed in ascending order, so always reject
+            for (int i=0;i<entryIndex;i++) {
+                long s2 = rangeContext[i][0];
+                long e2 = rangeContext[i][1];
                 // Given valid [s1,e1] and [s2,e2]
                 // If { s1>e2 || s2>e1 } then no overlap
                 // equivalent to
@@ -1262,8 +1263,12 @@ public class DefaultServlet extends HttpServlet {
                     // isOverlap
                     return false;
                 }
+                if (start<=e2) {
+                    // ranges that are not listed in ascending order
+                    return false;
+                }
             }
-            rangeContext.add(new long[] { start, end });
+            rangeContext[entryIndex++] = new long[] {start,end};
         }
         return true;
     }

--- a/test/org/apache/catalina/servlets/TestDefaultServletRangeRequests.java
+++ b/test/org/apache/catalina/servlets/TestDefaultServletRangeRequests.java
@@ -66,6 +66,9 @@ public class TestDefaultServletRangeRequests extends TomcatBaseTest {
         // Invalid overlapping ranges
         parameterSets.add(new Object[] { "bytes=1-100, 30-50", null, Integer.valueOf(416), "", "*/" + len });
         parameterSets.add(new Object[] { "bytes=1-100, 90-150", null, Integer.valueOf(416), "", "*/" + len });
+        // Invalid ranges that not in ascending order
+        parameterSets.add(new Object[] { "bytes=0-5, 6-10, 80-90, 60-70", null, Integer.valueOf(416), "", "*/" + len });
+        parameterSets.add(new Object[] { "bytes=0-5, -10, 60-70", null, Integer.valueOf(416), "", "*/" + len });
         // Invalid no equals
         parameterSets.add(new Object[] { "bytes 1-10", null, Integer.valueOf(416), "", "*/" + len });
         parameterSets.add(new Object[] { "bytes1-10", null, Integer.valueOf(416), "", "*/" + len });


### PR DESCRIPTION
Request that ranges are not strictly in ascending order, indicates either a broken client or a deliberate denial-of-service attack.