### PR TITLE
SpnegoAuthenticator allows wrong calls to login/logout methods

### DIFF
--- a/java/org/apache/catalina/authenticator/LoginlessAuthenticatorBase.java
+++ b/java/org/apache/catalina/authenticator/LoginlessAuthenticatorBase.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.catalina.authenticator;
+
+import jakarta.servlet.ServletException;
+import org.apache.catalina.connector.Request;
+
+/**
+ * A base class for the <b>Authenticator</b> and <b>Valve</b> implementations that do not allow login via username and
+ * password. Logout operation for those implementations is also forbidden.
+ */
+public abstract class LoginlessAuthenticatorBase extends AuthenticatorBase {
+
+    @Override
+    public void login(String username, String password, Request request) throws ServletException {
+        throw new ServletException("Authenticator does not support login operation");
+    }
+
+    @Override
+    public void logout(Request request) {
+        throw new UnsupportedOperationException("Authenticator does not support logout operation");
+    }
+}

--- a/java/org/apache/catalina/authenticator/SpnegoAuthenticator.java
+++ b/java/org/apache/catalina/authenticator/SpnegoAuthenticator.java
@@ -48,7 +48,7 @@ import org.ietf.jgss.Oid;
  * depends on the correct configuration of multiple components. If the configuration is invalid, the error messages are
  * often cryptic although a Google search will usually point you in the right direction.
  */
-public class SpnegoAuthenticator extends AuthenticatorBase {
+public class SpnegoAuthenticator extends LoginlessAuthenticatorBase {
 
     private final Log log = LogFactory.getLog(SpnegoAuthenticator.class); // must not be static
     private static final String AUTH_HEADER_VALUE_NEGOTIATE = "Negotiate";

--- a/test/org/apache/catalina/authenticator/TestSpnegoAuthenticator.java
+++ b/test/org/apache/catalina/authenticator/TestSpnegoAuthenticator.java
@@ -1,0 +1,93 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.catalina.authenticator;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.catalina.Context;
+import org.apache.catalina.startup.Tomcat;
+import org.apache.catalina.startup.TomcatBaseTest;
+import org.apache.tomcat.util.buf.ByteChunk;
+import org.apache.tomcat.util.descriptor.web.LoginConfig;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class TestSpnegoAuthenticator extends TomcatBaseTest {
+
+    private static String CONTEXT_PATH = "/context";
+    private static String URI = "/test";
+
+    @Test
+    public void testLoginThrowsServletException() throws IOException {
+        ByteChunk res = getUrl("http://localhost:" + getPort() + CONTEXT_PATH + URI, "login");
+        Assert.assertEquals(ServletException.class.getName(), res.toString());
+    }
+
+    @Test
+    public void testLogoutThrowsUnsupportedOperationException() throws IOException {
+        ByteChunk res = getUrl("http://localhost:" + getPort() + CONTEXT_PATH + URI, "logout");
+        Assert.assertEquals(UnsupportedOperationException.class.getName(), res.toString());
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        Tomcat tomcat = getTomcatInstance();
+
+        // Add  servlet
+        Context ctxt = tomcat.addContext(CONTEXT_PATH, null);
+        Tomcat.addServlet(ctxt, "SpnegoServlet", new SpnegoServlet());
+        ctxt.addServletMappingDecoded(URI, "SpnegoServlet");
+
+        // Configure the authenticator
+        LoginConfig lc = new LoginConfig();
+        lc.setAuthMethod("SPNEGO");
+        ctxt.setLoginConfig(lc);
+        ctxt.getPipeline().addValve(new SpnegoAuthenticator());
+
+        tomcat.start();
+    }
+
+    private static final class SpnegoServlet extends HttpServlet {
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+            try {
+                if (req.getHeader("action").equals("login")) {
+                    req.login("user", "pwd");
+                } else {
+                    req.logout();
+                }
+            } catch (ServletException | UnsupportedOperationException e) {
+                String response = e.getClass().getName();
+                resp.getWriter().print(response);
+            }
+        }
+    }
+
+    public static ByteChunk getUrl(String path, String param) throws IOException {
+        ByteChunk out = new ByteChunk();
+        getUrl(path, out, Map.of("action", List.of(param)), null);
+        return out;
+    }
+}


### PR DESCRIPTION
**Summary:**

Inconsistent behavior of the **HttpServletRequest.login(..)** method when using **SpnegoAuthenticator** for WEB application in Tomcat 11.0.2 and earlier.

**Details:**

Although SpnegoAuthenticator does not implement any public spec interface, usage of this Authenticator leads to violation of contract of HttpServletRequest.login(..) method. 
Documentation of the HttpServletRequest.login(..) says that it should either "authenticate the provided user name and password" or throw ServletException "if the configured authenticator does not support user name and password authentication":

```
/**
* Authenticate the provided user name and password and then associated the
* authenticated user with the request.
*
* ...
* 
* @throws ServletException If any of {@link #getRemoteUser()}, {@link
*           #getUserPrincipal()} or {@link #getAuthType()} are non-null, if the
*           configured authenticator does not support user name and password
*           authentication or if the authentication fails
*/
```

Neither of these actions are performed when using SpnegoAuthenticator: (1) ServletException is not thrown, (2) password is not verified against an existing user name (ANY password could be passed into this method and authentication is considered to be successful).

**Example:**

We have the Tomcat server 11.0.2 that is configured to use SpnegoAuthenticator as a valve in combination with JNDIRealm (LDAP configuration) for a specific application. JNDIRealm is configured in the following way:
```
<Realm className="org.apache.catalina.realm.JNDIRealm"       
    authentication="GSSAPI"
    ...
/>
```

We performed all the Tomcat setup to use Kerberos tickets for user authentication.
While working the application is able to call HttpServletRequest.logout() and afterwards HttpServletRequest.login(..) methods. We identified that in this configuration (authentication="GSSAPI") calling the HttpServletRequest.login(..) method with ANY existing LDAP user does NOT perform password check and allows getting ANOTHER principal to be used by application with its LDAP roles.

**Solution:**
It looks like the most correct way to fix this issue is to make SpnegoAuthenticator throw ServletException on its login method. Also it looks like such "loginless" implementations should not allow 'logout' operation, but org.apache.catalina.Authenticator.logout(..) does not have ServletException in its signature, so we introduced 'UnsupportedOperationException' in logout for the loginless type of authenticators.
