### PR TITLE
Include video/mp2t mime type by default

### DIFF
--- a/conf/web.xml
+++ b/conf/web.xml
@@ -3949,6 +3949,10 @@
         <mime-type>application/x-msterminal</mime-type>
     </mime-mapping>
     <mime-mapping>
+        <extension>ts</extension>
+        <mime-type>video/mp2t</mime-type>
+    </mime-mapping>
+    <mime-mapping>
         <extension>tsd</extension>
         <mime-type>application/timestamped-data</mime-type>
     </mime-mapping>


### PR DESCRIPTION
Fixes https://bz.apache.org/bugzilla/show_bug.cgi?id=69664.