### PR TITLE
Acceptor & Poller Thread should print error logs when it crashes now

### DIFF
--- a/java/org/apache/tomcat/util/net/Acceptor.java
+++ b/java/org/apache/tomcat/util/net/Acceptor.java
@@ -152,9 +152,9 @@ public class Acceptor<U> implements Runnable {
                         endpoint.destroySocket(socket);
                     }
                 } catch (Throwable t) {
-                    ExceptionUtils.handleThrowable(t);
                     String msg = sm.getString("endpoint.accept.fail");
                     log.error(msg, t);
+                    ExceptionUtils.handleThrowable(t);
                 }
             }
         } finally {

--- a/java/org/apache/tomcat/util/net/NioEndpoint.java
+++ b/java/org/apache/tomcat/util/net/NioEndpoint.java
@@ -779,8 +779,8 @@ public class NioEndpoint extends AbstractNetworkChannelEndpoint<NioChannel,Socke
                         hasEvents = (hasEvents | events());
                     }
                 } catch (Throwable x) {
-                    ExceptionUtils.handleThrowable(x);
                     log.error(sm.getString("endpoint.nio.selectorLoopError"), x);
+                    ExceptionUtils.handleThrowable(x);
                     continue;
                 }
 


### PR DESCRIPTION
As the title says, this is to facilitate troubleshooting. When the core thread crashes, we need to print the error log.