### PR TITLE
for delete failure case, send Allow header at same time with sc  Method not allowed

### DIFF
--- a/java/org/apache/catalina/servlets/DefaultServlet.java
+++ b/java/org/apache/catalina/servlets/DefaultServlet.java
@@ -711,7 +711,7 @@ public class DefaultServlet extends HttpServlet {
             if (resource.delete()) {
                 resp.setStatus(HttpServletResponse.SC_NO_CONTENT);
             } else {
-                resp.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+                sendNotAllowed(req, resp);
             }
         } else {
             resp.sendError(HttpServletResponse.SC_NOT_FOUND);


### PR DESCRIPTION
comply [rfc 9110 Section 15.5.6.](https://httpwg.org/specs/rfc9110.html#status.405) 405 Method Not Allowed:

The origin server ***MUST*** generate an ***[Allow](https://httpwg.org/specs/rfc9110.html#field.allow)*** header field in a 405 response containing a list of the target resource's currently supported methods.

Personally, #802 may be an alternative choice.