### PR TITLE
Ensure partial put data range not exceed ContentRange declared

### DIFF
--- a/java/org/apache/catalina/servlets/DefaultServlet.java
+++ b/java/org/apache/catalina/servlets/DefaultServlet.java
@@ -689,10 +689,15 @@ public class DefaultServlet extends HttpServlet {
             // Append data in request input stream to contentFile
             randAccessContentFile.seek(range.getStart());
             int numBytesRead;
+            long remainingBytes = range.getEnd() - range.getStart() + 1L;
             byte[] transferBuffer = new byte[BUFFER_SIZE];
             try (BufferedInputStream requestBufInStream = new BufferedInputStream(req.getInputStream(), BUFFER_SIZE)) {
-                while ((numBytesRead = requestBufInStream.read(transferBuffer)) != -1) {
+                while (remainingBytes > 0 && (numBytesRead = requestBufInStream.read(transferBuffer)) != -1) {
+                    if (numBytesRead > remainingBytes) {
+                        numBytesRead = (int) remainingBytes;
+                    }
                     randAccessContentFile.write(transferBuffer, 0, numBytesRead);
+                    remainingBytes -= numBytesRead;
                 }
             }
         }

--- a/test/org/apache/catalina/servlets/TestDefaultServletPut.java
+++ b/test/org/apache/catalina/servlets/TestDefaultServletPut.java
@@ -55,6 +55,9 @@ public class TestDefaultServletPut extends TomcatBaseTest {
                 "Content-Range: bytes 0-" + PATCH_LEN + "/" + START_LEN + CRLF, Boolean.TRUE, END_TEXT, Boolean.TRUE });
         parameterSets.add(new Object[] {
                 "Content-Range: ByTeS 0-" + PATCH_LEN + "/" + START_LEN + CRLF, Boolean.TRUE, END_TEXT, Boolean.TRUE });
+        // Valid partial PUT, only the first char is replaced.
+        parameterSets.add(new Object[] {
+                "Content-Range: ByTeS 0-" + 0 + "/" + START_LEN + CRLF, Boolean.TRUE, "Etarting text", Boolean.TRUE });
         // Full PUT
         parameterSets.add(new Object[] {
                 "", null, PATCH_TEXT, Boolean.TRUE });


### PR DESCRIPTION
Ensure updated content size not exceeds bounds ***(end-start+1)*** declared by Content-Range header.

For backwards compatibility, just discard the rest part instead of a sending 400.