### PR TITLE
Discard unsupported part header field while handling multipart fileupload request

### DIFF
--- a/java/org/apache/tomcat/util/http/fileupload/FileUploadBase.java
+++ b/java/org/apache/tomcat/util/http/fileupload/FileUploadBase.java
@@ -70,6 +70,13 @@ public abstract class FileUploadBase {
     public static final String CONTENT_DISPOSITION = "Content-disposition";
 
     /**
+     * HTTP content transfer encoding header name.
+     * @deprecated per rfc7578 Section 4.7
+     */
+    @Deprecated
+    public static final String CONTENT_TRANSFER_ENCODING="Content-Transfer-Encoding";
+
+    /**
      * HTTP content length header name.
      */
     public static final String CONTENT_LENGTH = "Content-length";
@@ -418,9 +425,11 @@ public abstract class FileUploadBase {
     }
 
     /**
-     * Reads the next header line.
+     * Reads the next header line. Per <a href="https://www.ietf.org/rfc/rfc7578.txt">RFC 7578</a>, only listed part
+     * header fields are supported, others MUST be ignored.
+     *
      * @param headers String with all headers.
-     * @param header Map where to store the current header.
+     * @param header  Map where to store the current header.
      */
     private void parseHeaderLine(final FileItemHeadersImpl headers, final String header) {
         final int colonOffset = header.indexOf(':');
@@ -430,7 +439,13 @@ public abstract class FileUploadBase {
         }
         final String headerName = header.substring(0, colonOffset).trim();
         final String headerValue = header.substring(colonOffset + 1).trim();
-        headers.addHeader(headerName, headerValue);
+        // see rfc7578 section 4.8
+        if (CONTENT_DISPOSITION.equalsIgnoreCase(headerName) || CONTENT_TYPE.equalsIgnoreCase(headerName) ||
+                CONTENT_TRANSFER_ENCODING.equalsIgnoreCase(headerName)) {
+            // Only listed part header fields are supported
+            // Other header fields MUST be ignored.
+            headers.addHeader(headerName, headerValue);
+        }
     }
 
     /**

--- a/test/jakarta/servlet/TestServletRequestParametersMultipartEncoded.java
+++ b/test/jakarta/servlet/TestServletRequestParametersMultipartEncoded.java
@@ -16,12 +16,16 @@
  */
 package jakarta.servlet;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.Part;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -49,7 +53,6 @@ public class TestServletRequestParametersMultipartEncoded extends ServletRequest
 
     @Parameter(0)
     public boolean chunked;
-
 
     @Test
     public void testBodyTooLarge() throws Exception {
@@ -128,5 +131,113 @@ public class TestServletRequestParametersMultipartEncoded extends ServletRequest
         client.processRequest();
 
         Assert.assertEquals(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE, client.getStatusCode());
+    }
+
+    @Test
+    public void testIgnoreUnsupportedPartField() throws Exception {
+
+        Tomcat tomcat = getTomcatInstance();
+
+        // No file system docBase required
+        StandardContext ctx = (StandardContext) getProgrammaticRootContext();
+        ctx.setAllowCasualMultipartParsing(true);
+
+        // Map the test Servlet
+        HttpServlet echoPartServlet = new EchoPartServlet();
+        Tomcat.addServlet(ctx, "echoPartServlet", echoPartServlet);
+        ctx.addServletMappingDecoded("/", "echoPartServlet");
+
+        tomcat.start();
+
+        TestParameterClient client = new TestParameterClient();
+        client.setPort(getPort());
+        if (chunked) {
+            client.setRequest(new String[] {
+                    "POST / HTTP/1.1" + CRLF +
+                    "Host: localhost:" + getPort() + CRLF +
+                    "Connection: close" + CRLF +
+                    "Transfer-Encoding: chunked" + CRLF +
+                    "Content-Type: multipart/form-data; boundary=AaBbCc" + CRLF +
+                    CRLF +
+                    "62" + CRLF +
+                    "--AaBbCc" + CRLF +
+                    "Content-Disposition: form-data; name=\"var1\"" + CRLF +
+                    "Content-ID: Invalid-Part-Header01" + CRLF +
+                    CRLF +
+                    "val1" + CRLF +
+                    CRLF +
+                    "62" + CRLF +
+                    "--AaBbCc" + CRLF +
+                    "Content-Disposition: form-data; name=\"var2\"" + CRLF +
+                    "X-SOURCEID: Invalid-Part-Header02" + CRLF +
+                    CRLF +
+                    "val2" + CRLF +
+                    CRLF +
+                    "62" + CRLF +
+                    "--AaBbCc" + CRLF +
+                    "Content-Disposition: form-data; name=\"var3\"" + CRLF +
+                    "X-SOURCEID: Invalid-Part-Header03" + CRLF +
+                    CRLF +
+                    "val3" + CRLF +
+                    CRLF +
+                    "0a" + CRLF +
+                    "--AaBbCc--" + CRLF +
+                    "0" + CRLF +
+                    CRLF});
+        } else {
+            String payload="--AaBbCc" + CRLF +
+                    "Content-Disposition: form-data; name=\"var1\"" + CRLF +
+                    "Content-ID: Invalid-Part-Header01" + CRLF +
+                    CRLF +
+                    "val1" + CRLF +
+                    "--AaBbCc" + CRLF +
+                    "Content-Disposition: form-data; name=\"var2\"" + CRLF +
+                    "X-SOURCEID: Invalid-Part-Header02" + CRLF +
+                    CRLF +
+                    "val2" + CRLF +
+                    "--AaBbCc" + CRLF +
+                    "Content-Disposition: form-data; name=\"var3\"" + CRLF +
+                    "X-SOURCEID: Invalid-Part-Header03" + CRLF +
+                    CRLF +
+                    "val3" + CRLF +
+                    "--AaBbCc--";
+            client.setRequest(new String[] {
+                    "POST / HTTP/1.1" + CRLF +
+                    "Host: localhost:" + getPort() + CRLF +
+                    "Connection: close" + CRLF +
+                    "Content-Length: "+payload.length() + CRLF +
+                    "Content-Type: multipart/form-data; boundary=AaBbCc" + CRLF +
+                    CRLF +payload});
+        }
+        client.setResponseBodyEncoding(StandardCharsets.UTF_8);
+        client.connect();
+        client.processRequest();
+
+        Assert.assertEquals(HttpServletResponse.SC_OK, client.getStatusCode());
+        String bodyInLowercase = client.getResponseBody().toLowerCase();
+        Assert.assertTrue(bodyInLowercase.contains("Content-Disposition".toLowerCase()));
+        Assert.assertTrue(client.getResponseBody().contains("form-data; name=\"var3\""));
+        Assert.assertFalse("Per rfc7578 section 4.8, supported fields of part are limited",client.getResponseBody().contains("Invalid-Part-Header"));
+        Assert.assertFalse("Per rfc7578 section 4.8, supported fields of part are limited",bodyInLowercase.contains("Content-ID".toLowerCase()));
+        Assert.assertFalse("Per rfc7578 section 4.8, supported fields of part are limited",bodyInLowercase.contains("X-SOURCEID".toLowerCase()));
+    }
+
+    private static class EchoPartServlet extends HttpServlet {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+            StringBuffer buf = new StringBuffer();
+            for (Part part : req.getParts()) {
+                buf.append(String.format("Part name:%s\n", part.getName()));
+                for (String header : part.getHeaderNames()) {
+                    for (String value : part.getHeaders(header)) {
+                        buf.append(String.format("\tHeader: %s=%s\n", header, value));
+                    }
+                }
+            }
+            resp.getWriter().write(buf.toString());
+            resp.getWriter().flush();
+        }
     }
 }


### PR DESCRIPTION
comply rfc7578 section [4.8](https://datatracker.ietf.org/doc/html/rfc7578#section-4.8)
```
4.8.  Other "Content-" Header Fields
   The multipart/form-data media type does not support any MIME header
   fields in parts other than Content-Type, Content-Disposition, and (in
   limited circumstances) Content-Transfer-Encoding.  Other header
   fields MUST NOT be included and MUST be ignored.
```
Only listed part header fields are supported. ignore others.