### PR TITLE
Simplify usage of custom ssl configuration

### DIFF
--- a/java/org/apache/tomcat/util/net/SSLContextWrapper.java
+++ b/java/org/apache/tomcat/util/net/SSLContextWrapper.java
@@ -1,0 +1,83 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.tomcat.util.net;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLServerSocketFactory;
+import javax.net.ssl.SSLSessionContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509KeyManager;
+import javax.net.ssl.X509TrustManager;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import java.util.Objects;
+
+final class SSLContextWrapper implements SSLContext {
+
+    private final javax.net.ssl.SSLContext sslContext;
+    private final X509KeyManager keyManager;
+    private final X509TrustManager trustManager;
+
+    SSLContextWrapper(javax.net.ssl.SSLContext sslContext, X509KeyManager keyManager, X509TrustManager trustManager) {
+        this.sslContext = Objects.requireNonNull(sslContext);
+        this.keyManager = Objects.requireNonNull(keyManager);
+        this.trustManager = Objects.requireNonNull(trustManager);
+    }
+
+    @Override
+    public void init(KeyManager[] kms, TrustManager[] tms, SecureRandom sr) {
+        // not needed to initialize as it is already initialized
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+
+    @Override
+    public SSLSessionContext getServerSessionContext() {
+        return sslContext.getServerSessionContext();
+    }
+
+    @Override
+    public SSLEngine createSSLEngine() {
+        return sslContext.createSSLEngine();
+    }
+
+    @Override
+    public SSLServerSocketFactory getServerSocketFactory() {
+        return sslContext.getServerSocketFactory();
+    }
+
+    @Override
+    public SSLParameters getSupportedSSLParameters() {
+        return sslContext.getSupportedSSLParameters();
+    }
+
+    @Override
+    public X509Certificate[] getCertificateChain(String alias) {
+        return keyManager.getCertificateChain(alias);
+    }
+
+    @Override
+    public X509Certificate[] getAcceptedIssuers() {
+        return trustManager.getAcceptedIssuers();
+    }
+
+}

--- a/java/org/apache/tomcat/util/net/SSLUtil.java
+++ b/java/org/apache/tomcat/util/net/SSLUtil.java
@@ -21,6 +21,8 @@ import java.util.List;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLSessionContext;
 import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509KeyManager;
+import javax.net.ssl.X509TrustManager;
 
 /**
  * Provides a common interface for {@link SSLImplementation}s to create the
@@ -28,6 +30,10 @@ import javax.net.ssl.TrustManager;
  * JSSE API.
  */
 public interface SSLUtil {
+
+    static SSLContext createSSLContext(javax.net.ssl.SSLContext sslContext, X509KeyManager keyManager, X509TrustManager trustManager) {
+        return new SSLContextWrapper(sslContext, keyManager, trustManager);
+    }
 
     SSLContext createSSLContext(List<String> negotiableProtocols) throws Exception;
 


### PR DESCRIPTION
This PR is a followup of the following earlier PR https://github.com/apache/tomcat/pull/673 Although that pull request didn't get merged, the code changes has been comitted to the main branch by the main developer, see here for the specific commit: https://github.com/apache/tomcat/commit/b0df9819c8d130adab0490b89dce1ab4ca6a3448

**Context**
With the earlier commit it is now possible to programatically configure the ssl configuration of tomcat instead of using properties and delegating to tomcat to construct the ssl configuration. This opens the possibility of reloading the ssl configuration or other customizations as shown also here: [sslcontext-kickstart](https://github.com/Hakky54/sslcontext-kickstart)

**Problem statement**
Boilerplate code is needed by the end-user to provide a custom ssl configuration. Tomcat takes a custom SSLContext, the full name is `org.apache.tomcat.util.net.SSLContext` while the end-user has `javax.net.ssl.SSLContext`. So the end-user is required to create an implementation of `org.apache.tomcat.util.net.SSLContext` which acts as a wrapper. This sslcontext needs to be passed to `SSLHostConfigCertificate` to further configure the server.

**Solution**
Provide a helper class which acts as a wrapper to reduce the boilerplate code. The utility interface is able to provide a method to wrap the required objects, in this case `javax.net.ssl.SSLContext`, KeyManager, TrustManager in a `org.apache.tomcat.util.net.SSLContext`

**Example usage**
Below is an example usage with Spring Boot and Tomcat
```java
import org.apache.catalina.connector.Connector;
import org.apache.coyote.http11.AbstractHttp11Protocol;
import org.apache.tomcat.util.net.SSLHostConfig;
import org.apache.tomcat.util.net.SSLHostConfigCertificate;
import org.apache.tomcat.util.net.SSLHostConfigCertificate.Type;
import org.apache.tomcat.util.net.SSLUtil;
import org.springframework.beans.factory.annotation.Value;
import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
import org.springframework.context.annotation.Configuration;

import javax.net.ssl.SSLContext;
import javax.net.ssl.X509KeyManager;
import javax.net.ssl.X509TrustManager;

@Configuration
public class SSLConnectorCustomizer implements TomcatConnectorCustomizer {

    private final int port;

    public SSLConnectorCustomizer(@Value("${server.port}") int port) {
        this.port = port;
    }

    @Override
    public void customize(Connector connector) {
        X509KeyManager keyManager = ...;        // initialized keyManager
        X509TrustManager trustManager = ...;    // initialized trustManager
        SSLContext sslContext = ...;            // initialized sslContext

        connector.setScheme("https");
        connector.setSecure(true);
        connector.setPort(port);

        AbstractHttp11Protocol<?> protocol = (AbstractHttp11Protocol<?>) connector.getProtocolHandler();
        protocol.setSSLEnabled(true);

        org.apache.tomcat.util.net.SSLContext context = SSLUtil.createSSLContext(sslContext, keyManager, trustManager);
        SSLHostConfig sslHostConfig = new SSLHostConfig();
        SSLHostConfigCertificate certificate = new SSLHostConfigCertificate(sslHostConfig, Type.UNDEFINED);
        certificate.setSslContext(context);
        sslHostConfig.addCertificate(certificate);
        protocol.addSslHostConfig(sslHostConfig);
    }

}
```

In the past I created the same PR, but I assumed it would not get merged and therefor I gave up and closed the PR. But I still think it is useful and decided the recreate the PR to give it another shot. Looking forward to your feedback and decision for this PR.