### PR TITLE
Fix invalid Eclipse setting key in formatting-asf-tomcat.xml

### DIFF
--- a/res/ide-support/eclipse/formatting-asf-tomcat.xml
+++ b/res/ide-support/eclipse/formatting-asf-tomcat.xml
@@ -20,7 +20,7 @@
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
-        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_for_statment" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_for_statement" value="common_lines"/>
         <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>


### PR DESCRIPTION
Fix typo in Eclipse setting key value.  According to Eclipse Help Docs : https://help.eclipse.org/latest/index.jsp?topic=%2Forg.eclipse.jdt.doc.isv%2Freference%2Fapi%2Forg%2Feclipse%2Fjdt%2Fcore%2Fformatter%2FDefaultCodeFormatterConstants.html

The appropriate setting key is:

org.eclipse.jdt.core.formatter.parentheses_positions_in_for_statement

but the code here shows:

org.eclipse.jdt.core.formatter.parentheses_positions_in_for_statment  (missing 'e' in statement)