### PR TITLE
certificate regression

### DIFF
--- a/java/org/apache/tomcat/util/net/SSLUtilBase.java
+++ b/java/org/apache/tomcat/util/net/SSLUtilBase.java
@@ -331,9 +331,10 @@ public abstract class SSLUtilBase implements SSLUtil {
             keyPassToUse = keyPass;
         }
 
-        if (keyPassToUse != null) {
-            keyPassArray = keyPassToUse.toCharArray();
+        if (keyPassToUse == null) {
+            keyPassToUse = "";
         }
+        keyPassArray = keyPassToUse.toCharArray();
 
         KeyManagerFactory kmf = KeyManagerFactory.getInstance(algorithm);
         if (kmf.getProvider().getInfo().contains("FIPS")) {


### PR DESCRIPTION
When server.xml has this:

```
	<Certificate 
	certificateKeyFile="/etc/letsencrypt/live/$DOMAIN/privkey.pem" 
	certificateFile="/etc/letsencrypt/live/$DOMAIN/cert.pem" 
	certificateChainFile="/etc/letsencrypt/live/$DOMAIN/fullchain.pem" 
	type="RSA" />

```
it woks on 10.1.x, but not on main (without this patch) it will fail like this:

```
30-Jan-2025 20:42:37.816 INFO [main] org.apache.coyote.AbstractProtocol.init Initializing ProtocolHandler ["https-jsse-nio-443"]
30-Jan-2025 20:42:38.723 SEVERE [main] org.apache.catalina.util.LifecycleBase.handleSubClassException Failed to initialize component [Connector["https-jsse-nio-443"]]
	org.apache.catalina.LifecycleException: Protocol handler initialization failed
		at org.apache.catalina.connector.Connector.initInternal(Connector.java:1056)
		at org.apache.catalina.util.LifecycleBase.init(LifecycleBase.java:122)
		at org.apache.catalina.core.StandardService.initInternal(StandardService.java:525)
		at org.apache.catalina.util.LifecycleBase.init(LifecycleBase.java:122)
		at org.apache.catalina.core.StandardServer.initInternal(StandardServer.java:953)
		at org.apache.catalina.util.LifecycleBase.init(LifecycleBase.java:122)
		at org.apache.catalina.startup.Catalina.load(Catalina.java:710)
		at org.apache.catalina.startup.Catalina.load(Catalina.java:733)
		at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
		at java.base/java.lang.reflect.Method.invoke(Method.java:580)
		at org.apache.catalina.startup.Bootstrap.load(Bootstrap.java:299)
		at org.apache.catalina.startup.Bootstrap.main(Bootstrap.java:469)
	Caused by: java.lang.IllegalArgumentException: Error creating SSLContext
		at org.apache.tomcat.util.net.AbstractEndpoint.createSSLContext(AbstractEndpoint.java:423)
		at org.apache.tomcat.util.net.AbstractEndpoint.initialiseSsl(AbstractEndpoint.java:597)
		at org.apache.tomcat.util.net.NioEndpoint.bind(NioEndpoint.java:200)
		at org.apache.tomcat.util.net.AbstractEndpoint.bindWithCleanup(AbstractEndpoint.java:1472)
		at org.apache.tomcat.util.net.AbstractEndpoint.init(AbstractEndpoint.java:1485)
		at org.apache.coyote.AbstractProtocol.init(AbstractProtocol.java:633)
		at org.apache.coyote.http11.AbstractHttp11Protocol.init(AbstractHttp11Protocol.java:83)
		at org.apache.catalina.connector.Connector.initInternal(Connector.java:1054)
		... 11 more
	Caused by: java.security.KeyStoreException: password can't be null
		at java.base/sun.security.provider.JavaKeyStore.engineSetKeyEntry(JavaKeyStore.java:285)
		at java.base/sun.security.util.KeyStoreDelegator.engineSetKeyEntry(KeyStoreDelegator.java:114)
		at java.base/java.security.KeyStore.setKeyEntry(KeyStore.java:1192)
		at org.apache.tomcat.util.net.SSLUtilBase.getKeyManagers(SSLUtilBase.java:371)
		at org.apache.tomcat.util.net.SSLUtilBase.createSSLContext(SSLUtilBase.java:267)
		at org.apache.tomcat.util.net.AbstractEndpoint.createSSLContext(AbstractEndpoint.java:421)
		... 18 more
30-Jan-2025 20:42:38.728 INFO [main] org.apache.catalina.startup.Catalina.load Server initialization in [3238] milliseconds
```
