### PR TITLE
Adding nonstandard support for c:set and c:remove

### DIFF
--- a/java/org/apache/jasper/EmbeddedServletOptions.java
+++ b/java/org/apache/jasper/EmbeddedServletOptions.java
@@ -223,6 +223,8 @@ public final class EmbeddedServletOptions implements Options {
 
     private boolean useInstanceManagerForTags = false;
 
+    private String useNonstandardTagOptimizations;
+
     public String getProperty(String name) {
         return settings.getProperty(name);
     }
@@ -470,6 +472,11 @@ public final class EmbeddedServletOptions implements Options {
         return useInstanceManagerForTags;
     }
 
+    @Override
+    public String getUseNonstandardTagOptimizations() {
+        return useNonstandardTagOptimizations;
+    }
+
     /**
      * Create an EmbeddedServletOptions object using data available from ServletConfig and ServletContext.
      *
@@ -650,6 +657,11 @@ public final class EmbeddedServletOptions implements Options {
         String classpath = config.getInitParameter("classpath");
         if (classpath != null) {
             this.classpath = classpath;
+        }
+
+        String useNonstandardTagOptimizations = config.getInitParameter("useNonstandardTagOptimizations");
+        if (useNonstandardTagOptimizations != null) {
+            this.useNonstandardTagOptimizations = useNonstandardTagOptimizations;
         }
 
         /*

--- a/java/org/apache/jasper/JspC.java
+++ b/java/org/apache/jasper/JspC.java
@@ -137,6 +137,7 @@ public class JspC extends Task implements Options {
     protected static final String SWITCH_QUOTE_ATTRIBUTE_EL = "-quoteAttributeEL";
     protected static final String SWITCH_NO_QUOTE_ATTRIBUTE_EL = "-no-quoteAttributeEL";
     protected static final String SWITCH_THREAD_COUNT = "-threadCount";
+    protected static final String SWITCH_USENONSTANDARD_TAG_OPTIMIZATIONS = "-useNonstandardTagOptimizations";
     protected static final String SHOW_SUCCESS = "-s";
     protected static final String LIST_ERRORS = "-l";
     protected static final int INC_WEBXML = 10;
@@ -267,6 +268,8 @@ public class JspC extends Task implements Options {
     protected int argPos;
     protected boolean fullstop = false;
     protected String[] args;
+
+    protected String useNonstandardTagOptimizations;
 
     public static void main(String[] arg) {
         if (arg.length == 0) {
@@ -399,6 +402,8 @@ public class JspC extends Task implements Options {
                 setQuoteAttributeEL(false);
             } else if (tok.equals(SWITCH_THREAD_COUNT)) {
                 setThreadCount(nextArg());
+            } else if (tok.equals(SWITCH_USENONSTANDARD_TAG_OPTIMIZATIONS)) {
+                setUseNonstandardTagOptimizations(nextArg());
             } else {
                 if (tok.startsWith("-")) {
                     throw new JasperException(Localizer.getMessage("jspc.error.unknownOption", tok));
@@ -993,6 +998,15 @@ public class JspC extends Task implements Options {
      */
     public void setFailOnError(final boolean b) {
         failOnError = b;
+    }
+
+    /**
+     * Sets the set of custom tags to use nonstandard optimizations.
+     *
+     * @param useNonstandardTagOptimizations which tags to override
+     */
+    public void setUseNonstandardTagOptimizations(String useNonstandardTagOptimizations) {
+        this.useNonstandardTagOptimizations = useNonstandardTagOptimizations;
     }
 
     /**
@@ -1722,6 +1736,11 @@ public class JspC extends Task implements Options {
         }
     }
 
+
+    @Override
+    public String getUseNonstandardTagOptimizations() {
+        return useNonstandardTagOptimizations;
+    }
 
     private class ProcessFile implements Callable<Void> {
         private final String file;

--- a/java/org/apache/jasper/Options.java
+++ b/java/org/apache/jasper/Options.java
@@ -342,4 +342,12 @@ public interface Options {
     default boolean getGeneratedJavaAddTimestamp() {
         return true;
     }
+
+    /**
+     * A string containing a comma-separated list of names to which custom tag implementations should be applied.
+     * Unknown or unused tag entries are harmless.  Generally defined via an init parameter on the JspServlet.
+     *
+     * @return which tags to use
+     */
+    String getUseNonstandardTagOptimizations();
 }

--- a/java/org/apache/jasper/compiler/Generator.java
+++ b/java/org/apache/jasper/compiler/Generator.java
@@ -51,6 +51,7 @@ import org.apache.jasper.JasperException;
 import org.apache.jasper.JspCompilationContext;
 import org.apache.jasper.TrimSpacesOption;
 import org.apache.jasper.compiler.Node.ChildInfoBase;
+import org.apache.jasper.compiler.Node.JspAttribute;
 import org.apache.jasper.compiler.Node.NamedAttribute;
 import org.apache.jasper.runtime.JspRuntimeLibrary;
 import org.xml.sax.Attributes;
@@ -69,6 +70,8 @@ class Generator {
     private static final Pattern PRE_TAG_PATTERN = Pattern.compile("(?s).*(<pre>|</pre>).*");
 
     private static final Pattern BLANK_LINE_PATTERN = Pattern.compile("(\\s*(\\n|\\r)+\\s*)");
+
+    private static final String CORE_LIBS_URI = "http://java.sun.com/jsp/jstl/core";
 
     private final ServletWriter out;
 
@@ -101,6 +104,8 @@ class Generator {
     private final DateFormat timestampFormat;
 
     private final ELInterpreter elInterpreter;
+
+    private final Set<String> nonstandardCustomTagNames;
 
     private final StringInterpreter stringInterpreter;
 
@@ -1480,6 +1485,9 @@ class Generator {
 
         @Override
         public void visit(Node.CustomTag n) throws JasperException {
+            if (visitPotentiallyNonstandardCustomTag(n)) {
+                return;
+            }
 
             // Use plugin to generate more efficient code if there is one.
             if (n.useTagPlugin()) {
@@ -3028,6 +3036,219 @@ class Generator {
 
             return varName;
         }
+
+        /**
+         * Determines whether a tag should be handled via nonstandard code (typically
+         * faster). Considers both configuration and level of support within Tomcat.
+         *
+         * Note that Tomcat is free to ignore any case it cannot handle, as long as it
+         * reports it accurately to the caller by returning false. For example, the
+         * initial implementation for c:set excludes support for body content. c:set
+         * tags with body content will be generated with the standard code and tags
+         * without body content will be generated via non-standard code.
+         *
+         * @param n tag
+         * @param jspAttributes jsp attributes
+         * @return whether code was generated
+         * @throws JasperException unexpected error
+         */
+        private boolean visitPotentiallyNonstandardCustomTag(Node.CustomTag n)
+                throws JasperException {
+            if (!nonstandardCustomTagNames.contains(n.getQName())) {
+                // tag is not configured, move along
+                return false;
+            }
+
+            // collect the attributes into one Map for further checks
+            Map<String, JspAttribute> jspAttributes = new HashMap<>();
+            if (n.getJspAttributes() != null) {
+                for (JspAttribute jspAttr : n.getJspAttributes()) {
+                    jspAttributes.put(jspAttr.getLocalName(), jspAttr);
+                }
+            }
+            switch (n.qName) {
+            case "c:set":
+                // requires var and value, scope is optional, body is prohibited, value cannot be deferred
+                if (n.hasEmptyBody()
+                        && jspAttributes.containsKey("var")
+                        && jspAttributes.containsKey("value")
+                        && CORE_LIBS_URI.equals(n.getURI())) {
+                    // verify value is not a deferred expression
+                    String valueText = jspAttributes.get("value").getValue();
+                    if (valueText.startsWith("#")) {
+                        return false;
+                    } else if (jspAttributes.size() == 2
+                            || (jspAttributes.size() == 3 && jspAttributes.containsKey("scope"))) {
+                        generateNonstandardSetLogic(n, jspAttributes);
+                        return true;
+                    }
+                }
+                break;
+            case "c:remove":
+                // requires var, scope is optional, body is prohibited
+                if (n.hasEmptyBody()
+                        && jspAttributes.containsKey("var")
+                        && CORE_LIBS_URI.equals(n.getURI())
+                        && (jspAttributes.size() == 1
+                                || (jspAttributes.size() == 2
+                                && jspAttributes.containsKey("scope")))) {
+                    generateNonstandardRemoveLogic(n, jspAttributes);
+                    return true;
+
+                }
+                break;
+            default:
+                // This indicates someone configured a tag with no non-standard implementation.
+                // Harmless, fall back to the standard implementation.
+            }
+            return false;
+        }
+
+        private void generateNonstandardSetLogic(Node.CustomTag n, Map<String, JspAttribute> jspAttributes)
+                throws JasperException {
+            String baseVar = createTagVarName(n.getQName(), n.getPrefix(), n.getLocalName());
+            String tagMethod = "_jspx_meth_" + baseVar;
+            ServletWriter outSave = out;
+
+            // generate method call
+            out.printin(tagMethod);
+            out.print("(");
+            out.print("_jspx_page_context");
+            out.println(");");
+            GenBuffer genBuffer = new GenBuffer(n, n.getBody());
+            methodsBuffered.add(genBuffer);
+            out = genBuffer.getOut();
+
+            // Generate code for method declaration
+            methodNesting++;
+            out.println();
+            out.pushIndent();
+            out.printin("private void ");
+            out.print(tagMethod);
+            out.println("(jakarta.servlet.jsp.PageContext _jspx_page_context)");
+            out.printil("        throws java.lang.Throwable {");
+            out.pushIndent();
+            // Generated body of method
+            out.printil("//  " + n.getQName());
+
+            JspAttribute varAttribute = jspAttributes.get("var");
+            Mark m = n.getStart();
+            out.printil("// " + m.getFile() + "(" + m.getLineNumber() + "," + m.getColumnNumber() + ") "
+                    + varAttribute.getTagAttributeInfo());
+
+            JspAttribute valueAttribute = jspAttributes.get("value");
+            m = n.getStart();
+            out.printil("// " + m.getFile() + "(" + m.getLineNumber() + "," + m.getColumnNumber() + ") "
+                    + valueAttribute.getTagAttributeInfo());
+
+            String varValue = varAttribute.getValue();
+
+            // get the scope constant at compile-time, where blank means page
+            String scopeValue = translateScopeToConstant(jspAttributes);
+
+            // translates the specified value attributes into EL-interpretation code using standard logic
+            String evaluatedAttribute = evaluateAttribute(getTagHandlerInfo(n), valueAttribute,
+                    n, null);
+
+            // call the multi-line logic equivalent of SetTag
+            out.printil("org.apache.jasper.runtime.JspRuntimeLibrary.nonstandardSetTag(_jspx_page_context, \""
+                    + varValue + "\", " + evaluatedAttribute + ", " + scopeValue + ");");
+
+            // Generate end of method
+            out.popIndent();
+            out.printil("}");
+            out.popIndent();
+
+            methodNesting--;
+            // restore previous writer
+            out = outSave;
+        }
+
+        /**
+         * Compile-time translation of the scope variable into the constant equivalent. Avoids runtime evaluation as
+         * performed by SetTag.  Unspecified scope means page.
+         *
+         * @param jspAttributes attributes
+         * @return equivalent constant from PageContext
+         */
+        private String translateScopeToConstant(Map<String, JspAttribute> jspAttributes) {
+            String scopeValue;
+            JspAttribute scopeAttribute = jspAttributes.get("scope");
+            if (scopeAttribute == null) {
+                scopeValue = "jakarta.servlet.jsp.PageContext.PAGE_SCOPE";
+            } else {
+                switch (scopeAttribute.getValue()) {
+                case "":
+                case "page":
+                    scopeValue = "jakarta.servlet.jsp.PageContext.PAGE_SCOPE";
+                    break;
+                case "request":
+                    scopeValue = "jakarta.servlet.jsp.PageContext.REQUEST_SCOPE";
+                    break;
+                case "session":
+                    scopeValue = "jakarta.servlet.jsp.PageContext.SESSION_SCOPE";
+                    break;
+                case "application":
+                    scopeValue = "jakarta.servlet.jsp.PageContext.APPLICATION_SCOPE";
+                    break;
+                default:
+                    throw new IllegalArgumentException(Localizer.getMessage("jsp.error.page.invalid.scope"));
+                }
+            }
+            return scopeValue;
+        }
+
+        /**
+         * Generates the code for a non-standard remove.  Note that removes w/o a specified scope will remove from all scopes.
+         *
+         * @param n tag
+         * @param jspAttributes attributes
+         * @throws JasperException unspecified error
+         */
+        private void generateNonstandardRemoveLogic(Node.CustomTag n, Map<String, JspAttribute> jspAttributes)
+                throws JasperException {
+            String baseVar = createTagVarName(n.getQName(), n.getPrefix(), n.getLocalName());
+            String tagMethod = "_jspx_meth_" + baseVar;
+            ServletWriter outSave = out;
+
+            // generate method call
+            out.printin(tagMethod);
+            out.print("(");
+            out.print("_jspx_page_context");
+            out.println(");");
+            GenBuffer genBuffer = new GenBuffer(n, n.getBody());
+            methodsBuffered.add(genBuffer);
+            out = genBuffer.getOut();
+
+            // Generate code for method declaration
+            methodNesting++;
+            out.println();
+            out.pushIndent();
+            out.printin("private void ");
+            out.print(tagMethod);
+            out.println("(jakarta.servlet.jsp.PageContext pageContext)");
+            out.printil("        throws java.lang.Throwable {");
+            out.pushIndent();
+            // Generated body of method
+            String varValue = jspAttributes.get("var").getValue();
+            JspAttribute scope = jspAttributes.get("scope");
+            if (scope == null) {
+                // c:remove without a scope means remove from all scopes
+                out.printil("pageContext.removeAttribute(\"" + varValue + "\");");
+            } else {
+                // c:remove with a scope means remove only from the specified scope
+                String scopeValue = translateScopeToConstant(jspAttributes);
+                out.printil("pageContext.removeAttribute(\"" + varValue + "\", " + scopeValue + ");");
+            }
+            // Generate end of method
+            out.popIndent();
+            out.printil("}");
+            out.popIndent();
+
+            methodNesting--;
+            // restore previous writer
+            out = outSave;
+        }
     }
 
     private static void generateLocalVariables(ServletWriter out, ChildInfoBase n) {
@@ -3170,6 +3391,12 @@ class Generator {
         }
         timestampFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         timestampFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        String nonstandardOptionsList = ctxt.getOptions().getUseNonstandardTagOptimizations();
+        if (nonstandardOptionsList == null) {
+            nonstandardCustomTagNames = Collections.emptySet();
+        } else {
+            nonstandardCustomTagNames = new HashSet<>(Arrays.asList(nonstandardOptionsList.split(",")));
+        }
     }
 
     /**

--- a/java/org/apache/jasper/runtime/JspRuntimeLibrary.java
+++ b/java/org/apache/jasper/runtime/JspRuntimeLibrary.java
@@ -25,6 +25,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 
+import jakarta.el.VariableMapper;
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
@@ -956,5 +957,31 @@ public class JspRuntimeLibrary {
             log.warn(Localizer.getMessage("jsp.warning.tagPreDestroy", tag.getClass().getName()), t);
         }
 
+    }
+
+    /**
+     * This method parallels the logic of {@code SetSupport.doEndTag()}.
+     *
+     * @param pageContext pageContext
+     * @param var name of the variable
+     * @param value value to store
+     * @param scope scope
+     */
+    public static void nonstandardSetTag(jakarta.servlet.jsp.PageContext pageContext, String var, Object value,
+            int scope) {
+        if (value == null) {
+            // matches SetTag and removes the key from the specified scope
+            pageContext.removeAttribute(var, scope);
+        } else {
+            if (scope == PageContext.PAGE_SCOPE) {
+                // matches SetTag and cleans up the VariableMapper
+                VariableMapper vm = pageContext.getELContext().getVariableMapper();
+                if (vm != null) {
+                    vm.setVariable(var, null);
+                }
+            }
+            // does the all-important set of the correct scope
+            pageContext.setAttribute(var, value, scope);
+        }
     }
 }

--- a/test/jakarta/servlet/jsp/TesterPageContext.java
+++ b/test/jakarta/servlet/jsp/TesterPageContext.java
@@ -29,6 +29,15 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpSession;
 
 public class TesterPageContext extends PageContext {
+    private final ELContext elContext;
+
+    public TesterPageContext() {
+        this.elContext = null;
+    }
+
+    public TesterPageContext(ELContext elContext) {
+        this.elContext = elContext;
+    }
 
     @Override
     public void initialize(Servlet servlet, ServletRequest request,
@@ -174,7 +183,6 @@ public class TesterPageContext extends PageContext {
 
     @Override
     public ELContext getELContext() {
-        // NO-OP
-        return null;
+        return elContext;
     }
 }

--- a/test/jakarta/servlet/jsp/TesterPageContextWithAttributes.java
+++ b/test/jakarta/servlet/jsp/TesterPageContextWithAttributes.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jakarta.servlet.jsp;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.el.ELContext;
+
+import org.apache.jasper.compiler.Localizer;
+
+public class TesterPageContextWithAttributes extends TesterPageContext {
+    private final Map<String, Object> applicationAttributes = new HashMap<>();
+    private final Map<String, Object> pageAttributes = new HashMap<>();
+    private final Map<String, Object> requestAttributes = new HashMap<>();
+    private final Map<String, Object> sessionAttributes = new HashMap<>();
+
+    public TesterPageContextWithAttributes() {
+        super();
+    }
+
+    public TesterPageContextWithAttributes(ELContext elContext) {
+        super(elContext);
+    }
+
+    @Override
+    public Object getAttribute(String name) {
+        return getAttribute(name, PAGE_SCOPE);
+    }
+
+    @Override
+    public Object getAttribute(String name, int scope) {
+        if (name == null) {
+            throw new NullPointerException(Localizer.getMessage("jsp.error.attribute.null_name"));
+        }
+
+        return switch (scope) {
+        case PAGE_SCOPE -> pageAttributes.get(name);
+        case REQUEST_SCOPE -> requestAttributes.get(name);
+        case SESSION_SCOPE -> sessionAttributes.get(name);
+        case APPLICATION_SCOPE -> applicationAttributes.get(name);
+        default -> throw new IllegalArgumentException(Localizer.getMessage("jsp.error.page.invalid.scope"));
+        };
+    }
+
+    @Override
+    public void removeAttribute(String name) {
+        removeAttribute(name, PAGE_SCOPE);
+        removeAttribute(name, REQUEST_SCOPE);
+        removeAttribute(name, SESSION_SCOPE);
+        removeAttribute(name, APPLICATION_SCOPE);
+    }
+
+    @Override
+    public void removeAttribute(String name, int scope) {
+        switch (scope) {
+        case PageContext.APPLICATION_SCOPE:
+            applicationAttributes.remove(name);
+            break;
+        case PageContext.PAGE_SCOPE:
+            pageAttributes.remove(name);
+            break;
+        case PageContext.REQUEST_SCOPE:
+            requestAttributes.remove(name);
+            break;
+        case PageContext.SESSION_SCOPE:
+            sessionAttributes.remove(name);
+            break;
+        default:
+            throw new IllegalArgumentException(Localizer.getMessage("jsp.error.page.invalid.scope"));
+        }
+    }
+
+    @Override
+    public void setAttribute(String name, Object value) {
+        setAttribute(name, value, PAGE_SCOPE);
+    }
+
+    @Override
+    public void setAttribute(String name, Object value, int scope) {
+        if (value == null) {
+            removeAttribute(name, scope);
+        } else {
+            switch (scope) {
+            case PAGE_SCOPE:
+                pageAttributes.put(name, value);
+                break;
+
+            case REQUEST_SCOPE:
+                requestAttributes.put(name, value);
+                break;
+
+            case SESSION_SCOPE:
+                sessionAttributes.put(name, value);
+                break;
+
+            case APPLICATION_SCOPE:
+                applicationAttributes.put(name, value);
+                break;
+
+            default:
+                throw new IllegalArgumentException(Localizer.getMessage("jsp.error.page.invalid.scope"));
+            }
+        }
+    }
+
+}

--- a/test/org/apache/jasper/compiler/TestGenerator.java
+++ b/test/org/apache/jasper/compiler/TestGenerator.java
@@ -393,6 +393,49 @@ public class TestGenerator extends TomcatBaseTest {
         doTestJspId(true);
     }
 
+    @Test
+    public void testNonstandardSets() throws Exception {
+        getTomcatInstanceTestWebapp(true, true);
+
+        // This should break all subsequent requests
+        ByteChunk body = new ByteChunk();
+        getUrl("http://localhost:" + getPort() + "/test/jsp/generator/nonstandard/set-01.jsp", body, null);
+        Assert.assertEquals("\n\n\n"
+                + "pageContext value=testValue\n"
+                + "request value=null\n"
+                + "session value=null\n"
+                + "application value=null", body.toString());
+        body.recycle();
+        getUrl("http://localhost:" + getPort() + "/test/jsp/generator/nonstandard/set-02.jsp", body, null);
+        Assert.assertEquals("\n\n\n"
+                + "pageContext value=testValue\n"
+                + "request value=null\n"
+                + "session value=null\n"
+                + "application value=null", body.toString());
+        body.recycle();
+        getUrl("http://localhost:" + getPort() + "/test/jsp/generator/nonstandard/set-03.jsp", body, null);
+        Assert.assertEquals("\n\n\n"
+                + "pageContext value=null\n"
+                + "request value=testValue\n"
+                + "session value=null\n"
+                + "application value=null", body.toString());
+        body.recycle();
+        getUrl("http://localhost:" + getPort() + "/test/jsp/generator/nonstandard/set-04.jsp", body, null);
+        Assert.assertEquals("\n\n\n"
+                + "pageContext value=null\n"
+                + "request value=null\n"
+                + "session value=testValue\n"
+                + "application value=null", body.toString());
+        body.recycle();
+        getUrl("http://localhost:" + getPort() + "/test/jsp/generator/nonstandard/set-05.jsp", body, null);
+        Assert.assertEquals("\n\n\n"
+                + "pageContext value=null\n"
+                + "request value=null\n"
+                + "session value=null\n"
+                + "application value=testValue", body.toString());
+        body.recycle();
+    }
+
     private void doTestJspId(boolean document) throws Exception {
         getTomcatInstanceTestWebapp(false, true);
 
@@ -1045,5 +1088,48 @@ public class TestGenerator extends TomcatBaseTest {
         int rc = getUrl("http://localhost:" + getPort() + "/test/jsp/generator/" + jspName, body, null);
 
         Assert.assertEquals(body.toString(), expectedResponseCode, rc);
+    }
+
+    @Test
+    public void testNonstandardRemoves() throws Exception {
+        getTomcatInstanceTestWebapp(true, true);
+
+        // This should break all subsequent requests
+        ByteChunk body = new ByteChunk();
+        getUrl("http://localhost:" + getPort() + "/test/jsp/generator/nonstandard/remove-01.jsp", body, null);
+        Assert.assertEquals("\n\n\n\n\n\n\n"
+                + "pageContext value=null\n"
+                + "request value=testValue\n"
+                + "session value=testValue\n"
+                + "application value=testValue", body.toString());
+        body.recycle();
+        getUrl("http://localhost:" + getPort() + "/test/jsp/generator/nonstandard/remove-02.jsp", body, null);
+        Assert.assertEquals("\n\n\n\n\n\n\n"
+                + "pageContext value=testValue\n"
+                + "request value=null\n"
+                + "session value=testValue\n"
+                + "application value=testValue", body.toString());
+        body.recycle();
+        getUrl("http://localhost:" + getPort() + "/test/jsp/generator/nonstandard/remove-03.jsp", body, null);
+        Assert.assertEquals("\n\n\n\n\n\n\n"
+                + "pageContext value=testValue\n"
+                + "request value=testValue\n"
+                + "session value=null\n"
+                + "application value=testValue", body.toString());
+        body.recycle();
+        getUrl("http://localhost:" + getPort() + "/test/jsp/generator/nonstandard/remove-04.jsp", body, null);
+        Assert.assertEquals("\n\n\n\n\n\n\n"
+                + "pageContext value=testValue\n"
+                + "request value=testValue\n"
+                + "session value=testValue\n"
+                + "application value=null", body.toString());
+        body.recycle();
+        getUrl("http://localhost:" + getPort() + "/test/jsp/generator/nonstandard/remove-05.jsp", body, null);
+        Assert.assertEquals("\n\n\n\n\n\n\n"
+                + "pageContext value=null\n"
+                + "request value=null\n"
+                + "session value=null\n"
+                + "application value=null", body.toString());
+        body.recycle();
     }
 }

--- a/test/org/apache/jasper/compiler/TestNonstandardTagPerformance.java
+++ b/test/org/apache/jasper/compiler/TestNonstandardTagPerformance.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jasper.compiler;
+
+import jakarta.el.ELContext;
+import jakarta.el.ELManager;
+import jakarta.el.ExpressionFactory;
+import jakarta.servlet.jsp.PageContext;
+import jakarta.servlet.jsp.TesterPageContext;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import org.apache.jasper.runtime.JspRuntimeLibrary;
+import org.apache.tomcat.InstanceManager;
+import org.apache.tomcat.SimpleInstanceManager;
+
+public class TestNonstandardTagPerformance {
+    static final long NUM_ITERATIONS = 100000000L;
+
+    static final int NUM_TESTS = 5;
+
+    private ELContext elContext;
+
+    private ExpressionFactory factory;
+
+    private InstanceManager instanceManager = new SimpleInstanceManager();
+
+    private ELManager manager;
+    public PageContext pageContext;
+
+    public jakarta.el.ExpressionFactory _jsp_getExpressionFactory() {
+        return factory;
+    }
+
+    private InstanceManager _jsp_getInstanceManager() {
+        return instanceManager;
+    }
+
+    private void newCode(jakarta.servlet.jsp.PageContext _jspx_page_context) throws java.lang.Throwable {
+        JspRuntimeLibrary.nonstandardSetTag(_jspx_page_context, null, _jspx_page_context,
+                jakarta.servlet.jsp.PageContext.PAGE_SCOPE);
+        _jspx_page_context.setAttribute("groupName", new Object(), jakarta.servlet.jsp.PageContext.PAGE_SCOPE);
+    }
+
+    /**
+     * This code is stolen from a generated JSP using standard c:set logic, except that the value is replaced by "new
+     * Object()". This eliminates the EL cost from the benchmark so we can accurately focus on the c:set performance.
+     *
+     * @param _jspx_th_c_005fwhen_005f11 parent tag
+     * @param _jspx_page_context page context
+     * @return whether to continue execution
+     * @throws java.lang.Throwable unknown error
+     */
+    private boolean oldCode(jakarta.servlet.jsp.tagext.JspTag _jspx_th_c_005fwhen_005f11,
+            jakarta.servlet.jsp.PageContext _jspx_page_context) throws java.lang.Throwable {
+//        jakarta.servlet.jsp.PageContext pageContext = _jspx_page_context;
+//        jakarta.servlet.jsp.JspWriter out = _jspx_page_context.getOut();
+//        // c:set
+//        org.apache.taglibs.standard.tag.rt.core.SetTag _jspx_th_c_005fset_005f39 = new org.apache.taglibs.standard.tag.rt.core.SetTag();
+//        _jsp_getInstanceManager().newInstance(_jspx_th_c_005fset_005f39);
+//        try {
+//            _jspx_th_c_005fset_005f39.setPageContext(_jspx_page_context);
+//            _jspx_th_c_005fset_005f39.setParent((jakarta.servlet.jsp.tagext.Tag) _jspx_th_c_005fwhen_005f11);
+//            // /WEB-INF/views/jsp/features/buybox/offerDisplayGroupLayout.jsp(230,12) name = var type = java.lang.String
+//            // reqTime = false required = false fragment = false deferredValue = false expectedTypeName = null
+//            // deferredMethod = false methodSignature = null
+//            _jspx_th_c_005fset_005f39.setVar("groupName");
+//            // /WEB-INF/views/jsp/features/buybox/offerDisplayGroupLayout.jsp(230,12) name = value type =
+//            // javax.el.ValueExpression reqTime = true required = false fragment = false deferredValue = true
+//            // expectedTypeName = java.lang.Object deferredMethod = false methodSignature = null
+//            _jspx_th_c_005fset_005f39.setValue(new Object());
+//            int _jspx_eval_c_005fset_005f39 = _jspx_th_c_005fset_005f39.doStartTag();
+//            if (_jspx_th_c_005fset_005f39.doEndTag() == jakarta.servlet.jsp.tagext.Tag.SKIP_PAGE) {
+//                return true;
+//            }
+//        } finally {
+//            org.apache.jasper.runtime.JspRuntimeLibrary.releaseTag(_jspx_th_c_005fset_005f39,
+//                    _jsp_getInstanceManager());
+//        }
+        return false;
+    }
+
+    /**
+     * This method depends on the availability of org.apache.taglibs.standard.tag.rt.core.SetTag, which is not typically
+     * available for Tomcat's unit tests. To execute the benchmark correctly, please:
+     * <ol>
+     * <li>add a taglibs jar to the classpath</li>
+     * <li>uncomment the body of {@code oldCode()}</li>
+     * <li>run the test manually (IDE or command-line)</li>
+     * <li>use jvm args similar to
+     *
+     * <pre>
+     * -Xmx1g -Xms1g -verbose:gc -XX:+UseParallelGC
+     * </pre>
+     *
+     * </li>
+     * </ol>
+     * @throws Throwable generic error
+     */
+    @Ignore
+    @Test
+    public void runBenchmark() throws Throwable {
+        long[] durations = new long[NUM_TESTS];
+        for (int i = 0; i < NUM_ITERATIONS / 10; i++) {
+            oldCode(null, pageContext);
+            newCode(pageContext);
+        }
+
+        for (int i = 0; i < NUM_TESTS; i++) {
+            long start = System.currentTimeMillis();
+            for (long j = 0; j < NUM_ITERATIONS; j++) {
+                oldCode(null, pageContext);
+            }
+            durations[i] = System.currentTimeMillis() - start;
+        }
+
+        for (int d = 0; d < durations.length; d++) {
+            System.out.println("Old: " + d + ". " + durations[d] + "ms");
+        }
+        for (int i = 0; i < NUM_TESTS; i++) {
+            long start = System.currentTimeMillis();
+            for (long j = 0; j < NUM_ITERATIONS; j++) {
+                newCode(pageContext);
+            }
+            durations[i] = System.currentTimeMillis() - start;
+        }
+
+        for (int d = 0; d < durations.length; d++) {
+            System.out.println("New: " + d + ". " + durations[d] + "ms");
+        }
+    }
+
+    @Before
+    public void setupTestVars() {
+        manager = new ELManager();
+        elContext = manager.getELContext();
+        factory = ELManager.getExpressionFactory();
+        pageContext = new TesterPageContext(elContext);
+    }
+}

--- a/test/webapp/WEB-INF/web.xml
+++ b/test/webapp/WEB-INF/web.xml
@@ -28,6 +28,11 @@
      required.
   </description>
 
+  <servlet-mapping>
+    <servlet-name>JSP-nonstandard</servlet-name>
+    <url-pattern>/jsp/generator/nonstandard/*</url-pattern>
+  </servlet-mapping>
+
   <servlet>
     <servlet-name>jsp</servlet-name>
       <servlet-class>org.apache.jasper.servlet.JspServlet</servlet-class>
@@ -38,6 +43,29 @@
       <init-param>
         <param-name>xpoweredBy</param-name>
         <param-value>false</param-value>
+      </init-param>
+      <!-- Required by /jsp/tagFileInJar.jsp / TestJspCompilationContext  -->
+      <init-param>
+        <param-name>modificationTestInterval</param-name>
+        <param-value>0</param-value>
+      </init-param>
+    <load-on-startup>3</load-on-startup>
+  </servlet>
+
+  <servlet>
+    <servlet-name>JSP-nonstandard</servlet-name>
+      <servlet-class>org.apache.jasper.servlet.JspServlet</servlet-class>
+      <init-param>
+        <param-name>fork</param-name>
+        <param-value>false</param-value>
+      </init-param>
+      <init-param>
+        <param-name>xpoweredBy</param-name>
+        <param-value>false</param-value>
+      </init-param>
+      <init-param>
+        <param-name>useNonstandardTagOptimizations</param-name>
+        <param-value>c:set,c:remove</param-value>
       </init-param>
       <!-- Required by /jsp/tagFileInJar.jsp / TestJspCompilationContext  -->
       <init-param>

--- a/test/webapp/jsp/generator/nonstandard/remove-01.jsp
+++ b/test/webapp/jsp/generator/nonstandard/remove-01.jsp
@@ -1,0 +1,26 @@
+<%--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%@ taglib uri = "http://java.sun.com/jsp/jstl/core" prefix = "c" %>
+<c:set var="testVar" value="${'testValue'}" scope="page"/>
+<c:set var="testVar" value="${'testValue'}" scope="request"/>
+<c:set var="testVar" value="${'testValue'}" scope="session"/>
+<c:set var="testVar" value="${'testValue'}" scope="application"/>
+<c:remove var="testVar" scope="page"/>
+pageContext value=<%= pageContext.getAttribute("testVar") %>
+request value=<%= request.getAttribute("testVar") %>
+session value=<%= session.getAttribute("testVar") %>
+application value=<%= application.getAttribute("testVar") %>

--- a/test/webapp/jsp/generator/nonstandard/remove-02.jsp
+++ b/test/webapp/jsp/generator/nonstandard/remove-02.jsp
@@ -1,0 +1,26 @@
+<%--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%@ taglib uri = "http://java.sun.com/jsp/jstl/core" prefix = "c" %>
+<c:set var="testVar" value="${'testValue'}" scope="page"/>
+<c:set var="testVar" value="${'testValue'}" scope="request"/>
+<c:set var="testVar" value="${'testValue'}" scope="session"/>
+<c:set var="testVar" value="${'testValue'}" scope="application"/>
+<c:remove var="testVar" scope="request"/>
+pageContext value=<%= pageContext.getAttribute("testVar") %>
+request value=<%= request.getAttribute("testVar") %>
+session value=<%= session.getAttribute("testVar") %>
+application value=<%= application.getAttribute("testVar") %>

--- a/test/webapp/jsp/generator/nonstandard/remove-03.jsp
+++ b/test/webapp/jsp/generator/nonstandard/remove-03.jsp
@@ -1,0 +1,26 @@
+<%--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%@ taglib uri = "http://java.sun.com/jsp/jstl/core" prefix = "c" %>
+<c:set var="testVar" value="${'testValue'}" scope="page"/>
+<c:set var="testVar" value="${'testValue'}" scope="request"/>
+<c:set var="testVar" value="${'testValue'}" scope="session"/>
+<c:set var="testVar" value="${'testValue'}" scope="application"/>
+<c:remove var="testVar" scope="session"/>
+pageContext value=<%= pageContext.getAttribute("testVar") %>
+request value=<%= request.getAttribute("testVar") %>
+session value=<%= session.getAttribute("testVar") %>
+application value=<%= application.getAttribute("testVar") %>

--- a/test/webapp/jsp/generator/nonstandard/remove-04.jsp
+++ b/test/webapp/jsp/generator/nonstandard/remove-04.jsp
@@ -1,0 +1,26 @@
+<%--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%@ taglib uri = "http://java.sun.com/jsp/jstl/core" prefix = "c" %>
+<c:set var="testVar" value="${'testValue'}" scope="page"/>
+<c:set var="testVar" value="${'testValue'}" scope="request"/>
+<c:set var="testVar" value="${'testValue'}" scope="session"/>
+<c:set var="testVar" value="${'testValue'}" scope="application"/>
+<c:remove var="testVar" scope="application"/>
+pageContext value=<%= pageContext.getAttribute("testVar") %>
+request value=<%= request.getAttribute("testVar") %>
+session value=<%= session.getAttribute("testVar") %>
+application value=<%= application.getAttribute("testVar") %>

--- a/test/webapp/jsp/generator/nonstandard/remove-05.jsp
+++ b/test/webapp/jsp/generator/nonstandard/remove-05.jsp
@@ -1,0 +1,26 @@
+<%--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%@ taglib uri = "http://java.sun.com/jsp/jstl/core" prefix = "c" %>
+<c:set var="testVar" value="${'testValue'}" scope="page"/>
+<c:set var="testVar" value="${'testValue'}" scope="request"/>
+<c:set var="testVar" value="${'testValue'}" scope="session"/>
+<c:set var="testVar" value="${'testValue'}" scope="application"/>
+<c:remove var="testVar"/>
+pageContext value=<%= pageContext.getAttribute("testVar") %>
+request value=<%= request.getAttribute("testVar") %>
+session value=<%= session.getAttribute("testVar") %>
+application value=<%= application.getAttribute("testVar") %>

--- a/test/webapp/jsp/generator/nonstandard/set-01.jsp
+++ b/test/webapp/jsp/generator/nonstandard/set-01.jsp
@@ -1,0 +1,22 @@
+<%--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%@ taglib uri = "http://java.sun.com/jsp/jstl/core" prefix = "c" %>
+<c:set var="testVar" value="${'testValue'}"/>
+pageContext value=<%= pageContext.getAttribute("testVar") %>
+request value=<%= request.getAttribute("testVar") %>
+session value=<%= session.getAttribute("testVar") %>
+application value=<%= application.getAttribute("testVar") %>

--- a/test/webapp/jsp/generator/nonstandard/set-02.jsp
+++ b/test/webapp/jsp/generator/nonstandard/set-02.jsp
@@ -1,0 +1,22 @@
+<%--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%@ taglib uri = "http://java.sun.com/jsp/jstl/core" prefix = "c" %>
+<c:set var="testVar" value="${'testValue'}" scope="page"/>
+pageContext value=<%= pageContext.getAttribute("testVar") %>
+request value=<%= request.getAttribute("testVar") %>
+session value=<%= session.getAttribute("testVar") %>
+application value=<%= application.getAttribute("testVar") %>

--- a/test/webapp/jsp/generator/nonstandard/set-03.jsp
+++ b/test/webapp/jsp/generator/nonstandard/set-03.jsp
@@ -1,0 +1,22 @@
+<%--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%@ taglib uri = "http://java.sun.com/jsp/jstl/core" prefix = "c" %>
+<c:set var="testVar" value="${'testValue'}" scope="request"/>
+pageContext value=<%= pageContext.getAttribute("testVar") %>
+request value=<%= request.getAttribute("testVar") %>
+session value=<%= session.getAttribute("testVar") %>
+application value=<%= application.getAttribute("testVar") %>

--- a/test/webapp/jsp/generator/nonstandard/set-04.jsp
+++ b/test/webapp/jsp/generator/nonstandard/set-04.jsp
@@ -1,0 +1,22 @@
+<%--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%@ taglib uri = "http://java.sun.com/jsp/jstl/core" prefix = "c" %>
+<c:set var="testVar" value="${'testValue'}" scope="session"/>
+pageContext value=<%= pageContext.getAttribute("testVar") %>
+request value=<%= request.getAttribute("testVar") %>
+session value=<%= session.getAttribute("testVar") %>
+application value=<%= application.getAttribute("testVar") %>

--- a/test/webapp/jsp/generator/nonstandard/set-05.jsp
+++ b/test/webapp/jsp/generator/nonstandard/set-05.jsp
@@ -1,0 +1,22 @@
+<%--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%@ taglib uri = "http://java.sun.com/jsp/jstl/core" prefix = "c" %>
+<c:set var="testVar" value="${'testValue'}" scope="application"/>
+pageContext value=<%= pageContext.getAttribute("testVar") %>
+request value=<%= request.getAttribute("testVar") %>
+session value=<%= session.getAttribute("testVar") %>
+application value=<%= application.getAttribute("testVar") %>

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -198,6 +198,11 @@
         <code>compilerTargetVM</code> have been updated to 21 to align with Java
         21 being the minimum Java version required for Tomcat 12. (markt)
       </update>
+      <add>
+        Add support for optimized execution of c:set and c:remove tags, when
+        activated via JSP servlet param useNonstandardTagOptimizations.
+        (jengebr)
+      </add>
       <!-- Entries for backport and removal before 12.0.0-M1 below this line -->
     </changelog>
   </subsection>


### PR DESCRIPTION
Enables optimized, non-standard behavior for the most common JSP tags, when configured to do so.

**Impact:** benchmark (included)shows 99% reduction in cpu, 100% reduction in object allocation

**Activation:** off by default, enabled via an init param to the JSP servlet, such as:
```
      <init-param>
        <param-name>useNonstandardTagOptimizations</param-name>
        <param-value>c:set,c:remove</param-value>
      </init-param>
```

**Example:**
Old code (standard): one method, two parameters, 10+ lines of code, one object allocated (and it's large!).
```
  private boolean _jspx_meth_c_005fset_005f39(javax.servlet.jsp.tagext.JspTag _jspx_th_c_005fwhen_005f11, javax.servlet.jsp.PageContext _jspx_page_context)
          throws java.lang.Throwable {
    javax.servlet.jsp.PageContext pageContext = _jspx_page_context;
    javax.servlet.jsp.JspWriter out = _jspx_page_context.getOut();
    //  c:set
    org.apache.taglibs.standard.tag.rt.core.SetTag _jspx_th_c_005fset_005f39 = new org.apache.taglibs.standard.tag.rt.core.SetTag();
    _jsp_getInstanceManager().newInstance(_jspx_th_c_005fset_005f39);
    try {
      _jspx_th_c_005fset_005f39.setPageContext(_jspx_page_context);
      _jspx_th_c_005fset_005f39.setParent((javax.servlet.jsp.tagext.Tag) _jspx_th_c_005fwhen_005f11);
      // /WEB-INF/views/jsp/features/buybox/offerDisplayGroupLayout.jsp(230,12) name = var type = java.lang.String reqTime = false required = false fragment = false deferredValue = false expectedTypeName = null deferredMethod = false methodSignature = null
      _jspx_th_c_005fset_005f39.setVar("groupName");
      // /WEB-INF/views/jsp/features/buybox/offerDisplayGroupLayout.jsp(230,12) name = value type = javax.el.ValueExpression reqTime = true required = false fragment = false deferredValue = true expectedTypeName = java.lang.Object deferredMethod = false methodSignature = null
      _jspx_th_c_005fset_005f39.setValue(new org.apache.jasper.el.JspValueExpression("/WEB-INF/views/jsp/features/buybox/offerDisplayGroupLayout.jsp(230,12) '${tabContents.keySet().toArray()[0]}'",_jsp_getExpressionFactory().createValueExpression(_jspx_page_context.getELContext(),"${tabContents.keySet().toArray()[0]}",java.lang.Object.class)).getValue(_jspx_page_context.getELContext()));
      int _jspx_eval_c_005fset_005f39 = _jspx_th_c_005fset_005f39.doStartTag();
      if (_jspx_th_c_005fset_005f39.doEndTag() == javax.servlet.jsp.tagext.Tag.SKIP_PAGE) {
        return true;
      }
    } finally {
      org.apache.jasper.runtime.JspRuntimeLibrary.releaseTag(_jspx_th_c_005fset_005f39, _jsp_getInstanceManager(), false);
    }
    return false;
  }

```

New code (nonstandard) - one parameter, one line of code, zero objects allocated.
```
  private void _jspx_meth_c_005fset_005f0(jakarta.servlet.jsp.PageContext _jspx_page_context)
          throws java.lang.Throwable {
    //  c:set
    // /jsp/generator/nonstandard/set-01.jsp(18,0) name = var type = java.lang.String reqTime = false required = false fragment = false deferredValue = false expectedTypeName = null deferredMethod = false methodSignature = null
    // /jsp/generator/nonstandard/set-01.jsp(18,0) name = value type = jakarta.el.ValueExpression reqTime = true required = false fragment = false deferredValue = true expectedTypeName = java.lang.Object deferredMethod = false methodSignature = null
    org.apache.jasper.runtime.JspRuntimeLibrary.nonstandardSetTag(_jspx_page_context, "testVar", new org.apache.jasper.el.JspValueExpression("/jsp/generator/nonstandard/set-01.jsp(18,0) '${'testValue'}'",_jsp_getExpressionFactory().createValueExpression(_jspx_page_context.getELContext(),"${'testValue'}",java.lang.Object.class)).getValue(_jspx_page_context.getELContext()), jakarta.servlet.jsp.PageContext.PAGE_SCOPE);
  }
```

Caller code is simplified by eliminating the boolean check, from:
```
          if (_jspx_meth_c_005fset_005f39(_jspx_th_c_005fwhen_005f11, _jspx_page_context))
            return true;
```
to
```
        _jspx_meth_c_005fset_005f125(_jspx_page_context);
```
