### PR TITLE
Enable rejectSuspiciousURIs by default to comply servlet 6 spec

### DIFF
--- a/java/org/apache/catalina/connector/Connector.java
+++ b/java/org/apache/catalina/connector/Connector.java
@@ -291,7 +291,7 @@ public class Connector extends LifecycleMBeanBase {
     protected boolean useBodyEncodingForURI = false;
 
 
-    private boolean rejectSuspiciousURIs;
+    private boolean rejectSuspiciousURIs = true;
 
 
     // ------------------------------------------------------------- Properties

--- a/test/conf/TestHttpServletUriPathCanonicalizationSpec.txt
+++ b/test/conf/TestHttpServletUriPathCanonicalizationSpec.txt
@@ -1,0 +1,102 @@
+# -----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+# https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#example-uris
+# Index Encoded URI path Decoded Path Rejected
+0 foo/bar /foo/bar 400 must start with /
+1 /foo/bar /foo/bar
+2 /foo/bar;jsessionid=1234 /foo/bar
+3 /foo/bar/ /foo/bar/
+4 /foo/bar/;jsessionid=1234 /foo/bar/
+5 /foo;/bar; /foo/bar
+6 /foo;/bar;/; /foo/bar/
+7 /foo%00/bar/ /foo[NUL]/bar/ 400 control character
+8 /foo%7Fbar /foo[DEL]bar 400 control character
+9 /foo%2Fbar /foo%2Fbar 400 encoded /
+10 /foo%2Fb%25r /foo%2Fb%25r 400 encoded /
+11 /foo/b%25r /foo/b%r
+12 /foo\bar /foo\bar 400 backslash character
+13 /foo%5Cbar /foo\bar 400 backslash character
+14 /foo;%2F/bar /foo/bar 400 encoded /
+15 /foo/./bar /foo/bar
+16 /foo/././bar /foo/bar
+17 /./foo/bar /foo/bar
+18 /foo/%2e/bar /foo/bar 400 encoded dot segment
+19 /foo/.;/bar /foo/bar 400 dot segment with parameter
+20 /foo/%2e;/bar /foo/bar 400 encoded dot segment
+21 /foo/.%2Fbar /foo/.%2Fbar 400 encoded /
+22 /foo/.%5Cbar /foo/.\bar 400 backslash character
+23 /foo/bar/. /foo/bar
+24 /foo/bar/./ /foo/bar/
+25 /foo/bar/.; /foo/bar 400 dot segment with parameter
+26 /foo/bar/./; /foo/bar/
+27 /foo/.bar /foo/.bar
+28 /foo/../bar /bar
+29 /foo/../../bar /../bar 400 leading dot-dot-segment
+30 /../foo/bar /../foo/bar 400 leading dot-dot-segment
+31 /foo/%2e%2E/bar /bar 400 encoded dot segment
+32 /foo/%2e%2e/%2E%2E/bar /../bar 400 leading dot-dot-segment & encoded dot segment
+33 /foo/./../bar /bar
+34 /foo/..;/bar /bar 400 dot segment with parameter
+35 /foo/%2e%2E;/bar /bar 400 encoded dot segment
+36 /foo/..%2Fbar /foo/..%2Fbar 400 encoded /
+37 /foo/..%5Cbar /foo/..\bar 400 backslash character
+38 /foo/bar/.. /foo
+39 /foo/bar/../ /foo/
+40 /foo/bar/..; /foo 400 dot segment with parameter
+41 /foo/bar/../; /foo/
+42 /foo/..bar /foo/..bar
+43 /foo/.../bar /foo/.../bar
+44 /foo//bar /foo/bar
+45 //foo//bar// /foo/bar/
+46 /;/foo;/;/bar/;/; /foo/bar/ 400 empty segment with parameters
+47 /foo//../bar /bar
+48 /foo/;/../bar /bar 400 empty segment with parameters
+49 /foo%E2%82%ACbar /foo€bar
+50 /foo%20bar /foo bar
+51 /foo%E2%82 /foo%E2%82 400 decode error
+52 /foo%E2%82bar /foo%E2%82bar 400 decode error
+53 /foo%-1/bar /foo%-1/bar 400 decode error
+54 /foo%XX/bar /foo%XX/bar 400 decode error
+55 /foo%/bar /foo%/bar 400 decode error
+56 /foo/bar%0 /foo/bar%0 400 decode error
+57 /good%20/bad%/%20mix% /good /bad%/%20mix% 400 decode error
+58 /foo/bar?q /foo/bar
+59 /foo/bar#f /foo/bar 400 fragment
+60 /foo/bar?q#f /foo/bar 400 fragment
+61 /foo/bar/?q /foo/bar/
+62 /foo/bar/#f /foo/bar/ 400 fragment
+63 /foo/bar/?q#f /foo/bar/ 400 fragment
+64 /foo/bar;?q /foo/bar
+65 /foo/bar;#f /foo/bar 400 fragment
+66 /foo/bar;?q#f /foo/bar 400 fragment
+67 / /
+68 // /
+69 /;/ / 400 empty segment with parameters
+70 /. /
+71 /.. /.. 400 leading dot-dot-segment
+72 /./ /
+73 /../ /../ 400 leading dot-dot-segment
+74 foo/bar/ /foo/bar/ 400 must start with /
+75 ./foo/bar/ /foo/bar/ 400 must start with /
+76 %2e/foo/bar/ /foo/bar/ 400 must start with / & encoded dot segment
+77 ../foo/bar/ /../foo/bar/ 400 must start with / & leading dot-dot-segment
+78 .%2e/foo/bar/ /../foo/bar/ 400 must start with / & leading dot-dot-segment & encoded dot segment
+79 ;/foo/bar/ /foo/bar/ 400 must start with / & empty segment with parameters
+80 /#f / 400 fragment
+81 #f / 400 fragment & must start with /
+82 /?q /
+83 ?q / 400 must start with /

--- a/test/jakarta/servlet/http/HttpServletUriPathCanonicalizationBaseTest.java
+++ b/test/jakarta/servlet/http/HttpServletUriPathCanonicalizationBaseTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jakarta.servlet.http;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.charset.Charset;
+
+import jakarta.servlet.ServletException;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+
+import static org.apache.catalina.startup.SimpleHttpClient.CRLF;
+import org.apache.catalina.connector.Request;
+import org.apache.catalina.connector.RequestFacade;
+import org.apache.catalina.core.StandardContext;
+import org.apache.catalina.startup.SimpleHttpClient;
+import org.apache.catalina.startup.Tomcat;
+import org.apache.catalina.startup.TomcatBaseTest;
+
+/**
+ *
+ */
+public abstract class HttpServletUriPathCanonicalizationBaseTest extends TomcatBaseTest {
+
+    @Parameter(0)
+    public String index;
+    @Parameter(1)
+    public String encodedUriPath;
+    @Parameter(2)
+    public String expectedDecodedPath;
+    @Parameter(3)
+    public Integer expectedRejectCode;
+
+    @Test
+    public void testServlet6_UriPathCanonicalization() throws Exception {
+        Tomcat tomcat = getTomcatInstance();
+        // per servlet 6.2, rejectSuspiciousURIs should be enabled by default
+        // tomcat.getConnector().setRejectSuspiciousURIs(true);
+        // No file system docBase required
+        StandardContext ctx = (StandardContext) getProgrammaticRootContext();
+
+        Tomcat.addServlet(ctx, "echoUriServlet", new EchoUriServlet());
+        ctx.addServletMappingDecoded("/", "echoUriServlet");
+
+        tomcat.start();
+
+        MySimpleClient client = new MySimpleClient();
+        client.setPort(getPort());
+        client.setResponseBodyEncoding(Charset.forName("utf-8"));
+        client.connect();
+        client.setRequest(new String[] {
+                "GET " + encodedUriPath + " HTTP/1.1" + CRLF +
+                "Host: localhost:" + getPort() + CRLF +
+                "Connection: close" + CRLF +
+                CRLF });
+        client.processRequest();
+        int sc = client.getStatusCode();
+        String body = client.getResponseBody();
+        if (expectedRejectCode != null && expectedRejectCode.intValue() != 200) {
+            Assert.assertEquals(expectedRejectCode.intValue(), sc);
+        } else {
+            Assert.assertEquals(expectedDecodedPath, body);
+            Assert.assertEquals(200, sc);
+        }
+    }
+
+    private static final class EchoUriServlet extends HttpServlet {
+
+        /**
+         *
+         */
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+            if(req instanceof RequestFacade rf) {
+                try {
+                    Field f = RequestFacade.class.getDeclaredField("request");
+                    f.setAccessible(true);
+                    Request internalRequest=(Request) f.get(rf);
+                    resp.setCharacterEncoding("utf-8");
+                    resp.getWriter().write(internalRequest.getDecodedRequestURI());
+                } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
+                    e.printStackTrace();
+                }
+
+            } else {
+                resp.getWriter().write("Unkown");
+            }
+        }
+    }
+
+    private static final class MySimpleClient extends SimpleHttpClient {
+        @Override
+        public boolean isResponseBodyOK() {
+            return getStatusCode() >= 200 && getStatusCode() < 300;
+        }
+    }
+
+}

--- a/test/jakarta/servlet/http/TestHttpServletUriPathCanonicalizationSpec.java
+++ b/test/jakarta/servlet/http/TestHttpServletUriPathCanonicalizationSpec.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jakarta.servlet.http;
+
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestHttpServletUriPathCanonicalizationSpec extends HttpServletUriPathCanonicalizationBaseTest {
+
+    @Parameterized.Parameters(name = "{index}: {1} {2} {3}")
+    public static Collection<Object[]> parameters() throws IOException {
+        // Servlet 6.1 spec, section 3.5.3 examples
+        List<Object[]> parameterSets = new ArrayList<>();
+        try (InputStream is = new FileInputStream("test/conf/TestHttpServletUriPathCanonicalizationSpec.txt")) {
+
+            BufferedReader br = new BufferedReader(new InputStreamReader(is));
+            List<String> lineList = br.lines().collect(Collectors.toList());
+            String[] lines = lineList.toArray(new String[0]);
+
+            for (int i = 1; i < lines.length; i++) {
+                if(lines[i].startsWith("#")) {
+                    continue;
+                }
+                String[] cols = lines[i].split(" ");
+                String caseIndex = cols[0];
+                if(Arrays.binarySearch(new String[] {"19","34"}, caseIndex)>=0) {
+                    continue;
+                }
+                String srcUri = cols[1];
+                String destUri = "/";
+                Integer sc = null;
+
+                if (cols.length >= 3) {
+                    StringBuffer destBuf = new StringBuffer(cols[2]);
+                    for (int c = 3; c < cols.length; c++) {
+                        try {
+                            sc = Integer.valueOf(cols[c]);
+                            break;
+                        } catch (Exception e) {
+                            destBuf.append(" ").append(cols[c]);
+                        }
+                    }
+                    destUri = destBuf.toString();
+                }
+                parameterSets.add(new Object[] { caseIndex, srcUri, destUri, sc });
+            }
+        }
+        return parameterSets;
+    }
+}

--- a/webapps/docs/config/ajp.xml
+++ b/webapps/docs/config/ajp.xml
@@ -295,7 +295,7 @@
     <attribute name="rejectSuspiciousURIs" required="false">
       <p>Should this <strong>Connector</strong> reject a requests if the URI
       matches one of the suspicious URIs patterns identified by the Servlet 6.0
-      specification? The default value is <code>false</code>.</p>
+      specification? The default value is <code>true</code>.</p>
     </attribute>
 
     <attribute name="scheme" required="false">

--- a/webapps/docs/config/http.xml
+++ b/webapps/docs/config/http.xml
@@ -289,7 +289,7 @@
     <attribute name="rejectSuspiciousURIs" required="false">
       <p>Should this <strong>Connector</strong> reject a requests if the URI
       matches one of the suspicious URIs patterns identified by the Servlet 6.0
-      specification? The default value is <code>false</code>.</p>
+      specification? The default value is <code>true</code>.</p>
     </attribute>
 
     <attribute name="scheme" required="false">


### PR DESCRIPTION
Make site safer, for those behind reverse proxy apps especially.