### PR TITLE
[optimization] Removed unused code

### DIFF
--- a/java/org/apache/catalina/valves/rewrite/RewriteRule.java
+++ b/java/org/apache/catalina/valves/rewrite/RewriteRule.java
@@ -47,11 +47,6 @@ public class RewriteRule {
             positive = false;
             patternString = patternString.substring(1);
         }
-        int flags = Pattern.DOTALL;
-        if (isNocase()) {
-            flags |= Pattern.CASE_INSENSITIVE;
-        }
-        Pattern.compile(patternString, flags);
         // Parse conditions
         for (RewriteCond condition : conditions) {
             condition.parse(maps);


### PR DESCRIPTION
the result of call Pattern.compile() isn't used. Variable int flags is redundant as a result