### PR TITLE
fix BZ 69446 - Propagate maxSwallowSize to enforce partial PUT request target file size

### DIFF
--- a/java/org/apache/catalina/connector/Request.java
+++ b/java/org/apache/catalina/connector/Request.java
@@ -3091,4 +3091,14 @@ public class Request implements HttpServletRequest {
             }
         });
     }
+
+    /**
+     * Get the maximum number of request body bytes to be swallowed by Tomcat for an aborted upload. A value of less
+     * than zero indicates that no limit should be enforced. The value is determined by its underlying connector.
+     *
+     * @return the maximum number of request body bytes to be swallowed by Tomcat for an aborted upload
+     */
+    public int getMaxSwallowSize() {
+        return (int) connector.getProperty("maxSwallowSize");
+    }
 }

--- a/java/org/apache/catalina/connector/RequestFacade.java
+++ b/java/org/apache/catalina/connector/RequestFacade.java
@@ -612,4 +612,15 @@ public class RequestFacade implements HttpServletRequest {
             throw new IllegalStateException(sm.getString("requestFacade.nullRequest"));
         }
     }
+
+    /**
+     * Get the maximum number of request body bytes to be swallowed by Tomcat for an aborted upload. A value of less
+     * than zero indicates that no limit should be enforced.
+     *
+     * @return the maximum number of request body bytes to be swallowed by Tomcat for an aborted upload
+     */
+    public int getMaxSwallowSize() {
+        checkFacade();
+        return request.getMaxSwallowSize();
+    }
 }

--- a/java/org/apache/catalina/servlets/DefaultServlet.java
+++ b/java/org/apache/catalina/servlets/DefaultServlet.java
@@ -612,9 +612,7 @@ public class DefaultServlet extends HttpServlet {
                 resourceInputStream = req.getInputStream();
             } else {
                 if (req instanceof RequestFacade) {
-                    int maxSwallowSize = -1;
-                    maxSwallowSize = ((RequestFacade) req).getMaxSwallowSize();
-
+                    int maxSwallowSize = ((RequestFacade) req).getMaxSwallowSize();
                     if (maxSwallowSize >= 0 && range.getLength() > maxSwallowSize) {
                         // maxSwallowSize is semantically equivalent to PUT destination file size limit.
                         resp.sendError(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE);

--- a/java/org/apache/catalina/servlets/DefaultServlet.java
+++ b/java/org/apache/catalina/servlets/DefaultServlet.java
@@ -611,6 +611,16 @@ public class DefaultServlet extends HttpServlet {
             if (range == IGNORE) {
                 resourceInputStream = req.getInputStream();
             } else {
+                if (req instanceof RequestFacade) {
+                    int maxSwallowSize = -1;
+                    maxSwallowSize = ((RequestFacade) req).getMaxSwallowSize();
+
+                    if (maxSwallowSize >= 0 && range.getLength() > maxSwallowSize) {
+                        // maxSwallowSize is semantically equivalent to PUT destination file size limit.
+                        resp.sendError(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE);
+                        return;
+                    }
+                }
                 File contentFile = executePartialPut(req, range, path);
                 resourceInputStream = new FileInputStream(contentFile);
             }


### PR DESCRIPTION
maxSwallowSize is semantically equivalent to max file size of upload file size. Send 413 when length of Content-Range request exceeds maxSwallowSize.