### PR TITLE
Invoke toStringType instead of toString in MimeHeaders

### DIFF
--- a/java/org/apache/tomcat/util/http/MimeHeaders.java
+++ b/java/org/apache/tomcat/util/http/MimeHeaders.java
@@ -382,7 +382,7 @@ public class MimeHeaders {
 
     public String getHeader(String name) {
         MessageBytes mh = getValue(name);
-        return mh != null ? mh.toString() : null;
+        return mh != null ? mh.toStringType() : null;
     }
 
     // -------------------- Removing --------------------


### PR DESCRIPTION
This is to avoid having to convert from Bytes to String again for the same header.