### PR TITLE
Replace \r\n with SimpleHttpClient.CRLF in Http2TestBase & Cleanup RequestUtil

### DIFF
--- a/java/org/apache/tomcat/util/http/RequestUtil.java
+++ b/java/org/apache/tomcat/util/http/RequestUtil.java
@@ -123,19 +123,12 @@ public class RequestUtil {
         // Build scheme://host:port from request
         StringBuilder target = new StringBuilder();
         String scheme = request.getScheme();
-        if (scheme == null) {
-            return false;
-        } else {
-            scheme = scheme.toLowerCase(Locale.ENGLISH);
-        }
-        target.append(scheme);
-        target.append("://");
-
         String host = request.getServerName();
-        if (host == null) {
+        if (scheme == null || host == null) {
             return false;
         }
-        target.append(host);
+        scheme = scheme.toLowerCase(Locale.ENGLISH);
+        target.append(scheme).append("://").append(host);
 
         int port = request.getServerPort();
         // Origin may or may not include the (default) port.
@@ -161,7 +154,7 @@ public class RequestUtil {
 
         // Both scheme and host are case-insensitive but the CORS spec states
         // this check should be case-sensitive
-        return origin.equals(target.toString());
+        return origin.contentEquals(target);
     }
 
 

--- a/test/org/apache/coyote/http2/Http2TestBase.java
+++ b/test/org/apache/coyote/http2/Http2TestBase.java
@@ -43,6 +43,7 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import org.apache.catalina.startup.SimpleHttpClient;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.runner.RunWith;
@@ -66,6 +67,8 @@ import org.apache.tomcat.util.http.FastHttpDateFormat;
 import org.apache.tomcat.util.http.MimeHeaders;
 import org.apache.tomcat.util.http.parser.Priority;
 import org.apache.tomcat.util.net.TesterSupport;
+
+import static org.apache.catalina.startup.SimpleHttpClient.CRLF;
 
 /**
  * Tests for compliance with the <a href="https://tools.ietf.org/html/rfc7540"> HTTP/2 specification</a>.
@@ -107,7 +110,7 @@ public abstract class Http2TestBase extends TomcatBaseTest {
 
     static {
         byte[] empty = new byte[0];
-        EMPTY_HTTP2_SETTINGS_HEADER = "HTTP2-Settings: " + Base64.getUrlEncoder().encodeToString(empty) + "\r\n";
+        EMPTY_HTTP2_SETTINGS_HEADER = "HTTP2-Settings: " + Base64.getUrlEncoder().encodeToString(empty) + CRLF;
     }
 
     protected static final String TRAILER_HEADER_NAME = "x-trailertest";
@@ -692,8 +695,8 @@ public abstract class Http2TestBase extends TomcatBaseTest {
 
     protected void doHttpUpgrade(String connection, String upgrade, String settings, boolean validate)
             throws IOException {
-        byte[] upgradeRequest = ("GET /simple HTTP/1.1\r\n" + "Host: localhost:" + getPort() + "\r\n" + "Connection: " +
-                connection + "\r\n" + "Upgrade: " + upgrade + "\r\n" + settings + "\r\n")
+        byte[] upgradeRequest = ("GET /simple HTTP/1.1" + CRLF + "Host: localhost:" + getPort() + CRLF + "Connection: " +
+                connection + CRLF + "Upgrade: " + upgrade + CRLF + settings + CRLF)
                 .getBytes(StandardCharsets.ISO_8859_1);
         os.write(upgradeRequest);
         os.flush();
@@ -776,7 +779,7 @@ public abstract class Http2TestBase extends TomcatBaseTest {
         String response = new String(data.array(), data.arrayOffset(), data.arrayOffset() + data.position(),
                 StandardCharsets.ISO_8859_1);
 
-        return response.split("\r\n");
+        return response.split(CRLF);
     }
 
 

--- a/test/org/apache/tomcat/util/http/TestRequestUtilSameOrigin.java
+++ b/test/org/apache/tomcat/util/http/TestRequestUtilSameOrigin.java
@@ -42,6 +42,8 @@ public class TestRequestUtilSameOrigin {
         TesterRequest request2 = new TesterRequest("ws", "example.com", 80);
         TesterRequest request3 = new TesterRequest("http", "example.com", 443);
         TesterRequest request4 = new TesterRequest("http", "example.com", 8080);
+        TesterRequest request5 = new TesterRequest(null, "exmaple.com", 80);
+        TesterRequest request6 = new TesterRequest("http", null, 8080);
 
         parameterSets.add(new Object[] { request1, "http://example.com", Boolean.TRUE });
         parameterSets.add(new Object[] { request1, "http://example.com:80", Boolean.TRUE });
@@ -58,6 +60,14 @@ public class TestRequestUtilSameOrigin {
         parameterSets.add(new Object[] { request4, "http://example.com", Boolean.FALSE });
         parameterSets.add(new Object[] { request4, "http://example.com:80", Boolean.FALSE });
         parameterSets.add(new Object[] { request4, "http://example.com:8080", Boolean.TRUE});
+
+        parameterSets.add(new Object[]{ request5, "http://example.com:80", Boolean.FALSE});
+        parameterSets.add(new Object[]{ request5, "://example.com:80", Boolean.FALSE});
+        parameterSets.add(new Object[]{ request5, "example.com:80", Boolean.FALSE});
+
+        parameterSets.add(new Object[]{ request6, "http://example.com:80", Boolean.FALSE});
+        parameterSets.add(new Object[]{ request6, "http://:80", Boolean.FALSE});
+        parameterSets.add(new Object[]{ request6, "http://", Boolean.FALSE});
 
         return parameterSets;
     }


### PR DESCRIPTION
- replace "\r\n\" to SimpleHttpClient.CRLF in Http2TestBsae
- unnecessary code deletion and secure origin comparison in RequestUtil