### PR TITLE
 recycle RequestInfo when Request is reused in pool

### DIFF
--- a/java/org/apache/coyote/RequestInfo.java
+++ b/java/org/apache/coyote/RequestInfo.java
@@ -261,4 +261,23 @@ public class RequestInfo {
     public void setLastRequestProcessingTime(long lastRequestProcessingTime) {
         this.lastRequestProcessingTime = lastRequestProcessingTime;
     }
+
+    public void recycle() {
+        this.bytesSent = 0;
+        this.bytesReceived = 0;
+
+        // Total time = divide by requestCount to get average.
+        this.processingTime = 0;
+        // The longest response time for a request
+        this.maxTime = 0;
+        // URI of the request that took maxTime
+        this.maxRequestUri = null;
+
+        this.requestCount = 0;
+        // number of response codes >= 400
+        this.errorCount = 0;
+
+        // the time of the last request
+        this.lastRequestProcessingTime = 0;
+    }
 }

--- a/java/org/apache/coyote/http2/Http2Protocol.java
+++ b/java/org/apache/coyote/http2/Http2Protocol.java
@@ -532,6 +532,8 @@ public class Http2Protocol implements UpgradeProtocol {
             requestAndResponse = new Request();
             Response response = new Response();
             requestAndResponse.setResponse(response);
+        } else {
+            requestAndResponse.getRequestProcessor().recycle();
         }
         return requestAndResponse;
     }


### PR DESCRIPTION
The request statistics will be wrong when Request object is reused in the object pool.