### PR TITLE
Move lower casing of headers from parser to valve

### DIFF
--- a/conf/server.xml
+++ b/conf/server.xml
@@ -160,6 +160,9 @@
                resourceName="UserDatabase"/>
       </Realm>
 
+      <!-- LowerCaseHeaders valve makes http headers case insensitive, but retains original spelling --> 
+      <Valve className="org.apache.catalina.valves.LowerCaseHeadersValve" />
+
       <Host name="localhost"  appBase="webapps"
             unpackWARs="true" autoDeploy="true">
 

--- a/java/org/apache/catalina/valves/LowerCaseHeadersValve.java
+++ b/java/org/apache/catalina/valves/LowerCaseHeadersValve.java
@@ -1,0 +1,57 @@
+package org.apache.catalina.valves;
+
+import org.apache.catalina.connector.Response;
+import org.apache.catalina.valves.ValveBase;
+import org.apache.tomcat.util.buf.MessageBytes;
+import org.apache.tomcat.util.http.MimeHeaders;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.util.*;
+
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
+
+public class LowerCaseHeadersValve extends ValveBase {
+	private static final Log log = LogFactory.getLog(LowerCaseHeadersValve.class);
+
+    @Override
+    public void invoke(org.apache.catalina.connector.Request request, Response response) throws IOException, ServletException {
+		log.debug("in");
+        // Access the Coyote request (Tomcat's internal request object)
+        org.apache.coyote.Request coyoteRequest = request.getCoyoteRequest();
+        MimeHeaders mimeHeaders = coyoteRequest.getMimeHeaders();
+
+        // Preserve original header names with case
+        Map<String, List<String>> originalHeaders = new LinkedHashMap<>();
+
+        for (int i = 0; i < mimeHeaders.size(); i++) {
+            MessageBytes nameMessageBytes = mimeHeaders.getName(i);
+            MessageBytes valueMessageBytes = mimeHeaders.getValue(i);
+
+            String name = nameMessageBytes.toString();
+            String value = valueMessageBytes.toString();
+
+			if(log.isDebugEnabled()) {
+				log.debug("raw: "+name+": "+value);
+			}
+
+            originalHeaders.computeIfAbsent(name, k -> new ArrayList<>()).add(value);
+
+			nameMessageBytes.setString(name.toLowerCase());
+
+			if(log.isDebugEnabled()) {
+            	name = nameMessageBytes.toString();
+            	value = valueMessageBytes.toString();
+				log.debug("current: "+name+": "+value);
+			}
+        }
+
+        // Store headers in request attributes for downstream use
+        request.setAttribute("originalHeaders", originalHeaders);
+
+        // Continue pipeline
+        getNext().invoke(request, response);
+    }
+}
+

--- a/java/org/apache/coyote/http11/Http11InputBuffer.java
+++ b/java/org/apache/coyote/http11/Http11InputBuffer.java
@@ -906,11 +906,6 @@ public class Http11InputBuffer implements InputBuffer, ApplicationBufferHandler 
                 // skipLine() will handle the error
                 return skipLine(false);
             }
-
-            // chr is next byte of header name. Convert to lowercase.
-            if (chr >= Constants.A && chr <= Constants.Z) {
-                byteBuffer.put(pos, (byte) (chr - Constants.LC_OFFSET));
-            }
         }
 
         // Skip the line and ignore the header


### PR DESCRIPTION
There is a very old Bugzilla issue for this already [58464](https://bz.apache.org/bugzilla/show_bug.cgi?id=58464).

If you think of tomcat as an app by itself, and not as a part of a larger ecosystem of apps, it may be ok to claim that tomcat is opinionated on the subject of keeping all the headers lower cased. However, in enterprise environments, like my own, there are hundreds of apps all talking to one another, especially if async pipelines, like the ones powered by activemq or kafka, are involved. In this case preserving access to the original header spelling may be important, as there are maybe hundreds of legacy applications that are not ready to be refreshed to fully support lower cased headers yet. Yes, it is 2025, and yes, it is still relevant. Legacy is legacy. It would be nice if tomcat offered access to the original spelling of the headers. While http1 spec does require case agnostic treatment, it doesn't require losing original spelling of the http headers. I am proposing to move case processing from the [Http11InputBuffer]() into its own [valve](https://github.com/maxfortun/tomcat/blob/feature/retain_original_header_spelling/java/org/apache/catalina/valves/LowerCaseHeadersValve.java), and have it included into the [default configuration](https://github.com/maxfortun/tomcat/blob/e2904f7f7f9be667099462505164f54a90b80f40/conf/server.xml#L164). This should retain full backward compatibility to current deployments and actually allow tomcat users that do require original spelling to access it via something like this:
```java
    public static Map<String, List<String>> getOriginalHeaders(HttpServletRequest httpServletRequest) {
        Map<String, List<String>> originalHeaders = (Map<String, List<String>>) httpServletRequest.getAttribute("originalHeaders");

        if (originalHeaders != null) {
            if(logger.isDebugEnabled()) {
                originalHeaders.forEach((name, values) -> {
                    logger.debug(name + " = " + values);
                });
            }
        } else {
            logger.debug("No original headers");
        }

        return originalHeaders;
    }
```
