### PR TITLE
Fix info-then-debug logging in Http2UpgradeHandler

### DIFF
--- a/java/org/apache/coyote/http2/Http2UpgradeHandler.java
+++ b/java/org/apache/coyote/http2/Http2UpgradeHandler.java
@@ -89,6 +89,8 @@ class Http2UpgradeHandler extends AbstractStream implements InternalHttpUpgradeH
 
     protected static final HeaderSink HEADER_SINK = new HeaderSink();
 
+    protected static final UserDataHelper userDataHelper = new UserDataHelper(log);
+
     protected final String connectionId;
 
     protected final Http2Protocol protocol;
@@ -135,8 +137,6 @@ class Http2UpgradeHandler extends AbstractStream implements InternalHttpUpgradeH
     private final AtomicLong overheadCount;
     private volatile int lastNonFinalDataPayload;
     private volatile int lastWindowUpdate;
-
-    protected final UserDataHelper userDataHelper = new UserDataHelper(log);
 
 
     Http2UpgradeHandler(Http2Protocol protocol, Adapter adapter, Request coyoteRequest,


### PR DESCRIPTION
Fix info-then-debug logging in `Http2UpgradeHandler` by making the `UserDataHelper` static. Otherwise the _lastInfoTime_ in `UserDataHelper` will be per HTTP2-connection, but it should be a global scoped timestamp.

This also makes it consistant with how `UserDataHelper` is used in `Cookie`.