### PR TITLE
Forward toString in MessageBytes toStringType

### DIFF
--- a/java/org/apache/tomcat/util/buf/MessageBytes.java
+++ b/java/org/apache/tomcat/util/buf/MessageBytes.java
@@ -163,20 +163,7 @@ public final class MessageBytes implements Cloneable, Serializable {
      */
     @Override
     public String toString() {
-        switch (type) {
-            case T_NULL:
-            case T_STR:
-                // No conversion required
-                break;
-            case T_BYTES:
-                strValue = byteC.toString();
-                break;
-            case T_CHARS:
-                strValue = charC.toString();
-                break;
-        }
-
-        return strValue;
+        return toStringType();
     }
 
 


### PR DESCRIPTION
toString doesn't check if the value has already been converted to String while toStringType does this. I couldn't find a reason not to do the same for toString