### PR TITLE
Remove redundant conversion of applicationEventListenerList

### DIFF
--- a/java/org/apache/catalina/core/StandardContext.java
+++ b/java/org/apache/catalina/core/StandardContext.java
@@ -3963,7 +3963,7 @@ public class StandardContext extends ContainerBase implements Context, Notificat
         // Put them these listeners after the ones defined in web.xml and/or
         // annotations then overwrite the list of instances with the new, full
         // list.
-        eventListeners.addAll(Arrays.asList(getApplicationEventListeners()));
+        eventListeners.addAll(applicationEventListenersList);
         setApplicationEventListeners(eventListeners.toArray());
         for (Object lifecycleListener : getApplicationLifecycleListeners()) {
             lifecycleListeners.add(lifecycleListener);


### PR DESCRIPTION
Hello,

While reviewing the source code, I found a redundant conversion of `applicationEventListenerList` in `StandardContext.java`.
This pull request removes the unnecessary conversion.

Thank you for reviewing my contribution.