### PR TITLE
WebResource read/write lock key changed to in lowercase arbitrarily

### DIFF
--- a/java/org/apache/catalina/webresources/DirResourceSet.java
+++ b/java/org/apache/catalina/webresources/DirResourceSet.java
@@ -45,8 +45,6 @@ public class DirResourceSet extends AbstractFileResourceSet implements WebResour
 
     private static final Log log = LogFactory.getLog(DirResourceSet.class);
 
-    private boolean caseSensitive = true;
-
     private Map<String,ResourceLock> resourceLocksByPath = new HashMap<>();
     private Object resourceLocksByPathLock = new Object();
 
@@ -322,7 +320,6 @@ public class DirResourceSet extends AbstractFileResourceSet implements WebResour
     @Override
     protected void initInternal() throws LifecycleException {
         super.initInternal();
-        caseSensitive = isCaseSensitive(getFileBase());
         // Is this an exploded web application?
         if (getWebAppMount().equals("")) {
             // Look for a manifest
@@ -338,47 +335,9 @@ public class DirResourceSet extends AbstractFileResourceSet implements WebResour
     }
 
 
-    /* Determines if this ResourceSet is based on a case sensitive file system or not. */
-    private boolean isCaseSensitive(File dir) {
-        try {
-            // Some file system (e.g. windows) treat files and directories as case insensitive by default, and also
-            // support
-            // setting case sensitivity per directory. Then we have to handle case sensitivity for each directory.
-            // Ensure file path contain ENGLISH string, otherwise its upper and lower maybe are same.
-            File baseDir = dir.getCanonicalFile();
-            String lastPartName = ".Tomcat_cs_verify";
-            File testFile = new File(baseDir, lastPartName);
-            if (!testFile.exists()) {
-                if (testFile.createNewFile()) {
-                    testFile.deleteOnExit();
-                } else {
-                    throw new IOException();
-                }
-            }
-            String canonicalPath = testFile.getCanonicalPath();
-            File upper = new File(baseDir, lastPartName.toUpperCase(Locale.ENGLISH));
-            if (!upper.getCanonicalPath().equals(canonicalPath)) {
-                return true;
-            }
-            File lower = new File(baseDir, lastPartName.toLowerCase(Locale.ENGLISH));
-            if (!lower.getCanonicalPath().equals(canonicalPath)) {
-                return true;
-            }
-            /* Both upper and lower case versions of the current fileBase have the same canonical path so the file
-             * system must be case insensitive. */
-        } catch (IOException ioe) {
-            log.warn(sm.getString("dirResourceSet.isCaseSensitive.fail", dir.getAbsolutePath()), ioe);
-        }
-        return false;
-    }
-
-
     private String getLockKey(String path) {
         // Normalize path to ensure that the same key is used for the same path.
         String normalisedPath = RequestUtil.normalize(path);
-        if (caseSensitive) {
-            return normalisedPath;
-        }
         return normalisedPath.toLowerCase(Locale.ENGLISH);
     }
 


### PR DESCRIPTION
Discarding the file name case sensitivity of resource directory.

Detection of a directory case sensitivity is expansive, we have to create file with different upper/lower case name and check result.

Based on talk in PR #820 .

To avoid vulnerability, we simply treat all lock key as lowercase.