### PR TITLE
[fix] service.bat JvmOptions9 - FollowUp on Improve CVE-2024-56337 protection

### DIFF
--- a/bin/catalina.bat
+++ b/bin/catalina.bat
@@ -243,7 +243,7 @@ if not "%LOGGING_MANAGER%" == "" goto noJuliManager
 set LOGGING_MANAGER=-Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager
 :noJuliManager
 
-rem Configure JAVA 9 specific start-up parameters
+rem Configure JAVA 9 specific start-up parameters - KEEP in line with service.bat
 set "JDK_JAVA_OPTIONS=%JDK_JAVA_OPTIONS% --add-opens=java.base/java.lang=ALL-UNNAMED"
 set "JDK_JAVA_OPTIONS=%JDK_JAVA_OPTIONS% --add-opens=java.base/java.lang.invoke=ALL-UNNAMED"
 set "JDK_JAVA_OPTIONS=%JDK_JAVA_OPTIONS% --add-opens=java.base/java.lang.reflect=ALL-UNNAMED"

--- a/bin/catalina.bat
+++ b/bin/catalina.bat
@@ -243,7 +243,7 @@ if not "%LOGGING_MANAGER%" == "" goto noJuliManager
 set LOGGING_MANAGER=-Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager
 :noJuliManager
 
-rem Configure JAVA 9 specific start-up parameters - KEEP in line with service.bat
+rem Configure JAVA 9 specific start-up parameters - ensure to keep it in line with service.bat
 set "JDK_JAVA_OPTIONS=%JDK_JAVA_OPTIONS% --add-opens=java.base/java.lang=ALL-UNNAMED"
 set "JDK_JAVA_OPTIONS=%JDK_JAVA_OPTIONS% --add-opens=java.base/java.lang.invoke=ALL-UNNAMED"
 set "JDK_JAVA_OPTIONS=%JDK_JAVA_OPTIONS% --add-opens=java.base/java.lang.reflect=ALL-UNNAMED"

--- a/bin/service.bat
+++ b/bin/service.bat
@@ -223,12 +223,12 @@ if exist "%CATALINA_HOME%\bin\%DEFAULT_SERVICE_NAME%.exe" (
 
 rem Configure JAVA 9 specific start-up parameters - KEEP in line with catalina.bat
 set                "JVM9_OPTIONS=--add-opens=java.base/java.lang=ALL-UNNAMED"
-set "JVM9_OPTIONS=%JVM9_OPTIONS%#--add-opens=java.base/java.lang.invoke=ALL-UNNAMED"
-set "JVM9_OPTIONS=%JVM9_OPTIONS%#--add-opens=java.base/java.lang.reflect=ALL-UNNAMED"
-set "JVM9_OPTIONS=%JVM9_OPTIONS%#--add-opens=java.base/java.io=ALL-UNNAMED"
-set "JVM9_OPTIONS=%JVM9_OPTIONS%#--add-opens=java.base/java.util=ALL-UNNAMED"
-set "JVM9_OPTIONS=%JVM9_OPTIONS%#--add-opens=java.base/java.util.concurrent=ALL-UNNAMED"
-set "JVM9_OPTIONS=%JVM9_OPTIONS%#--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED"
+set "JVM9_OPTIONS=%JVM9_OPTIONS%;--add-opens=java.base/java.lang.invoke=ALL-UNNAMED"
+set "JVM9_OPTIONS=%JVM9_OPTIONS%;--add-opens=java.base/java.lang.reflect=ALL-UNNAMED"
+set "JVM9_OPTIONS=%JVM9_OPTIONS%;--add-opens=java.base/java.io=ALL-UNNAMED"
+set "JVM9_OPTIONS=%JVM9_OPTIONS%;--add-opens=java.base/java.util=ALL-UNNAMED"
+set "JVM9_OPTIONS=%JVM9_OPTIONS%;--add-opens=java.base/java.util.concurrent=ALL-UNNAMED"
+set "JVM9_OPTIONS=%JVM9_OPTIONS%;--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED"
 
 "%EXECUTABLE%" //IS//%SERVICE_NAME% ^
     --Description "Apache Tomcat @VERSION@ Server - https://tomcat.apache.org/" ^

--- a/bin/service.bat
+++ b/bin/service.bat
@@ -221,6 +221,15 @@ if exist "%CATALINA_HOME%\bin\%DEFAULT_SERVICE_NAME%.exe" (
     )
 )
 
+rem Configure JAVA 9 specific start-up parameters - KEEP in line with catalina.bat
+set                "JVM9_OPTIONS=--add-opens=java.base/java.lang=ALL-UNNAMED"
+set "JVM9_OPTIONS=%JVM9_OPTIONS%#--add-opens=java.base/java.lang.invoke=ALL-UNNAMED"
+set "JVM9_OPTIONS=%JVM9_OPTIONS%#--add-opens=java.base/java.lang.reflect=ALL-UNNAMED"
+set "JVM9_OPTIONS=%JVM9_OPTIONS%#--add-opens=java.base/java.io=ALL-UNNAMED"
+set "JVM9_OPTIONS=%JVM9_OPTIONS%#--add-opens=java.base/java.util=ALL-UNNAMED"
+set "JVM9_OPTIONS=%JVM9_OPTIONS%#--add-opens=java.base/java.util.concurrent=ALL-UNNAMED"
+set "JVM9_OPTIONS=%JVM9_OPTIONS%#--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED"
+
 "%EXECUTABLE%" //IS//%SERVICE_NAME% ^
     --Description "Apache Tomcat @VERSION@ Server - https://tomcat.apache.org/" ^
     --DisplayName "Apache Tomcat @VERSION_MAJOR_MINOR@ %SERVICE_NAME%" ^
@@ -239,7 +248,7 @@ if exist "%CATALINA_HOME%\bin\%DEFAULT_SERVICE_NAME%.exe" (
     --StartParams start ^
     --StopParams stop ^
     --JvmOptions "-Dcatalina.home=%CATALINA_HOME%;-Dcatalina.base=%CATALINA_BASE%;-D%ENDORSED_PROP%=%CATALINA_HOME%\endorsed;-Djava.io.tmpdir=%CATALINA_BASE%\temp;-Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager;-Djava.util.logging.config.file=%CATALINA_BASE%\conf\logging.properties;-Dsun.io.useCanonCaches=false;%JvmArgs%" ^
-    --JvmOptions9 "--add-opens=java.base/java.lang=ALL-UNNAMED#--add-opens=java.base/java.io=ALL-UNNAMED#--add-opens=java.base/java.util=ALL-UNNAMED#--add-opens=java.base/java.util.concurrent=ALL-UNNAMED#--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED" ^
+    --JvmOptions9 "%JVM9_OPTIONS%" ^
     --Startup "%SERVICE_STARTUP_MODE%" ^
     --JvmMs "%JvmMs%" ^
     --JvmMx "%JvmMx%"

--- a/bin/service.bat
+++ b/bin/service.bat
@@ -221,7 +221,7 @@ if exist "%CATALINA_HOME%\bin\%DEFAULT_SERVICE_NAME%.exe" (
     )
 )
 
-rem Configure JAVA 9 specific start-up parameters - KEEP in line with catalina.bat
+rem Configure JAVA 9 specific start-up parameters - ensure to keep it in line with catalina.bat
 set                "JVM9_OPTIONS=--add-opens=java.base/java.lang=ALL-UNNAMED"
 set "JVM9_OPTIONS=%JVM9_OPTIONS%;--add-opens=java.base/java.lang.invoke=ALL-UNNAMED"
 set "JVM9_OPTIONS=%JVM9_OPTIONS%;--add-opens=java.base/java.lang.reflect=ALL-UNNAMED"


### PR DESCRIPTION
**Reference:** Commit 0c75cd1e3ac85944fb8ecbcf88cc38e9fa1fe4d5 by @markt-asf 

**Issue:** The commit referred did miss to keep `service.bat` JvmOptions9 in line with the change of catalina.bat made by that commit.

**Changes:**
- service.bat:
  - fix JvmOptions9 to followup according changes in catalina.bat
  - improve legibility of JvmOptions9 parameter line by introducing intermediate set variable JVM9_OPTIONS
  - add comment to JVM9_OPTIONS settings with hint to keep in line with catalina.bat

- catalina.bat:
  - add comment to JDK_JAVA_OPTIONS --add-opens settings with hint to keep in line with service.bat

**Test result: (updated after commit 3767fd5bdb1e09c19d42b499ff71b1c7e3e35436)**
![image](https://github.com/user-attachments/assets/5fa3f166-4f7b-4a91-aa53-15ff250ea4e0)


