### PR TITLE
Fix incorrect reference to StaticMembershipInterceptor in cluster-howto.xml

### DIFF
--- a/webapps/docs/cluster-howto.xml
+++ b/webapps/docs/cluster-howto.xml
@@ -365,7 +365,7 @@ should be completed:</p>
                         dropTime="3000"/>]]></source>
     <p>
         Membership is done using multicasting. Please note that Tribes also supports static memberships using the
-        <code>StaticMembershipInterceptor</code> if you want to extend your membership to points beyond multicasting.
+        <code>StaticMembershipService</code> if you want to extend your membership to points beyond multicasting.
         The address attribute is the multicast address used and the port is the multicast port. These two together
         create the cluster separation. If you want a QA cluster and a production cluster, the easiest config is to
         have the QA cluster be on a separate multicast address/port combination than the production cluster.<br/>


### PR DESCRIPTION
This PR fixes a documentation inaccuracy in `cluster-howto.xml`.

The original text incorrectly states that static memberships are configured using `StaticMembershipInterceptor`.
However, the correct class to use in the `<Membership>` element is `StaticMembershipService`.

This fix updates the wording and clarifies the distinction between the two classes to avoid misleading users.

No runtime behavior is affected by this change — documentation only.

Bugzilla: https://bz.apache.org/bugzilla/show_bug.cgi?id=69747