### PR TITLE
for delete failure case, respond with SC_CONFLICT rather than SC_METHOD_NOT_ALLOWED

### DIFF
--- a/java/org/apache/catalina/servlets/DefaultServlet.java
+++ b/java/org/apache/catalina/servlets/DefaultServlet.java
@@ -711,7 +711,7 @@ public class DefaultServlet extends HttpServlet {
             if (resource.delete()) {
                 resp.setStatus(HttpServletResponse.SC_NO_CONTENT);
             } else {
-                resp.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+                resp.sendError(HttpServletResponse.SC_CONFLICT);
             }
         } else {
             resp.sendError(HttpServletResponse.SC_NOT_FOUND);


### PR DESCRIPTION
Since allowed methods check has been performed previously, failure status code switch to 409 / SC_CONFLICT.

Root cause may be insufficient privileges, OS file locking, or already deleted by another concurrent request.