### PR TITLE
FIX: add inline comment support in text rewrite map file

### DIFF
--- a/java/org/apache/catalina/valves/rewrite/RandomizedTextRewriteMap.java
+++ b/java/org/apache/catalina/valves/rewrite/RandomizedTextRewriteMap.java
@@ -50,8 +50,11 @@ public class RandomizedTextRewriteMap implements RewriteMap {
                 BufferedReader reader = new BufferedReader(new InputStreamReader(txtResource.getInputStream()))) {
             while ((line = reader.readLine()) != null) {
                 if (line.startsWith("#") || line.isEmpty()) {
-                    // Ignore comment or empty lines
+                    // Ignore comment line or empty lines
                     continue;
+                } else if (line.indexOf('#') > 0) {
+                    // comment characters after '#'
+                    line = line.substring(0, line.indexOf('#')).trim();
                 }
                 String[] keyValuePair = line.split(" ", 2);
                 if (keyValuePair.length > 1) {

--- a/test/conf/TesterRewriteMapB.txt
+++ b/test/conf/TesterRewriteMapB.txt
@@ -20,5 +20,5 @@
 
 a aa
 
-aa aaaa
-b bb
+aa aaaa #abc
+b bb #abc


### PR DESCRIPTION
enable inline comment support for plain text rewrite map.

Per doc [rewritemap.html#txt](https://httpd.apache.org/docs/2.4/rewrite/rewritemap.html#txt) :
```
# Comment line
MatchingKey SubstValue
MatchingKey SubstValue # comment
```