### PR TITLE
BUGFIX: fix an incorrect range size validation

### DIFF
--- a/java/org/apache/catalina/servlets/DefaultServlet.java
+++ b/java/org/apache/catalina/servlets/DefaultServlet.java
@@ -731,19 +731,20 @@ public class DefaultServlet extends HttpServlet {
 
             // Append data in request input stream to contentFile
             randAccessContentFile.seek(range.getStart());
+            long rangeSize = range.getEnd() - range.getStart() + 1;
             long received = 0;
-            int numBytesRead;
             byte[] transferBuffer = new byte[BUFFER_SIZE];
             try (BufferedInputStream requestBufInStream = new BufferedInputStream(req.getInputStream(), BUFFER_SIZE)) {
+                int numBytesRead;
                 while ((numBytesRead = requestBufInStream.read(transferBuffer)) != -1) {
                     received += numBytesRead;
-                    if (received > range.getEnd() - range.getStart()) {
+                    if (received > rangeSize) {
                         throw new IllegalStateException(sm.getString("defaultServlet.wrongByteCountForRange",
                                 String.valueOf(received), String.valueOf(range.getEnd() - range.getStart())));
                     }
                     randAccessContentFile.write(transferBuffer, 0, numBytesRead);
                 }
-                if (received < range.getEnd() - range.getStart()) {
+                if (received < rangeSize) {
                     throw new IllegalStateException(sm.getString("defaultServlet.wrongByteCountForRange",
                             String.valueOf(received), String.valueOf(range.getEnd() - range.getStart())));
                 }

--- a/test/org/apache/catalina/servlets/TestDefaultServletPut.java
+++ b/test/org/apache/catalina/servlets/TestDefaultServletPut.java
@@ -41,9 +41,9 @@ import org.apache.tomcat.util.buf.ByteChunk;
 public class TestDefaultServletPut extends TomcatBaseTest {
 
     private static final String START_TEXT= "Starting text";
-    private static final String START_LEN = Integer.toString(START_TEXT.length());
+    private static final int START_LEN = START_TEXT.length();
     private static final String PATCH_TEXT= "Ending *";
-    private static final String PATCH_LEN = Integer.toString(PATCH_TEXT.length());
+    private static final int PATCH_LEN = PATCH_TEXT.length();
     private static final String END_TEXT= "Ending * text";
 
     @Parameterized.Parameters(name = "{index} rangeHeader [{0}]")
@@ -52,23 +52,23 @@ public class TestDefaultServletPut extends TomcatBaseTest {
 
         // Valid partial PUT
         parameterSets.add(new Object[] {
-                "Content-Range: bytes 0-" + PATCH_LEN + "/" + START_LEN + CRLF, Boolean.TRUE, END_TEXT, Boolean.TRUE });
+                "Content-Range: bytes 0-" + (PATCH_LEN-1) + "/" + START_LEN + CRLF, Boolean.TRUE, END_TEXT, Boolean.TRUE });
         parameterSets.add(new Object[] {
-                "Content-Range: ByTeS 0-" + PATCH_LEN + "/" + START_LEN + CRLF, Boolean.TRUE, END_TEXT, Boolean.TRUE });
+                "Content-Range: ByTeS 0-" + (PATCH_LEN-1) + "/" + START_LEN + CRLF, Boolean.TRUE, END_TEXT, Boolean.TRUE });
         // Full PUT
         parameterSets.add(new Object[] {
                 "", null, PATCH_TEXT, Boolean.TRUE });
         // Invalid range
         parameterSets.add(new Object[] {
-                "Content-Range: apples 0-" + PATCH_LEN + "/" + START_LEN + CRLF, Boolean.FALSE, START_TEXT, Boolean.TRUE });
+                "Content-Range: apples 0-" + (PATCH_LEN-1) + "/" + START_LEN + CRLF, Boolean.FALSE, START_TEXT, Boolean.TRUE });
         parameterSets.add(new Object[] {
-                "Content-Range: bytes00-" + PATCH_LEN + "/" + START_LEN + CRLF, Boolean.FALSE, START_TEXT, Boolean.TRUE });
+                "Content-Range: bytes00-" + (PATCH_LEN-1) + "/" + START_LEN + CRLF, Boolean.FALSE, START_TEXT, Boolean.TRUE });
         parameterSets.add(new Object[] {
-                "Content-Range: bytes0-" + PATCH_LEN + "/" + START_LEN + CRLF, Boolean.FALSE, START_TEXT, Boolean.TRUE });
+                "Content-Range: bytes0-" + (PATCH_LEN-1) + "/" + START_LEN + CRLF, Boolean.FALSE, START_TEXT, Boolean.TRUE });
         parameterSets.add(new Object[] {
-                "Content-Range: bytes=0-" + PATCH_LEN + "/" + START_LEN + CRLF, Boolean.FALSE, START_TEXT, Boolean.TRUE });
+                "Content-Range: bytes=0-" + (PATCH_LEN-1) + "/" + START_LEN + CRLF, Boolean.FALSE, START_TEXT, Boolean.TRUE });
         parameterSets.add(new Object[] {
-                "Content-Range: bytes@0-" + PATCH_LEN + "/" + START_LEN + CRLF, Boolean.FALSE, START_TEXT, Boolean.TRUE });
+                "Content-Range: bytes@0-" + (PATCH_LEN-1) + "/" + START_LEN + CRLF, Boolean.FALSE, START_TEXT, Boolean.TRUE });
         parameterSets.add(new Object[] {
                 "Content-Range: bytes 9-7/" + START_LEN + CRLF, Boolean.FALSE, START_TEXT, Boolean.TRUE });
         parameterSets.add(new Object[] {
@@ -82,16 +82,17 @@ public class TestDefaultServletPut extends TomcatBaseTest {
         parameterSets.add(new Object[] {
                 "Content-Range: bytes 0-5/0x5" + CRLF, Boolean.FALSE, START_TEXT, Boolean.TRUE });
         parameterSets.add(new Object[] {
-                "Content-Range: bytes 0-" + PATCH_LEN + "/" + PATCH_LEN + CRLF, Boolean.FALSE, START_TEXT, Boolean.TRUE });
+                "Content-Range: bytes 0-" + (PATCH_LEN) + "/" + PATCH_LEN + CRLF, Boolean.FALSE, START_TEXT, Boolean.TRUE });
         // Valid partial PUT but partial PUT is disabled
         parameterSets.add(new Object[] {
-                "Content-Range: bytes 0-" + PATCH_LEN + "/" + START_LEN + CRLF, Boolean.TRUE, START_TEXT, Boolean.FALSE });
+                "Content-Range: bytes 0-" + (PATCH_LEN-1) + "/" + START_LEN + CRLF, Boolean.TRUE, START_TEXT, Boolean.FALSE });
         // Errors due to incorrect length
         parameterSets.add(new Object[] {
                 "Content-Range: bytes 0-1/" + PATCH_LEN + CRLF, Boolean.FALSE, START_TEXT, Boolean.TRUE });
-        parameterSets.add(new Object[] {
-                "Content-Range: bytes 0-19/20" + CRLF, Boolean.FALSE, START_TEXT, Boolean.TRUE });
-
+        parameterSets.add(new Object[] { "Content-Range: bytes 0-" + PATCH_LEN + "/20" + CRLF, Boolean.FALSE,
+                START_TEXT, Boolean.TRUE });
+        parameterSets.add(new Object[] { "Content-Range: bytes 0-" + (PATCH_LEN - 2) + "/20" + CRLF, Boolean.FALSE,
+                START_TEXT, Boolean.TRUE });
         return parameterSets;
     }
 


### PR DESCRIPTION
**semantics fix:** range size = end_pos - start_pos + 1

## See error log
```bash
curl http://localhost:64438/one.txt -d c -H "Content-Range: bytes 0-0/1" -i
HTTP/1.1 405
Allow: OPTIONS, GET, HEAD, PUT, DELETE
Content-Type: text/html;charset=utf-8
Content-Language: zh-CN
Content-Length: 637
Date: Mon, 14 Apr 2025 08:44:27 GMT
```