### PR TITLE
Add support for CIDR notation in RemoteIpFilter(#632)

### DIFF
--- a/java/org/apache/catalina/filters/LocalStrings.properties
+++ b/java/org/apache/catalina/filters/LocalStrings.properties
@@ -68,6 +68,7 @@ remoteCidrFilter.noRemoteIp=Client does not have an IP address. Request denied.
 
 remoteIpFilter.invalidHostHeader=Invalid value [{0}] found for Host in HTTP header [{1}]
 remoteIpFilter.invalidHostWithPort=Host value [{0}] in HTTP header [{1}] included a port number which will be ignored
+remoteIpFilter.invalidNetMask=One or more netmasks provided are invalid: {0}
 remoteIpFilter.invalidNumber=Illegal number for parameter [{0}]: [{1}]
 remoteIpFilter.invalidPort=Port [{0}] in HTTP header [{1}] included a port number which will be ignored
 remoteIpFilter.invalidRemoteAddress=Unable to determine the remote host because the reported remote address [{0}] is not valid


### PR DESCRIPTION
### CIDR Rule Storage Logic:
A dedicated netMaskSet storage mechanism is introduced to store the parsed CIDR network segment rules for 
internal proxies and trusted proxies, providing data support for subsequent IP verification.
### Proxy IP Verification Logic:
  When verifying an internal proxy IP, it first checks whether the IP conforms to the original regular expression format. If not, it 
  further verifies whether the IP falls within the stored CIDR network segments of internal proxies.
  When verifying a trusted proxy IP, it also first checks whether the IP matches the original regular expression format. If not, it 
  further confirms whether the IP is within the stored CIDR network segments of trusted proxies.