### PR TITLE
Adding nonstandard catch, if, choose/when/otherwise

### DIFF
--- a/test/org/apache/jasper/compiler/TestGenerator.java
+++ b/test/org/apache/jasper/compiler/TestGenerator.java
@@ -1132,4 +1132,78 @@ public class TestGenerator extends TomcatBaseTest {
                 + "application value=null", body.toString());
         body.recycle();
     }
+
+    @Test
+    public void testNonstandardCatch() throws Exception {
+        getTomcatInstanceTestWebapp(true, true);
+
+        ByteChunk body = new ByteChunk();
+        // catch with no variable to store the exception, but no exception
+        getUrl("http://localhost:" + getPort() + "/test/jsp/generator/nonstandard/catch-01.jsp", body, null);
+        Assert.assertEquals("\n\n\nNo exception\n\n", body.toString());
+        body.recycle();
+
+        // catch with no variable to store the exception, and an exception
+        getUrl("http://localhost:" + getPort() + "/test/jsp/generator/nonstandard/catch-02.jsp", body, null);
+        Assert.assertEquals("\n\n\n\n", body.toString());
+        body.recycle();
+
+        // catch with variable, and an exception
+        getUrl("http://localhost:" + getPort() + "/test/jsp/generator/nonstandard/catch-03.jsp", body, null);
+        Assert.assertEquals("\n\n\n\njava.lang.RuntimeException: test", body.toString());
+        body.recycle();
+
+        // catch with variable, but no exception
+        getUrl("http://localhost:" + getPort() + "/test/jsp/generator/nonstandard/catch-04.jsp", body, null);
+        Assert.assertEquals("\n\n\nNo exception thrown\n\n", body.toString());
+        body.recycle();
+
+    }
+
+    @Test
+    public void testNonstandardIf() throws Exception {
+        getTomcatInstanceTestWebapp(true, true);
+
+        ByteChunk body = new ByteChunk();
+        // if with false (no body execution)
+        getUrl("http://localhost:" + getPort() + "/test/jsp/generator/nonstandard/if-01.jsp", body, null);
+        Assert.assertEquals("\n\n\n\n", body.toString());
+        body.recycle();
+
+        // if with true (body execution)
+        getUrl("http://localhost:" + getPort() + "/test/jsp/generator/nonstandard/if-02.jsp", body, null);
+        Assert.assertEquals("\n\n\n\n  true case\n\n", body.toString());
+        body.recycle();
+    }
+
+    @Test
+    public void testNonstandardChooseWhenOtherwise() throws Exception {
+        getTomcatInstanceTestWebapp(true, true);
+
+        ByteChunk body = new ByteChunk();
+        // branch 1
+        getUrl("http://localhost:" + getPort() + "/test/jsp/generator/nonstandard/choose-01.jsp?branch=1", body, null);
+        Assert.assertEquals("\n\n\n\n  1\n  \n  \n  \n\n", body.toString());
+        body.recycle();
+
+        // branch 2
+        getUrl("http://localhost:" + getPort() + "/test/jsp/generator/nonstandard/choose-01.jsp?branch=2", body, null);
+        Assert.assertEquals("\n\n\n\n  \n  2\n  \n  \n\n", body.toString());
+        body.recycle();
+
+        // branch 3
+        getUrl("http://localhost:" + getPort() + "/test/jsp/generator/nonstandard/choose-01.jsp?branch=3", body, null);
+        Assert.assertEquals("\n\n\n\n  \n  \n  3\n  \n\n", body.toString());
+        body.recycle();
+
+        // branch none (== otherwise)
+        getUrl("http://localhost:" + getPort() + "/test/jsp/generator/nonstandard/choose-01.jsp?branch=", body, null);
+        Assert.assertEquals("\n\n\n\n  \n  \n  \n  Otherwise\n\n", body.toString());
+        body.recycle();
+
+        // branch none (no otherwise)
+        getUrl("http://localhost:" + getPort() + "/test/jsp/generator/nonstandard/choose-02.jsp?branch=", body, null);
+        Assert.assertEquals("\n\n\n\n  \n  \n  \n\n", body.toString());
+        body.recycle();
+    }
 }

--- a/test/webapp/WEB-INF/web.xml
+++ b/test/webapp/WEB-INF/web.xml
@@ -65,7 +65,7 @@
       </init-param>
       <init-param>
         <param-name>useNonstandardTagOptimizations</param-name>
-        <param-value>c:set,c:remove</param-value>
+        <param-value>c:set,c:remove,c:catch,c:if,c:choose,c:when,c:otherwise</param-value>
       </init-param>
       <!-- Required by /jsp/tagFileInJar.jsp / TestJspCompilationContext  -->
       <init-param>

--- a/test/webapp/jsp/generator/nonstandard/catch-01.jsp
+++ b/test/webapp/jsp/generator/nonstandard/catch-01.jsp
@@ -1,0 +1,21 @@
+<%--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%@ taglib uri = "http://java.sun.com/jsp/jstl/core" prefix = "c" %>
+<c:catch>
+No exception
+</c:catch>
+${pageScope.e}

--- a/test/webapp/jsp/generator/nonstandard/catch-02.jsp
+++ b/test/webapp/jsp/generator/nonstandard/catch-02.jsp
@@ -1,0 +1,22 @@
+<%--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%@ taglib uri = "http://java.sun.com/jsp/jstl/core" prefix = "c" %>
+<c:catch>
+<% if (System.currentTimeMillis() > 0) throw new RuntimeException("test"); %>
+No exception
+</c:catch>
+${pageScope.e}

--- a/test/webapp/jsp/generator/nonstandard/catch-03.jsp
+++ b/test/webapp/jsp/generator/nonstandard/catch-03.jsp
@@ -1,0 +1,22 @@
+<%--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%@ taglib uri = "http://java.sun.com/jsp/jstl/core" prefix = "c" %>
+<c:catch var="e">
+<% if (System.currentTimeMillis() > 0) throw new RuntimeException("test"); %>
+Should've seen an exception
+</c:catch>
+${pageScope.e}

--- a/test/webapp/jsp/generator/nonstandard/catch-04.jsp
+++ b/test/webapp/jsp/generator/nonstandard/catch-04.jsp
@@ -1,0 +1,21 @@
+<%--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%@ taglib uri = "http://java.sun.com/jsp/jstl/core" prefix = "c" %>
+<c:catch var="e">
+No exception thrown
+</c:catch>
+${pageScope.e}

--- a/test/webapp/jsp/generator/nonstandard/choose-01.jsp
+++ b/test/webapp/jsp/generator/nonstandard/choose-01.jsp
@@ -1,0 +1,24 @@
+<%--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%@ taglib uri = "http://java.sun.com/jsp/jstl/core" prefix = "c" %>
+<c:set var="branchChoice" value="${param.branch}"/>
+<c:choose>
+  <c:when test="${branchChoice == 1}">1</c:when>
+  <c:when test="${branchChoice == 2}">2</c:when>
+  <c:when test="${branchChoice == 3}">3</c:when>
+  <c:otherwise>Otherwise</c:otherwise>
+</c:choose>

--- a/test/webapp/jsp/generator/nonstandard/choose-02.jsp
+++ b/test/webapp/jsp/generator/nonstandard/choose-02.jsp
@@ -1,0 +1,23 @@
+<%--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%@ taglib uri = "http://java.sun.com/jsp/jstl/core" prefix = "c" %>
+<c:set var="branchChoice" value="${param.branch}"/>
+<c:choose>
+  <c:when test="${branchChoice == 1}">1</c:when>
+  <c:when test="${branchChoice == 2}">2</c:when>
+  <c:when test="${branchChoice == 3}">3</c:when>
+</c:choose>

--- a/test/webapp/jsp/generator/nonstandard/if-01.jsp
+++ b/test/webapp/jsp/generator/nonstandard/if-01.jsp
@@ -1,0 +1,21 @@
+<%--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%@ taglib uri = "http://java.sun.com/jsp/jstl/core" prefix = "c" %>
+<c:set var="booleanExpression" value="${1 > 2}" scope="page"/>
+<c:if test="${booleanExpression}">
+  true case
+</c:if>

--- a/test/webapp/jsp/generator/nonstandard/if-02.jsp
+++ b/test/webapp/jsp/generator/nonstandard/if-02.jsp
@@ -1,0 +1,21 @@
+<%--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%@ taglib uri = "http://java.sun.com/jsp/jstl/core" prefix = "c" %>
+<c:set var="booleanExpression" value="${2 > 1}" scope="page"/>
+<c:if test="${booleanExpression}">
+  true case
+</c:if>


### PR DESCRIPTION
Adds non-standard implementations of `c:catch`, `c:if`, `c:choose`, `c:when`, and `c:otherwise`.  Note that incorrectly structured choose/when/otherwise combinations are blocked by the tag lib validation, so an entire class of edge cases does not need to be supported or tested.

Along the way I cleaned up the code into implementations of a new interface `NonstandardCustomTagGenerator`.  Application owners cannot yet create their own overrides (exposing fields is problematic) but this organizes the now-seven tag implementations and is a step in the right direction to open it up.

When activated, these changes eliminate the vast majority of tags on my application's JSPs, with impressive performance results.  I have no immediate plans to support other tags.

Sample code below is generated by the unit tests.

`c:catch`
```
  private void _jspx_meth_c_005fcatch_005f0(jakarta.servlet.jsp.PageContext pageContext)
          throws java.lang.Throwable {
    jakarta.servlet.jsp.JspWriter out = pageContext.getOut();
    int[] _jspx_push_body_count_c_005fcatch_005f0 = new int[] { 0 };
    boolean caught = false;
    try {
      out.write('\n');
 if (System.currentTimeMillis() > 0) throw new RuntimeException("test"); 
      out.write("\n");
      out.write("No exception\n");
    } catch (java.lang.Throwable _jspx_exception) { 
      caught = true;
      while (_jspx_push_body_count_c_005fcatch_005f0[0]-- > 0)
        out = pageContext.popBody();
    } finally {
    }
  }
```
`c:if`
```
  private void _jspx_meth_c_005fif_005f0(jakarta.servlet.jsp.PageContext _jspx_page_context)
          throws java.lang.Throwable {
    jakarta.servlet.jsp.JspWriter out = _jspx_page_context.getOut();
    // /jsp/generator/nonstandard/if-02.jsp(19,0) name = test type = boolean reqTime = true required = true fragment = false deferredValue = false expectedTypeName = null deferredMethod = false methodSignature = null
    boolean condition = ((java.lang.Boolean) org.apache.jasper.runtime.PageContextImpl.proprietaryEvaluate("${booleanExpression}", boolean.class, (jakarta.servlet.jsp.PageContext)_jspx_page_context, null)).booleanValue();
    if (condition) {
      out.write("\n");
      out.write("  true case\n");
    }
  }
```

`c:choose`, `c:when`, `c:otherwise`
```

  private void _jspx_meth_c_005fchoose_005f0(jakarta.servlet.jsp.PageContext _jspx_page_context)
          throws java.lang.Throwable {
    jakarta.servlet.jsp.JspWriter out = _jspx_page_context.getOut();
    boolean completed = false;
    out.write('\n');
    out.write(' ');
    out.write(' ');
    completed = (completed || _jspx_meth_c_005fwhen_005f0(_jspx_page_context));
    out.write('\n');
    out.write(' ');
    out.write(' ');
    completed = (completed || _jspx_meth_c_005fwhen_005f1(_jspx_page_context));
    out.write('\n');
    out.write(' ');
    out.write(' ');
    completed = (completed || _jspx_meth_c_005fwhen_005f2(_jspx_page_context));
    out.write('\n');
    out.write(' ');
    out.write(' ');
    if (!completed)
      _jspx_meth_c_005fotherwise_005f0(_jspx_page_context);
    out.write('\n');
  }

  private boolean _jspx_meth_c_005fwhen_005f0(jakarta.servlet.jsp.PageContext _jspx_page_context)
          throws java.lang.Throwable {
    jakarta.servlet.jsp.JspWriter out = _jspx_page_context.getOut();
    // /jsp/generator/nonstandard/choose-01.jsp(20,2) name = test type = boolean reqTime = true required = true fragment = false deferredValue = false expectedTypeName = null deferredMethod = false methodSignature = null
    boolean condition = ((java.lang.Boolean) org.apache.jasper.runtime.PageContextImpl.proprietaryEvaluate("${branchChoice == 1}", boolean.class, (jakarta.servlet.jsp.PageContext)_jspx_page_context, null)).booleanValue();
    if (condition) {
      out.write('1');
      return true;
    }
    return false;
  }

  private boolean _jspx_meth_c_005fotherwise_005f0(jakarta.servlet.jsp.PageContext _jspx_page_context)
          throws java.lang.Throwable {
    jakarta.servlet.jsp.JspWriter out = _jspx_page_context.getOut();
    out.write("Otherwise");
    return true;
  }
```