### PR TITLE
Fix null stream issue for resource loading based on relative names

### DIFF
--- a/java/org/apache/catalina/loader/WebappClassLoaderBase.java
+++ b/java/org/apache/catalina/loader/WebappClassLoaderBase.java
@@ -1098,14 +1098,12 @@ public abstract class WebappClassLoaderBase extends URLClassLoader
             log.trace("  Searching local repositories");
         }
         String path = nameToPath(name);
-        if (!notFoundClassResources.contains(path)) {
+        if (name.startsWith("/") || !notFoundClassResources.contains(path)) {
             WebResource resource = resources.getClassLoaderResource(path);
             if (resource.exists()) {
                 stream = resource.getInputStream();
                 trackLastModified(path, resource);
             }
-        }
-        if (!notFoundClassResources.contains(name)) {
             try {
                 if (hasExternalRepositories && stream == null) {
                     URL url = super.findResource(name);
@@ -1116,18 +1114,13 @@ public abstract class WebappClassLoaderBase extends URLClassLoader
             } catch (IOException e) {
                 // Ignore
             }
-        }
-        if (stream != null) {
-            if (log.isTraceEnabled()) {
-                log.trace("  --> Returning stream from local");
+            if (stream != null) {
+                if (log.isTraceEnabled()) {
+                    log.trace("  --> Returning stream from local");
+                }
+                return stream;
             }
-            return stream;
-        }
-        if (!notFoundClassResources.contains(path)) {
             notFoundClassResources.add(path);
-        }
-        if (!notFoundClassResources.contains(name)) {
-            notFoundClassResources.add(name);
         }
 
         // (3) Delegate to parent unconditionally

--- a/java/org/apache/catalina/loader/WebappClassLoaderBase.java
+++ b/java/org/apache/catalina/loader/WebappClassLoaderBase.java
@@ -1104,6 +1104,8 @@ public abstract class WebappClassLoaderBase extends URLClassLoader
                 stream = resource.getInputStream();
                 trackLastModified(path, resource);
             }
+        }
+        if (!notFoundClassResources.contains(name)) {
             try {
                 if (hasExternalRepositories && stream == null) {
                     URL url = super.findResource(name);
@@ -1114,13 +1116,18 @@ public abstract class WebappClassLoaderBase extends URLClassLoader
             } catch (IOException e) {
                 // Ignore
             }
-            if (stream != null) {
-                if (log.isTraceEnabled()) {
-                    log.trace("  --> Returning stream from local");
-                }
-                return stream;
+        }
+        if (stream != null) {
+            if (log.isTraceEnabled()) {
+                log.trace("  --> Returning stream from local");
             }
+            return stream;
+        }
+        if (!notFoundClassResources.contains(path)) {
             notFoundClassResources.add(path);
+        }
+        if (!notFoundClassResources.contains(name)) {
+            notFoundClassResources.add(name);
         }
 
         // (3) Delegate to parent unconditionally

--- a/java/org/apache/catalina/loader/WebappClassLoaderBase.java
+++ b/java/org/apache/catalina/loader/WebappClassLoaderBase.java
@@ -1120,7 +1120,9 @@ public abstract class WebappClassLoaderBase extends URLClassLoader
                 }
                 return stream;
             }
-            notFoundClassResources.add(path);
+            if (!name.startsWith("/")) {
+                notFoundClassResources.add(path);
+            }
         }
 
         // (3) Delegate to parent unconditionally


### PR DESCRIPTION
This addresses a case in the `getResourceAsStream` [1] method which falsely identifies resources to be absent when looking them up with relative names (names that don't start with a slash) if they have already been looked up with the absolute name (names that start with a slash). 

In the getResourceAsStream [1] method, Tomcat checks the recently introduced `notFoundClassResources` based on the "path" variable alone, which is always the absolute name.

However, there are cases such as [2] in the Apache CXF core component where the class loading first tries calling the `getResourceAsStream` [1] method with the absolute name as the “name” argument and if this returns a null stream, it then tries the relative name by calling the `getResourceAsStream` [1] method with the relative name as the “name”.

In both calls to the `getResourceAsStream` method, the “path” variable set at [3] is the absolute name and therefore, Tomcat checks the cache for the absolute name both times.

As a result, the second attempt based on the relative name gets skipped, and a null stream is returned even though the resource is present.

In this PR, the block where the resource is loaded based on the "name" variable has been moved to a separate if block where the cache is checked for the "name" variable instead of the "path" variable.

[1] https://github.com/apache/tomcat/blob/08206671035f05e205806140b11c10c6eb3ca5c3/java/org/apache/catalina/loader/WebappClassLoaderBase.java#L1070
[2] https://github.com/apache/cxf/blob/cxf-3.5.9/core/src/main/java/org/apache/cxf/version/Version.java#L38
[3] https://github.com/apache/tomcat/blob/08206671035f05e205806140b11c10c6eb3ca5c3/java/org/apache/catalina/loader/WebappClassLoaderBase.java#L1100