### PR TITLE
enable preconditions evaluation during doPut / doDelete

### DIFF
--- a/java/org/apache/catalina/servlets/DefaultServlet.java
+++ b/java/org/apache/catalina/servlets/DefaultServlet.java
@@ -580,6 +580,10 @@ public class DefaultServlet extends HttpServlet {
 
         WebResource resource = resources.getResource(path);
 
+        if (resource != null && !checkIfHeaders(req, resp, resource)) {
+            return;
+        }
+
         ContentRange range = parseContentRange(req, resp);
 
         if (range == null) {
@@ -699,6 +703,9 @@ public class DefaultServlet extends HttpServlet {
 
         WebResource resource = resources.getResource(path);
 
+        if (resource != null && !checkIfHeaders(req, resp, resource)) {
+            return;
+        }
         if (resource.exists()) {
             if (resource.delete()) {
                 resp.setStatus(HttpServletResponse.SC_NO_CONTENT);

--- a/test/org/apache/catalina/servlets/TestDefaultServletRfc9110Section13.java
+++ b/test/org/apache/catalina/servlets/TestDefaultServletRfc9110Section13.java
@@ -32,7 +32,6 @@ import java.util.function.IntPredicate;
 import jakarta.servlet.http.HttpServletResponse;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.apache.catalina.Context;
@@ -289,7 +288,6 @@ public class TestDefaultServletRfc9110Section13 extends TomcatBaseTest {
         testPreconditions(Task.POST_INDEX_HTML, IfPolicy.ETAG_SYNTAX_INVALID, null, null, null, null, true, 400);
     }
 
-    @Ignore
     @Test
     public void testPreconditions2_2_1_put0() throws Exception {
         startServer(true);
@@ -303,7 +301,6 @@ public class TestDefaultServletRfc9110Section13 extends TomcatBaseTest {
         testPreconditions(Task.PUT_NEW_TXT, null, null, null, null, null, HttpServletResponse.SC_CREATED);
     }
 
-    @Ignore
     @Test
     public void testPreconditions2_2_1_put1() throws Exception {
         startServer(false);
@@ -313,7 +310,6 @@ public class TestDefaultServletRfc9110Section13 extends TomcatBaseTest {
         testPreconditions(Task.PUT_EXIST_TXT, IfPolicy.ETAG_EXACTLY, null, null, null, null, 412);
     }
 
-    @Ignore
     @Test
     public void testPreconditions2_2_1_delete0() throws Exception {
         startServer(true);
@@ -327,7 +323,6 @@ public class TestDefaultServletRfc9110Section13 extends TomcatBaseTest {
         testPreconditions(Task.DELETE_NOT_EXIST_TXT, null, null, null, null, null, 404);
     }
 
-    @Ignore
     @Test
     public void testPreconditions2_2_1_delete1() throws Exception {
         startServer(false);
@@ -450,8 +445,8 @@ public class TestDefaultServletRfc9110Section13 extends TomcatBaseTest {
                 }
                 break;
             case ETAG_SYNTAX_INVALID:
-                headerValues.add("*");
                 headerValues.add("W/\"1abcd\"");
+                headerValues.add("*");
                 break;
             default:
                 break;

--- a/test/org/apache/catalina/servlets/TestDefaultServletRfc9110Section13.java
+++ b/test/org/apache/catalina/servlets/TestDefaultServletRfc9110Section13.java
@@ -129,6 +129,8 @@ public class TestDefaultServletRfc9110Section13 extends TomcatBaseTest {
         testPreconditions(Task.HEAD_INDEX_HTML, null, IfPolicy.DATE_GT, IfPolicy.ETAG_EXACTLY, IfPolicy.DATE_MULTI_IN,
                 null, 304);
         testPreconditions(Task.HEAD_INDEX_HTML, null, IfPolicy.DATE_GT, IfPolicy.ETAG_ALL, IfPolicy.DATE_EQ, null, 304);
+
+        testPreconditions(Task.HEAD_INDEX_HTML, null, IfPolicy.DATE_LT, null, IfPolicy.DATE_GT, null, 412);
     }
 
     @Test


### PR DESCRIPTION
per rfc9110 , normally state-changing request should evaluate preconditions before performing actions.
see enabled testcase testPreconditions2_2_1_put0, testPreconditions2_2_1_delete0.