### PR TITLE
Fix typo: Change CATALIA_HOME to CATALINA_HOME in documentation

### DIFF
--- a/webapps/docs/introduction.xml
+++ b/webapps/docs/introduction.xml
@@ -115,7 +115,7 @@ do let us know.</p>
         instances with single CATALINA_HOME location share one set of
         <code>.jar</code> files and binary files, you can easily upgrade the files
         to newer version and have the change propagated to all Tomcat instances
-        using the same CATALIA_HOME directory.
+        using the same CATALINA_HOME directory.
       </li>
       <li>
         Avoiding duplication of the same static <code>.jar</code> files.


### PR DESCRIPTION
## Description
Fixed a typo in the Tomcat documentation where `CATALIA_HOME` was missing the letter 'N' and should be `CATALINA_HOME`.

## Changes Made
- Changed `CATALIA_HOME` to `CATALINA_HOME` on line 118 of the introduction documentation
- This ensures consistency with the correct environment variable name used throughout Tomcat

## Type of Change
- [x] Documentation update
