### PR TITLE
Use UTF-8 for logging in Http11InputBuffer

### DIFF
--- a/java/org/apache/coyote/http11/Http11InputBuffer.java
+++ b/java/org/apache/coyote/http11/Http11InputBuffer.java
@@ -811,7 +811,7 @@ public class Http11InputBuffer implements InputBuffer, ApplicationBufferHandler,
 
         if (log.isTraceEnabled()) {
             log.trace("Received [" + new String(byteBuffer.array(), byteBuffer.position(), byteBuffer.remaining(),
-                    StandardCharsets.ISO_8859_1) + "]");
+                    StandardCharsets.UTF_8) + "]");
         }
 
         if (nRead > 0) {


### PR DESCRIPTION
I'm not sure if there's any reason not to use UTF-8 there, but for non-ASCII characters, their encoding is broken, so it would be nice to use UTF-8 unless there's other reason not to do so.