### PR TITLE
[fix] ensure that when acceptor is stopped it doesn't log an error for nothing

### DIFF
--- a/java/org/apache/tomcat/util/net/NioEndpoint.java
+++ b/java/org/apache/tomcat/util/net/NioEndpoint.java
@@ -235,9 +235,9 @@ public class NioEndpoint extends AbstractNetworkChannelEndpoint<NioChannel,Socke
                 }
             }
         } else {
-            serverSock = ServerSocketChannel.open();
-            socketProperties.setProperties(serverSock.socket());
             InetSocketAddress addr = new InetSocketAddress(getAddress(), getPortWithOffset());
+            serverSock = ServerSocketChannel.open(addr.getAddress().getAddress().length == 4 ? StandardProtocolFamily.INET : StandardProtocolFamily.INET6);
+            socketProperties.setProperties(serverSock.socket());
             serverSock.bind(addr, getAcceptCount());
         }
         serverSock.configureBlocking(true); //mimic APR behavior


### PR DESCRIPTION
Proposal to have a clean shutdown (follow up of the mail on the list).

This only handles the case bindOnInit=false.