### PR TITLE
Replace wine by makensis for Linux and use finalization to sign (un)installer

### DIFF
--- a/build.properties.default
+++ b/build.properties.default
@@ -94,6 +94,10 @@ codesigning.storetype=DIGICERTONE
 # Set codesigning.storepass in build.properties with the following syntax
 #codesigning.storepass=<api-key>|/path/to/Certificate_pkcs12.p12|<password>
 
+# Which tool to use for building Windows installer
+# on unix platform: wine or makensis.
+codesigning.tool=wine
+
 # ----- Settings to control downloading of files -----
 execute.download=true
 trydownload.httpusecaches=true

--- a/build.properties.default
+++ b/build.properties.default
@@ -96,7 +96,7 @@ codesigning.storetype=DIGICERTONE
 
 # Which tool to use for building Windows installer
 # on unix platform: wine or makensis.
-codesigning.tool=wine
+nsis.tool=wine
 
 # ----- Settings to control downloading of files -----
 execute.download=true

--- a/build.xml
+++ b/build.xml
@@ -2499,19 +2499,34 @@
     <property environment="env" />
     <condition property="wine.ok">
       <or>
+        <and>
+          <equals arg1="${codesigning.tool}" arg2="wine" forcestring="true"/>
+          <available file="wine" filepath="${env.PATH}" />
+        </and>
+      </or>
+    </condition>
+    <condition property="makensis.ok">
+      <or>
+        <and>
+          <equals arg1="${codesigning.tool}" arg2="makensis" forcestring="true"/>
+          <available file="makensis" filepath="${env.PATH}" />
+        </and>
+      </or>
+    </condition>
+    <condition property="installer.ok">
+      <or>
         <os family="windows" />
-        <available file="wine" filepath="${env.PATH}" />
-        <available file="makensis" filepath="${env.PATH}" />
-        <isset property="skip.installer"/>
+        <isset property="wine.ok"/>
+        <isset property="makensis.ok"/>
       </or>
     </condition>
   </target>
 
-  <target name="-installer-init" depends="-installer-pre-init" unless="${wine.ok}">
-    <fail message="The executable wine was not found on the current path.
-Wine is required to build the Windows installer when running a release build on
-a non-Windows platform. To skip building the Windows installer, set the
-skip.installer property in build.properties" />
+  <target name="-installer-init" depends="-installer-pre-init" unless="${installer.ok}">
+	  <fail message="The executable ${codesigning.tool} was not found on the current path.
+Either wine or makensis are required to build the Windows installer on a non-Windows platform.
+Choose the tool by setting property codesigning.tool in build.properties.
+To skip building the Windows installer, set the skip.installer property in build.properties" />
   </target>
 
   <target name="-installer-prep"
@@ -2543,16 +2558,28 @@ skip.installer property in build.properties" />
     </touch>
   </target>
 
-  <target name="-installer" unless="skip.installer"
-      depends="-installer-prep">
-    <exec dir="${tomcat.dist}" executable="${nsis.exe}" osfamily="windows">
+  <target name="-installer-wine" if="${wine.ok}">
+    <exec dir="${tomcat.dist}" executable="wine" osfamily="unix">
+      <arg value="${nsis.exe}" />
       <arg value="/DNSISDIR=${nsis.home}" />
       <arg value="/V2" />
       <arg value="tomcat.nsi" />
     </exec>
+  </target>
+
+  <target name="-installer-makensis" if="${makensis.ok}">
     <exec dir="${tomcat.dist}" executable="makensis" osfamily="unix">
       <arg value="-DNSISDIR=${nsis.home}" />
       <arg value="-V2" />
+      <arg value="tomcat.nsi" />
+    </exec>
+  </target>
+
+  <target name="-installer" unless="skip.installer"
+      depends="-installer-prep,-installer-wine,-installer-makensis">
+    <exec dir="${tomcat.dist}" executable="${nsis.exe}" osfamily="windows">
+      <arg value="/DNSISDIR=${nsis.home}" />
+      <arg value="/V2" />
       <arg value="tomcat.nsi" />
     </exec>
   </target>

--- a/build.xml
+++ b/build.xml
@@ -2496,6 +2496,7 @@
       <or>
         <os family="windows" />
         <available file="wine" filepath="${env.PATH}" />
+        <available file="makensis" filepath="${env.PATH}" />
         <isset property="skip.installer"/>
       </or>
     </condition>
@@ -2516,13 +2517,8 @@ skip.installer property in build.properties" />
         <include name="*.bmp" />
         <include name="*.ico" />
         <include name="*.xml" />
-        <include name="Uninstall.exe.sig" />
       </fileset>
     </copy>
-    <copy file="res/install-win/tomcat-installer.exe.sig"
-        tofile="${tomcat.release}/v${version}/bin/${final.name}.exe.sig"
-        failonerror="false"
-        quiet="true" />
     <copy file="${nsis.installoptions.dll}" todir="${tomcat.dist}" />
     <copy file="${nsis.nsexec.dll}" todir="${tomcat.dist}" />
     <copy file="${nsis.nsisdl.dll}" todir="${tomcat.dist}" />
@@ -2541,93 +2537,66 @@ skip.installer property in build.properties" />
     </touch>
   </target>
 
-  <target name="-installer-create-tempinstaller"
-      unless="skip.installer" depends="-installer-prep">
+  <target name="-installer" unless="skip.installer"
+      depends="-installer-prep">
     <exec dir="${tomcat.dist}" executable="${nsis.exe}" osfamily="windows">
-      <arg value="/DUNINSTALLONLY" />
       <arg value="/DNSISDIR=${nsis.home}" />
       <arg value="/V2" />
       <arg value="tomcat.nsi" />
     </exec>
-    <exec dir="${tomcat.dist}" executable="wine" osfamily="unix">
-      <arg value="${nsis.exe}" />
-      <arg value="/DUNINSTALLONLY" />
-      <arg value="/DNSISDIR=${nsis.home}" />
-      <arg value="/V2" />
+    <exec dir="${tomcat.dist}" executable="makensis" osfamily="unix">
+      <arg value="-DNSISDIR=${nsis.home}" />
+      <arg value="-V2" />
       <arg value="tomcat.nsi" />
     </exec>
   </target>
 
-  <target name="-installer-create-uninstaller"
-      unless="skip.installer" depends="-installer-create-tempinstaller">
-    <!-- Execute the temporary installer to create the uninstaller -->
-    <exec dir="${tomcat.dist}" executable="${tomcat.dist}/tempinstaller.exe"
-        osfamily="windows"  />
-    <exec dir="${tomcat.dist}" executable="wine" osfamily="unix">
-      <arg value="${tomcat.dist}/tempinstaller.exe" />
-    </exec>
-    <!-- Reproducible builds: consistent timestamps for installer files -->
-    <touch datetime="${tstamp.file}" pattern="yyyy-MM-dd HH:mm:ss">
-      <fileset dir="${tomcat.dist}"/>
-    </touch>
-  </target>
-
-  <target name="-installer-sign-uninstaller"
-      unless="skip.installer" depends="-installer-create-uninstaller,setup-jsign"
-      if="${do.codesigning}">
-    <!-- If the detached signature doesn't exist, this will sign the file    -->
-    <!-- and create the detached signature. If the detached signature does   -->
-    <!-- exist it will be attached to the file.                              -->
-    <jsign file="${tomcat.dist}/Uninstall.exe"
+  <target name="jsign-installer"
+      description="Sign the Windows installer"
+      depends="setup-jsign" if="${do.codesigning}" >
+      <echo>Signing ${tomcat.dist}/tomcat-installer.exe</echo>
+      <!-- Copy pre-existing detachced signature to signing directory -->
+      <copy file="res/install-win/tomcat-installer.exe.sig"
+          tofile="${tomcat.dist}/tomcat-installer.exe.sig"
+          failonerror="false" />
+      <jsign file="${tomcat.dist}/tomcat-installer.exe"
         storepass="${codesigning.storepass}"
         storetype="${codesigning.storetype}"
         alias="${codesigning.alias}"
         alg="${codesigning.digest}"
         tsaurl="http://timestamp.digicert.com"
         detached="true"/>
-    <!-- Copy detached signature to source tree -->
-    <copy file="${tomcat.dist}/Uninstall.exe.sig" todir="res/install-win"/>
-    <!-- Reproducible builds: consistent timestamps for installer files -->
-    <touch datetime="${tstamp.file}" pattern="yyyy-MM-dd HH:mm:ss">
-      <fileset dir="${tomcat.dist}"/>
-    </touch>
+      <move file="${tomcat.dist}/tomcat-installer.exe" tofile="${tomcat.release}/v${version}/bin/${final.name}.exe" />
+      <!-- Move detached signature to source tree -->
+      <move file="${tomcat.dist}/tomcat-installer.exe.sig" tofile="res/install-win/tomcat-installer.exe.sig"/>
   </target>
 
-  <target name="-installer" unless="skip.installer"
-      depends="-installer-sign-uninstaller">
-    <exec dir="${tomcat.dist}" executable="${nsis.exe}" osfamily="windows">
-      <arg value="/DNSISDIR=${nsis.home}" />
-      <arg value="/V2" />
-      <arg value="tomcat.nsi" />
-    </exec>
-    <exec dir="${tomcat.dist}" executable="wine" osfamily="unix">
-      <arg value="${nsis.exe}" />
-      <arg value="/DNSISDIR=${nsis.home}" />
-      <arg value="/V2" />
-      <arg value="tomcat.nsi" />
-    </exec>
-    <move file="${tomcat.dist}/tomcat-installer.exe" tofile="${tomcat.release}/v${version}/bin/${final.name}.exe" />
-    <hashAndSign file="${tomcat.release}/v${version}/bin/${final.name}.exe" />
-  </target>
-
-  <target name="installer-sign"
-      description="Builds and optionally signs the Windows installer"
-      depends="-installer,setup-jsign" if="${do.codesigning}" >
-    <jsign file="${tomcat.release}/v${version}/bin/${final.name}.exe"
+  <target name="jsign-uninstaller"
+      description="Sign the Windows uninstaller"
+      depends="setup-jsign" if="${do.codesigning}" >
+      <echo>Signing ${codesigning.file_to_sign}</echo>
+      <!-- Copy pre-existing detachced signature to signing directory -->
+      <copy file="res/install-win/Uninstall.exe.sig"
+          tofile="${codesigning.file_to_sign}.sig"
+          failonerror="false" />
+      <jsign file="${codesigning.file_to_sign}"
         storepass="${codesigning.storepass}"
         storetype="${codesigning.storetype}"
         alias="${codesigning.alias}"
         alg="${codesigning.digest}"
         tsaurl="http://timestamp.digicert.com"
         detached="true" />
-    <!-- Copy detached signature to source tree -->
-    <copy file="${tomcat.release}/v${version}/bin/${final.name}.exe.sig"
-        tofile="res/install-win/tomcat-installer.exe.sig"/>
-    <delete file="${tomcat.release}/v${version}/bin/${final.name}.exe.sig" />
-    <!-- .exe has changed so need to redo checksums and OpenPGP signature -->
-    <delete file="${tomcat.release}/v${version}/bin/${final.name}.exe.asc" />
-    <delete file="${tomcat.release}/v${version}/bin/${final.name}.exe.sha512" />
-    <hashAndSign file="${tomcat.release}/v${version}/bin/${final.name}.exe" />
+      <!-- Move detached signature to source tree -->
+      <move file="${codesigning.file_to_sign}.sig" tofile="res/install-win/Uninstall.exe.sig"/>
+  </target>
+
+  <target name="installer-sign"
+      description="Builds and optionally signs the Windows installer"
+      depends="-installer"  unless="skip.installer" >
+      <!-- .exe has changed so need to redo checksums and OpenPGP signature -->
+      <delete file="${tomcat.release}/v${version}/bin/${final.name}.exe.asc" />
+      <delete file="${tomcat.release}/v${version}/bin/${final.name}.exe.sha512" />
+      <hashAndSign file="${tomcat.release}/v${version}/bin/${final.name}.exe" />
   </target>
 
   <target name="-pre-release-lone-target-check">

--- a/build.xml
+++ b/build.xml
@@ -286,6 +286,11 @@
     <filter token="JASPIC_SPEC_VERSION" value="${jaspic.spec.version}"/>
   </filterset>
 
+  <!-- Path filter set -->
+  <filterset id="path.filters">
+    <filter token="BASEDIR" value="${basedir}"/>
+  </filterset>
+
   <!-- Files to change line endings for depending on target platform -->
   <patternset id="text.files" >
     <include name="**/INSTALLLICENSE"/>
@@ -2526,6 +2531,7 @@ skip.installer property in build.properties" />
     <copy file="${nsis.nsdialogs.dll}" todir="${tomcat.dist}" />
     <copy file="res/install-win/tomcat.nsi" tofile="${tomcat.dist}/tomcat.nsi" overwrite="true" encoding="ISO-8859-1">
       <filterset refid="version.filters"/>
+      <filterset refid="path.filters"/>
     </copy>
     <fixcrlf srcdir="${tomcat.dist}" eol="crlf"
         encoding="ISO-8859-1" fixlast="false" >

--- a/build.xml
+++ b/build.xml
@@ -2523,7 +2523,7 @@
   </target>
 
   <target name="-installer-init" depends="-installer-pre-init" unless="${installer.ok}">
-	  <fail message="The executable ${codesigning.tool} was not found on the current path.
+    <fail message="The executable ${codesigning.tool} was not found on the current path.
 Either wine or makensis are required to build the Windows installer on a non-Windows platform.
 Choose the tool by setting property codesigning.tool in build.properties.
 To skip building the Windows installer, set the skip.installer property in build.properties" />

--- a/build.xml
+++ b/build.xml
@@ -2500,7 +2500,7 @@
     <condition property="wine.ok">
       <or>
         <and>
-          <equals arg1="${codesigning.tool}" arg2="wine" forcestring="true"/>
+          <equals arg1="${nsis.tool}" arg2="wine" forcestring="true"/>
           <available file="wine" filepath="${env.PATH}" />
         </and>
       </or>
@@ -2508,7 +2508,7 @@
     <condition property="makensis.ok">
       <or>
         <and>
-          <equals arg1="${codesigning.tool}" arg2="makensis" forcestring="true"/>
+          <equals arg1="${nsis.tool}" arg2="makensis" forcestring="true"/>
           <available file="makensis" filepath="${env.PATH}" />
         </and>
       </or>
@@ -2523,9 +2523,9 @@
   </target>
 
   <target name="-installer-init" depends="-installer-pre-init" unless="${installer.ok}">
-    <fail message="The executable ${codesigning.tool} was not found on the current path.
+    <fail message="The executable ${nsis.tool} was not found on the current path.
 Either wine or makensis are required to build the Windows installer on a non-Windows platform.
-Choose the tool by setting property codesigning.tool in build.properties.
+Choose the tool by setting property nsis.tool in build.properties.
 To skip building the Windows installer, set the skip.installer property in build.properties" />
   </target>
 

--- a/build.xml
+++ b/build.xml
@@ -2599,7 +2599,6 @@ To skip building the Windows installer, set the skip.installer property in build
         alg="${codesigning.digest}"
         tsaurl="http://timestamp.digicert.com"
         detached="true"/>
-      <move file="${tomcat.dist}/tomcat-installer.exe" tofile="${tomcat.release}/v${version}/bin/${final.name}.exe" />
       <!-- Move detached signature to source tree -->
       <move file="${tomcat.dist}/tomcat-installer.exe.sig" tofile="res/install-win/tomcat-installer.exe.sig"/>
   </target>
@@ -2626,6 +2625,7 @@ To skip building the Windows installer, set the skip.installer property in build
   <target name="installer-sign"
       description="Builds and optionally signs the Windows installer"
       depends="-installer"  unless="skip.installer" >
+      <move file="${tomcat.dist}/tomcat-installer.exe" tofile="${tomcat.release}/v${version}/bin/${final.name}.exe" />
       <!-- .exe has changed so need to redo checksums and OpenPGP signature -->
       <delete file="${tomcat.release}/v${version}/bin/${final.name}.exe.asc" />
       <delete file="${tomcat.release}/v${version}/bin/${final.name}.exe.sha512" />

--- a/res/install-win/tomcat.nsi
+++ b/res/install-win/tomcat.nsi
@@ -17,11 +17,7 @@
 
 Unicode true
 
-!ifdef UNINSTALLONLY
-  OutFile "tempinstaller.exe"
-!else
-  OutFile tomcat-installer.exe
-!endif
+OutFile tomcat-installer.exe
 
   ;Compression options
   CRCCheck on
@@ -117,11 +113,9 @@ Var ServiceInstallLog
   Page custom CheckUserType
   !insertmacro MUI_PAGE_FINISH
 
-  !ifdef UNINSTALLONLY
-    ;Uninstall Page order
-    !insertmacro MUI_UNPAGE_CONFIRM
-    !insertmacro MUI_UNPAGE_INSTFILES
-  !endif
+  ;Uninstall Page order
+  !insertmacro MUI_UNPAGE_CONFIRM
+  !insertmacro MUI_UNPAGE_INSTFILES
 
   ;Language
   !insertmacro MUI_LANGUAGE English
@@ -162,6 +156,9 @@ Var ServiceInstallLog
   InstType Minimum
   InstType Full
 
+  !finalize 'ant -f ../../build.xml jsign-installer'
+  !uninstfinalize 'ant -f ../../build.xml -Dcodesigning.file_to_sign=%1 jsign-uninstaller'
+
   ReserveFile System.dll
   ReserveFile nsDialogs.dll
   ReserveFile tomcat-users_1.xml
@@ -199,6 +196,9 @@ Section "Core" SecTomcatCore
   File conf\*.*
   SetOutPath $INSTDIR\webapps\ROOT
   File /r webapps\ROOT\*.*
+
+  ;Create uninstaller
+  WriteUninstaller "$INSTDIR\Uninstall.exe"
 
   Call configure
 
@@ -338,12 +338,6 @@ Section -post
     Call createShortcuts
   ${EndIf}
 
-  !ifndef UNINSTALLONLY
-    SetOutPath $INSTDIR
-    ; this packages the signed uninstaller
-    File Uninstall.exe
-  !endif
-
   WriteRegStr HKLM "SOFTWARE\Apache Software Foundation\Tomcat\@VERSION_MAJOR_MINOR@\$TomcatServiceName" "InstallPath" $INSTDIR
   WriteRegStr HKLM "SOFTWARE\Apache Software Foundation\Tomcat\@VERSION_MAJOR_MINOR@\$TomcatServiceName" "Version" @VERSION@
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Apache Tomcat @VERSION_MAJOR_MINOR@ $TomcatServiceName" \
@@ -425,14 +419,6 @@ Function ReadFromConfigIni
 FunctionEnd
 
 Function .onInit
-  !ifdef UNINSTALLONLY
-    ; If UNINSTALLONLY is defined, then we aren't supposed to do anything except write out
-    ; the installer.  This is better than processing a command line option as it means
-    ; this entire code path is not present in the final (real) installer.
-    WriteUninstaller "$EXEDIR\Uninstall.exe"
-    Quit
-  !endif
-
   ${GetParameters} $R0
   ClearErrors
 
@@ -1140,7 +1126,6 @@ FunctionEnd
 ;--------------------------------
 ;Uninstaller Section
 
-!ifdef UNINSTALLONLY
   Section Uninstall
 
     ${If} $TomcatServiceName == ""
@@ -1269,7 +1254,5 @@ FunctionEnd
     ; DetailPrint "Search [$1] closed"
    FindClose $1
   FunctionEnd
-
-!endif
 
 ;eof

--- a/res/install-win/tomcat.nsi
+++ b/res/install-win/tomcat.nsi
@@ -156,8 +156,8 @@ Var ServiceInstallLog
   InstType Minimum
   InstType Full
 
-  !finalize 'ant -f ../../build.xml jsign-installer'
-  !uninstfinalize 'ant -f ../../build.xml -Dcodesigning.file_to_sign=%1 jsign-uninstaller'
+  !finalize 'ant -f @BASEDIR@/build.xml jsign-installer'
+  !uninstfinalize 'ant -f @BASEDIR@/build.xml -Dcodesigning.file_to_sign=%1 jsign-uninstaller'
 
   ReserveFile System.dll
   ReserveFile nsDialogs.dll


### PR DESCRIPTION
Nullsoft installers for Windows can be produced on Linux using the same NSIS scripts. Of course one needs to install makensis.

The other reason for using wine in build.xml was running the temporary installer used to create the uninstaller in order to be able to sign it.  But NSIS now allows to define a callback used to sign installer and uninstaller files while creating the installer. So the temporary installer is not needed any more.

First tests look good for me, but I am not using the official signing service used by release managers.

What is not very nice is, that in tomcat.nsi we are calling ant from inside the tomcat.dist directory. So we have to point it to the directory with the build.xml. I am using ../.. which will break if someone uses a non-default tomcat.dist. Since tomcat.nsi is produced by the version filter, in principal we could patch the path to build.xml into tomcat.nsi, but I didn't find a property containing the absolute basedir path.

It would be nice if release managers could test this. I can provide it for the other release branches as well (the patch needs some simple adjustments, because the jsign task uses different attributes in the other branches).