### PR TITLE
fix Resolving XML external entity in user-controlled data `Digester.java`

### DIFF
--- a/java/org/apache/tomcat/util/digester/Digester.java
+++ b/java/org/apache/tomcat/util/digester/Digester.java
@@ -1507,7 +1507,11 @@ public class Digester extends DefaultHandler2 {
         configure();
         InputSource input = new InputSource(new FileInputStream(file));
         input.setSystemId("file://" + file.getAbsolutePath());
-        getXMLReader().parse(input);
+        XMLReader reader = getXMLReader();
+        reader.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        reader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        reader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        reader.parse(input);
         return root;
     }
 
@@ -1523,7 +1527,11 @@ public class Digester extends DefaultHandler2 {
      */
     public Object parse(InputSource input) throws IOException, SAXException {
         configure();
-        getXMLReader().parse(input);
+        XMLReader reader = getXMLReader();
+        reader.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        reader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        reader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        reader.parse(input);
         return root;
     }
 
@@ -1540,7 +1548,11 @@ public class Digester extends DefaultHandler2 {
     public Object parse(InputStream input) throws IOException, SAXException {
         configure();
         InputSource is = new InputSource(input);
-        getXMLReader().parse(is);
+        XMLReader reader = getXMLReader();
+        reader.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        reader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        reader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        reader.parse(is);
         return root;
     }
 


### PR DESCRIPTION
https://github.com/apache/tomcat/blob/b037fcfec53dda465e280d221fd5b85e50078794/java/org/apache/tomcat/util/digester/Digester.java#L1526-L1526

fix the issue external entity resolution must be explicitly disabled in the `XMLReader` used by the `Digester` class. This can be achieved by setting the appropriate features on the `XMLReader` instance. Specifically:
1. Disable the `http://xml.org/sax/features/external-general-entities` and `http://xml.org/sax/features/external-parameter-entities` features.
2. Disallow the use of `DOCTYPE` declarations by setting the `http://apache.org/xml/features/disallow-doctype-decl` feature to `true`.

The changes should be made in the `configure()` method or wherever the `XMLReader` is initialized. This ensures that all parsing operations in the `Digester` class are secure.


Parsing untrusted XML files with a weakly configured XML parser may lead to an XML External Entity (XXE) attack. This type of attack uses external entity references to access arbitrary files on a system, carry out denial of service, or server side request forgery. Even when the result of parsing is not returned to the user, out-of-band data retrieval techniques may allow attackers to steal sensitive data. Denial of services can also be carried out in this situation.

There are many XML parsers for Java, and most of them are vulnerable to XXE because their default settings enable parsing of external entities. This query currently identifies vulnerable XML parsing from the following parsers: `javax.xml.parsers.DocumentBuilder`, `javax.xml.stream.XMLStreamReader`, `org.jdom.input.SAXBuilder`/`org.jdom2.input.SAXBuilder`, `javax.xml.parsers.SAXParser`,`org.dom4j.io.SAXReader`, `org.xml.sax.XMLReader`, `javax.xml.transform.sax.SAXSource`, `javax.xml.transform.TransformerFactory`, `javax.xml.transform.sax.SAXTransformerFactory`, `javax.xml.validation.SchemaFactory`, `javax.xml.bind.Unmarshaller` and `javax.xml.xpath.XPathExpression`.

The following calls `parse` on a `DocumentBuilder` that is not safely configured on untrusted data, and is therefore inherently unsafe.
```java
public void parse(Socket sock) throws Exception {
  DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
  DocumentBuilder builder = factory.newDocumentBuilder();
  builder.parse(sock.getInputStream()); // BAD: DTD parsing is enabled
}
```
the `DocumentBuilder` is created with DTD disabled, securing it against XXE attack.
```java
public void disableDTDParse(Socket sock) throws Exception {
  DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
  factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
  DocumentBuilder builder = factory.newDocumentBuilder();
  builder.parse(sock.getInputStream()); // GOOD: DTD parsing is disabled
}
```
## References
[XML External Entity (XXE) Processing](https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Processing)
[XXE Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#java)
Paper by Timothy Morgen: [XML Schema, DTD, and Entity Attacks](https://research.nccgroup.com/2014/05/19/xml-schema-dtd-and-entity-attacks-a-compendium-of-known-techniques/)
Out-of-band data retrieval: Timur Yunusov & Alexey Osipov, Black hat EU 2013: [XML Out-Of-Band Data Retrieval](https://www.slideshare.net/qqlan/bh-ready-v4)
[Billion Laughs.](https://en.wikipedia.org/wiki/Billion_laughs)
[Processing Limit Definitions.](https://docs.oracle.com/javase/tutorial/jaxp/limits/limits.html)
[CWE-611](https://cwe.mitre.org/data/definitions/611.html)
[CWE-776](https://cwe.mitre.org/data/definitions/776.html)
[CWE-827](https://cwe.mitre.org/data/definitions/827.html)