### PR TITLE
Fix issue on multiple path parameters processing in RequestUtil

### DIFF
--- a/java/org/apache/catalina/util/RequestUtil.java
+++ b/java/org/apache/catalina/util/RequestUtil.java
@@ -85,13 +85,16 @@ public final class RequestUtil {
             } else {
                 pos = followingSlash;
             }
-            if (request != null && nextSemiColon + 1 <pos) {
-                String pathVariable = input.substring(nextSemiColon + 1, pos);
-                int equals = pathVariable.indexOf('=');
-                if (equals > -1 && equals + 1 < pathVariable.length()) {
-                    String name = pathVariable.substring(0, equals);
-                    String value = pathVariable.substring(equals + 1);
-                    request.addPathParameter(name, value);
+            if (request != null && nextSemiColon + 1 < pos) {
+                String pathVariableString = input.substring(nextSemiColon + 1, pos);
+                String[] pathVariants = pathVariableString.split(";");
+                for (String pathVariable : pathVariants) {
+                    int equals = pathVariable.indexOf('=');
+                    if (equals > -1 && equals + 1 < pathVariable.length()) {
+                        String name = pathVariable.substring(0, equals);
+                        String value = pathVariable.substring(equals + 1);
+                        request.addPathParameter(name, value);
+                    }
                 }
             }
         }

--- a/test/org/apache/catalina/core/TestApplicationContextStripPathParams.java
+++ b/test/org/apache/catalina/core/TestApplicationContextStripPathParams.java
@@ -62,6 +62,8 @@ public class TestApplicationContextStripPathParams extends TomcatBaseTest {
             { ";/foo;=/bar", "/foo/bar", Boolean.FALSE },
             { ";/foo;a=/bar", "/foo/bar", Boolean.FALSE },
             { ";/foo;=1/bar", "/foo/bar", Boolean.FALSE },
+            { "/foo;b=1;a=1/bar", "/foo/bar", Boolean.TRUE },
+            { ";/foo;b=1;a=1/bar", "/foo/bar", Boolean.TRUE },
         });
     }
 


### PR DESCRIPTION
RequestUtil#stripPathParams: enable support for multiple k=v pairs