### PR TITLE
tiny doc adj

### DIFF
--- a/webapps/docs/default-servlet.xml
+++ b/webapps/docs/default-servlet.xml
@@ -202,10 +202,10 @@ Tomcat.</p>
         Should the server list all directories before all files. [false]
   </property>
   <property name="allowPartialPut">
-        Should the server treat an HTTP PUT request with a Range header as a
-        partial PUT? Note that while RFC 7233 clarified that Range headers only
-        valid for GET requests, RFC 9110 (which obsoletes RFC 7233) now allows
-        partial puts. [true]
+        Should the server treat an HTTP PUT request with a Content-Range header
+        as a partial PUT? Note that while RFC 7231 clarified that such a PUT
+        with a Content-Range header field is a bad request, RFC 9110
+        (which obsoletes RFC 7231) now allows partial PUT. [true]
   </property>
   <property name="directoryRedirectStatusCode">
         When a directory redirect (trailing slash missing) is made, use this as


### PR DESCRIPTION
Document of DefaultServlet - correct the referenced RFC spec number about partial PUT - a PUT with Content-Range Header.

The original text of ***RFC7231*** #4.3.4 (which is obsoleted by RFC9110): An origin server that allows PUT on a given target resource MUST send a 400 (Bad Request) response to a PUT request that contains a Content-Range header field