### PR TITLE
Optimize Request#getCharsetHolder to avoid repeated parsing when charset is null

### DIFF
--- a/java/org/apache/coyote/Request.java
+++ b/java/org/apache/coyote/Request.java
@@ -139,7 +139,7 @@ public final class Request {
      */
     private long contentLength = -1;
     private MessageBytes contentTypeMB = null;
-    private CharsetHolder charsetHolder = CharsetHolder.EMPTY;
+    private CharsetHolder charsetHolder = null;
 
     /**
      * Is there an expectation ?
@@ -389,7 +389,7 @@ public final class Request {
     // -------------------- encoding/type --------------------
 
     public CharsetHolder getCharsetHolder() {
-        if (charsetHolder.getName() == null) {
+        if (charsetHolder == null) {
             charsetHolder = CharsetHolder.getInstance(getCharsetFromContentType(getContentType()));
         }
         return charsetHolder;
@@ -397,6 +397,10 @@ public final class Request {
 
 
     public void setCharsetHolder(CharsetHolder charsetHolder) {
+        if (charsetHolder == null || charsetHolder.getName() == null) {
+            this.charsetHolder = null;
+            return;
+        }
         this.charsetHolder = charsetHolder;
     }
 
@@ -724,7 +728,7 @@ public final class Request {
 
         contentLength = -1;
         contentTypeMB = null;
-        charsetHolder = CharsetHolder.EMPTY;
+        charsetHolder = null;
         expectation = false;
         headers.recycle();
         trailerFields.recycle();


### PR DESCRIPTION
In org.apache.coyote.Request#getCharsetHolder, when charsetHolder.getName() returns null, parsing is performed repeatedly, resulting in unnecessary performance overhead. The following optimizations are proposed:

1. Initialize the org.apache.coyote.Request#charsetHolder member variable to null instead of CharsetHolder.EMPTY, so that null clearly indicates the unparsed state.
2. In getCharsetHolder, check if charsetHolder is null to determine whether parsing is needed, instead of checking charsetHolder.getName() == null.
3. Once charsetHolder is assigned (regardless of whether name is null), consider it parsed and avoid any further parsing.

This avoids repeated parsing when charsetHolder.getName() is null, improving performance. Please ensure thread safety and that assignment semantics remain consistent during implementation.
