### PR TITLE
Update logging.properties

### DIFF
--- a/conf/logging.properties
+++ b/conf/logging.properties
@@ -1,9 +1,9 @@
 # Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
+# contributor license agreements. See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
 # The ASF licenses this file to You under the Apache License, Version 2.0
 # (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
+# the License. You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
@@ -22,34 +22,33 @@ handlers = 1catalina.org.apache.juli.AsyncFileHandler, 2localhost.org.apache.jul
 # Describes specific configuration info for Handlers.
 ############################################################
 
-1catalina.org.apache.juli.AsyncFileHandler.level = ALL
+1catalina.org.apache.juli.AsyncFileHandler.level = INFO
 1catalina.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
 1catalina.org.apache.juli.AsyncFileHandler.prefix = catalina.
-1catalina.org.apache.juli.AsyncFileHandler.maxDays = 90
+1catalina.org.apache.juli.AsyncFileHandler.maxDays = 30
 1catalina.org.apache.juli.AsyncFileHandler.encoding = UTF-8
 
-2localhost.org.apache.juli.AsyncFileHandler.level = ALL
+2localhost.org.apache.juli.AsyncFileHandler.level = INFO
 2localhost.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
 2localhost.org.apache.juli.AsyncFileHandler.prefix = localhost.
-2localhost.org.apache.juli.AsyncFileHandler.maxDays = 90
+2localhost.org.apache.juli.AsyncFileHandler.maxDays = 30
 2localhost.org.apache.juli.AsyncFileHandler.encoding = UTF-8
 
-3manager.org.apache.juli.AsyncFileHandler.level = ALL
+3manager.org.apache.juli.AsyncFileHandler.level = WARNING
 3manager.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
 3manager.org.apache.juli.AsyncFileHandler.prefix = manager.
-3manager.org.apache.juli.AsyncFileHandler.maxDays = 90
+3manager.org.apache.juli.AsyncFileHandler.maxDays = 30
 3manager.org.apache.juli.AsyncFileHandler.encoding = UTF-8
 
-4host-manager.org.apache.juli.AsyncFileHandler.level = ALL
+4host-manager.org.apache.juli.AsyncFileHandler.level = WARNING
 4host-manager.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
 4host-manager.org.apache.juli.AsyncFileHandler.prefix = host-manager.
-4host-manager.org.apache.juli.AsyncFileHandler.maxDays = 90
+4host-manager.org.apache.juli.AsyncFileHandler.maxDays = 30
 4host-manager.org.apache.juli.AsyncFileHandler.encoding = UTF-8
 
-java.util.logging.ConsoleHandler.level = ALL
+java.util.logging.ConsoleHandler.level = SEVERE
 java.util.logging.ConsoleHandler.formatter = org.apache.juli.OneLineFormatter
 java.util.logging.ConsoleHandler.encoding = UTF-8
-
 
 ############################################################
 # Facility specific properties.
@@ -59,18 +58,14 @@ java.util.logging.ConsoleHandler.encoding = UTF-8
 org.apache.catalina.core.ContainerBase.[Catalina].[localhost].level = INFO
 org.apache.catalina.core.ContainerBase.[Catalina].[localhost].handlers = 2localhost.org.apache.juli.AsyncFileHandler
 
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].level = WARNING
 org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].handlers = 3manager.org.apache.juli.AsyncFileHandler
 
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].level = WARNING
 org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].handlers = 4host-manager.org.apache.juli.AsyncFileHandler
 
-# For example, set the org.apache.catalina.util.LifecycleBase logger to log
-# each component that extends LifecycleBase changing state:
-#org.apache.catalina.util.LifecycleBase.level = FINE
-
-# To see debug messages for HTTP/2 handling, uncomment the following line:
+# To enable debug messages for HTTP/2 handling, uncomment the following line:
 #org.apache.coyote.http2.level = FINE
 
-# To see debug messages for WebSocket handling, uncomment the following line:
+# To enable debug messages for WebSocket handling, uncomment the following line:
 #org.apache.tomcat.websocket.level = FINE


### PR DESCRIPTION
Log levels set to INFO or WARNING to balance detail and noise in production.

Logs retained for 30 days to balance disk space usage and audit needs.

All logs use UTF-8 encoding, supporting internationalization.

Console logs limited to SEVERE to reduce noise for console viewers.

Comments included to guide when to increase log verbosity for troubleshooting.