### PR TITLE
Enhance case sensitivity check

### DIFF
--- a/java/org/apache/catalina/webresources/DirResourceSet.java
+++ b/java/org/apache/catalina/webresources/DirResourceSet.java
@@ -343,7 +343,10 @@ public class DirResourceSet extends AbstractFileResourceSet implements WebResour
      */
     private boolean isCaseSensitive() {
         try {
-            String canonicalPath = getFileBase().getCanonicalPath();
+            // Some file system (e.g. windows) treat files and directories as case insensitive by default, and also support
+            // setting case sensitivity per directory. Then we have to handle case sensitivity for each directory.
+            // Ensure file path contain ENGLISH string, otherwise its upper and lower maybe are same.
+            String canonicalPath = new File(getFileBase(),"Foo.TxT").getCanonicalPath();
             File upper = new File(canonicalPath.toUpperCase(Locale.ENGLISH));
             if (!canonicalPath.equals(upper.getCanonicalPath())) {
                 return true;


### PR DESCRIPTION
fix incorrect case sensitivity result when the target base directory (dir name without [a-z|A-Z] / or NON-ENGLISH language) on windows is changed to case sensitive.

Previous behavior:
1. Windows file system.
2. directory "tomcat/webapps" is case insensitive.
3. sub directory "tomcat/webapps/1" (maybe "tomcat/webapps/应用1“) is changed to case sensitive, via ```fsutil.exe file setCaseSensitiveInfo <path> enable```
4. DirResourceSet#isCaseSensitive returns case insensitive of directory "tomcat/webapps/1".
5. Unexpected.