### PR TITLE
Access log nanoseconds

### DIFF
--- a/java/org/apache/catalina/AccessLog.java
+++ b/java/org/apache/catalina/AccessLog.java
@@ -16,6 +16,8 @@
  */
 package org.apache.catalina;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 
@@ -57,12 +59,29 @@ public interface AccessLog {
 
     /**
      * Add the request/response to the access log using the specified processing time.
+     * <p>
+     * Note: As of Tomcat 10.1.x, this method will expect nanoseconds rather than milliseconds.
      *
      * @param request  Request (associated with the response) to log
      * @param response Response (associated with the request) to log
      * @param time     Time taken to process the request/response in milliseconds (use 0 if not known)
      */
     void log(Request request, Response response, long time);
+
+    /**
+     * Add the request/response to the access log using the specified processing time.
+     *
+     * @param request  Request (associated with the response) to log
+     * @param response Response (associated with the request) to log
+     * @param time     Time taken to process the request/response in nanoseconds (use 0 if not known)
+     *
+     * @deprecated This will be removed in Tomcat 10.1.x and the {@link #log(Request, Response, long)} method changed to
+     *                 expect nanoseconds.
+     */
+    @Deprecated
+    default void logNanos(Request request, Response response, long time) {
+        log(request, response, TimeUnit.NANOSECONDS.toMillis(time));
+    }
 
     /**
      * Should this valve use request attributes for IP address, hostname, protocol and port used for the request? The

--- a/java/org/apache/catalina/Container.java
+++ b/java/org/apache/catalina/Container.java
@@ -430,7 +430,7 @@ public interface Container extends Lifecycle {
      *
      * @param request    Request (associated with the response) to log
      * @param response   Response (associated with the request) to log
-     * @param time       Time taken to process the request/response in milliseconds (use 0 if not known)
+     * @param time       Time taken to process the request/response in nanoseconds (use 0 if not known)
      * @param useDefault Flag that indicates that the request/response should be logged in the engine's default access
      *                       log
      */

--- a/java/org/apache/catalina/Container.java
+++ b/java/org/apache/catalina/Container.java
@@ -18,6 +18,7 @@ package org.apache.catalina;
 
 import java.beans.PropertyChangeListener;
 import java.io.File;
+import java.util.concurrent.TimeUnit;
 
 import javax.management.ObjectName;
 
@@ -427,14 +428,35 @@ public interface Container extends Lifecycle {
     /**
      * Log a request/response that was destined for this container but has been handled earlier in the processing chain
      * so that the request/response still appears in the correct access logs.
+     * <p>
+     * Note: As of Tomcat 10.1.x, this method will expect nanoseconds rather than milliseconds.
+     *
+     * @param request    Request (associated with the response) to log
+     * @param response   Response (associated with the request) to log
+     * @param time       Time taken to process the request/response in milliseconds (use 0 if not known)
+     * @param useDefault Flag that indicates that the request/response should be logged in the engine's default access
+     *                       log
+     */
+    void logAccess(Request request, Response response, long time, boolean useDefault);
+
+
+    /**
+     * Log a request/response that was destined for this container but has been handled earlier in the processing chain
+     * so that the request/response still appears in the correct access logs.
      *
      * @param request    Request (associated with the response) to log
      * @param response   Response (associated with the request) to log
      * @param time       Time taken to process the request/response in nanoseconds (use 0 if not known)
      * @param useDefault Flag that indicates that the request/response should be logged in the engine's default access
      *                       log
+     *
+     * @deprecated This will be removed in Tomcat 10.1.x and the {@link #logAccess(Request, Response, long, boolean)}
+     *                 method changed to expect nanoseconds.
      */
-    void logAccess(Request request, Response response, long time, boolean useDefault);
+    @Deprecated
+    default void logAccessNanos(Request request, Response response, long time, boolean useDefault) {
+        logAccess(request, response, TimeUnit.NANOSECONDS.toMillis(time), useDefault);
+    }
 
 
     /**

--- a/java/org/apache/catalina/connector/CoyoteAdapter.java
+++ b/java/org/apache/catalina/connector/CoyoteAdapter.java
@@ -278,8 +278,8 @@ public class CoyoteAdapter implements Adapter {
             // Access logging
             if (!success || !request.isAsync()) {
                 long time = 0;
-                if (req.getStartTime() != -1) {
-                    time = System.currentTimeMillis() - req.getStartTime();
+                if (req.getStartTimeNanos() != -1) {
+                    time = System.nanoTime() - req.getStartTimeNanos();
                 }
                 Context context = request.getContext();
                 if (context != null) {
@@ -404,7 +404,7 @@ public class CoyoteAdapter implements Adapter {
                 // The other possibility is that an error occurred early in
                 // processing and the request could not be mapped to a Context.
                 // Log via the host or engine in that case.
-                long time = System.currentTimeMillis() - req.getStartTime();
+                long time = System.nanoTime() - req.getStartTimeNanos();
                 if (context != null) {
                     context.logAccess(request, response, time, false);
                 } else if (response.isError()) {

--- a/java/org/apache/catalina/core/AccessLogAdapter.java
+++ b/java/org/apache/catalina/core/AccessLogAdapter.java
@@ -18,6 +18,7 @@ package org.apache.catalina.core;
 
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.catalina.AccessLog;
 import org.apache.catalina.connector.Request;
@@ -44,8 +45,14 @@ public class AccessLogAdapter implements AccessLog {
 
     @Override
     public void log(Request request, Response response, long time) {
+        logNanos(request, response, TimeUnit.MILLISECONDS.toNanos(time));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public void logNanos(Request request, Response response, long time) {
         for (AccessLog log : logs) {
-            log.log(request, response, time);
+            log.logNanos(request, response, time);
         }
     }
 

--- a/java/org/apache/catalina/core/ContainerBase.java
+++ b/java/org/apache/catalina/core/ContainerBase.java
@@ -877,18 +877,25 @@ public abstract class ContainerBase extends LifecycleMBeanBase implements Contai
 
     @Override
     public void logAccess(Request request, Response response, long time, boolean useDefault) {
+        logAccessNanos(request, response, TimeUnit.MILLISECONDS.toNanos(time), useDefault);
+    }
+
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public void logAccessNanos(Request request, Response response, long time, boolean useDefault) {
 
         boolean logged = false;
 
         if (getAccessLog() != null) {
-            getAccessLog().log(request, response, time);
+            getAccessLog().logNanos(request, response, time);
             logged = true;
         }
 
         if (getParent() != null) {
             // No need to use default logger once request/response has been logged
             // once
-            getParent().logAccess(request, response, time, (useDefault && !logged));
+            getParent().logAccessNanos(request, response, time, (useDefault && !logged));
         }
     }
 

--- a/java/org/apache/catalina/core/StandardEngine.java
+++ b/java/org/apache/catalina/core/StandardEngine.java
@@ -219,13 +219,14 @@ public class StandardEngine extends ContainerBase implements Engine {
      * default host and then the default host's ROOT context. If still none is found, return the default NoOp access
      * log.
      */
+    @SuppressWarnings("deprecation")
     @Override
-    public void logAccess(Request request, Response response, long time, boolean useDefault) {
+    public void logAccessNanos(Request request, Response response, long time, boolean useDefault) {
 
         boolean logged = false;
 
         if (getAccessLog() != null) {
-            accessLog.log(request, response, time);
+            accessLog.logNanos(request, response, time);
             logged = true;
         }
 
@@ -268,7 +269,7 @@ public class StandardEngine extends ContainerBase implements Engine {
                 }
             }
 
-            newDefaultAccessLog.log(request, response, time);
+            newDefaultAccessLog.logNanos(request, response, time);
         }
     }
 

--- a/java/org/apache/catalina/valves/AbstractAccessLogValve.java
+++ b/java/org/apache/catalina/valves/AbstractAccessLogValve.java
@@ -663,6 +663,12 @@ public abstract class AbstractAccessLogValve extends ValveBase implements Access
 
     @Override
     public void log(Request request, Response response, long time) {
+        logNanos(request, response, TimeUnit.MILLISECONDS.toNanos(time));
+    }
+
+
+    @Override
+    public void logNanos(Request request, Response response, long time) {
         if (!getState().isAvailable() || !getEnabled() || logElements == null ||
                 condition != null && null != request.getRequest().getAttribute(condition) ||
                 conditionIf != null && null == request.getRequest().getAttribute(conditionIf)) {

--- a/java/org/apache/catalina/valves/JDBCAccessLogValve.java
+++ b/java/org/apache/catalina/valves/JDBCAccessLogValve.java
@@ -24,6 +24,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 import javax.servlet.ServletException;
 
@@ -435,6 +436,12 @@ public class JDBCAccessLogValve extends ValveBase implements AccessLog {
 
     @Override
     public void log(Request request, Response response, long time) {
+        logNanos(request, response, TimeUnit.MILLISECONDS.toNanos(time));
+    }
+
+    @Override
+    public void logNanos(Request request, Response response, long time) {
+
         if (!getState().isAvailable()) {
             return;
         }

--- a/java/org/apache/catalina/valves/JsonAccessLogValve.java
+++ b/java/org/apache/catalina/valves/JsonAccessLogValve.java
@@ -20,7 +20,6 @@ import java.io.CharArrayWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.ListIterator;
@@ -123,7 +122,7 @@ public class JsonAccessLogValve extends AccessLogValve {
         }
 
         @Override
-        public void addElement(CharArrayWriter buf, Date date, Request request, Response response, long time) {
+        public void addElement(CharArrayWriter buf, Request request, Response response, long time) {
             buf.write(ch);
         }
     }
@@ -252,12 +251,12 @@ public class JsonAccessLogValve extends AccessLogValve {
         }
 
         @Override
-        public void addElement(CharArrayWriter buf, Date date, Request request, Response response, long time) {
+        public void addElement(CharArrayWriter buf, Request request, Response response, long time) {
             buf.append('"').append(attributeName).append('"').append(':');
             if (quoteValue) {
                 buf.append('"');
             }
-            delegate.addElement(buf, date, request, response, time);
+            delegate.addElement(buf, request, response, time);
             if (quoteValue) {
                 buf.append('"');
             }

--- a/java/org/apache/coyote/AbstractProcessor.java
+++ b/java/org/apache/coyote/AbstractProcessor.java
@@ -1088,6 +1088,6 @@ public abstract class AbstractProcessor extends AbstractProcessorLight implement
         // Set up the minimal response information
         response.setStatus(400);
         response.setError();
-        getAdapter().log(request, response, 0);
+        getAdapter().logNanos(request, response, 0);
     }
 }

--- a/java/org/apache/coyote/Adapter.java
+++ b/java/org/apache/coyote/Adapter.java
@@ -16,6 +16,8 @@
  */
 package org.apache.coyote;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.tomcat.util.net.SocketEvent;
 
 /**
@@ -74,12 +76,29 @@ public interface Adapter {
 
     /**
      * Callback to allow logging access outside of the execution of the regular service.
+     * <p>
+     * Note: As of Tomcat 10.1.x, this method will expect nanoseconds rather than milliseconds.
      *
      * @param req  the request object
      * @param res  the response object
      * @param time time taken to process the request/response in milliseconds (use 0 if not known)
      */
     void log(Request req, Response res, long time);
+
+    /**
+     * Callback to allow logging access outside of the execution of the regular service.
+     *
+     * @param req  the request object
+     * @param res  the response object
+     * @param time time taken to process the request/response in nanoseconds (use 0 if not known)
+     *
+     * @deprecated This will be removed in Tomcat 10.1.x and the {@link #log(Request, Response, long)} method changed to
+     *                 expect nanoseconds.
+     */
+    @Deprecated
+    default void logNanos(Request req, Response res, long time) {
+        log(req, res, TimeUnit.NANOSECONDS.toMillis(time));
+    }
 
     /**
      * Assert that request and response have been recycled. If they have not then log a warning and force a recycle.

--- a/java/org/apache/coyote/ajp/AjpProcessor.java
+++ b/java/org/apache/coyote/ajp/AjpProcessor.java
@@ -329,6 +329,7 @@ public class AjpProcessor extends AbstractProcessor {
     }
 
 
+    @SuppressWarnings("deprecation")
     @Override
     public SocketState service(SocketWrapperBase<?> socket) throws IOException {
 
@@ -435,7 +436,7 @@ public class AjpProcessor extends AbstractProcessor {
                     // 500 - Internal Server Error
                     response.setStatus(500);
                     setErrorState(ErrorState.CLOSE_CLEAN, t);
-                    getAdapter().log(request, response, 0);
+                    getAdapter().logNanos(request, response, 0);
                 }
             }
 
@@ -641,6 +642,7 @@ public class AjpProcessor extends AbstractProcessor {
     /**
      * After reading the request headers, we have to setup the request filters.
      */
+    @SuppressWarnings("deprecation")
     private void prepareRequest() {
 
         // Translate the HTTP method code to a String.
@@ -888,7 +890,7 @@ public class AjpProcessor extends AbstractProcessor {
         parseHost(valueMB);
 
         if (!getErrorState().isIoAllowed()) {
-            getAdapter().log(request, response, 0);
+            getAdapter().logNanos(request, response, 0);
         }
     }
 

--- a/java/org/apache/coyote/http11/Http11Processor.java
+++ b/java/org/apache/coyote/http11/Http11Processor.java
@@ -248,6 +248,7 @@ public class Http11Processor extends AbstractProcessor {
     }
 
 
+    @SuppressWarnings("deprecation")
     @Override
     public SocketState service(SocketWrapperBase<?> socketWrapper) throws IOException {
         RequestInfo rp = request.getRequestProcessor();
@@ -355,7 +356,7 @@ public class Http11Processor extends AbstractProcessor {
                             response.setHeader("Connection", "Upgrade");
                             response.setHeader("Upgrade", requestedProtocol);
                             action(ActionCode.CLOSE, null);
-                            getAdapter().log(request, response, 0);
+                            getAdapter().logNanos(request, response, 0);
 
                             // Continue processing using new protocol
                             InternalHttpUpgradeHandler upgradeHandler = upgradeProtocol
@@ -425,7 +426,7 @@ public class Http11Processor extends AbstractProcessor {
                     // 500 - Internal Server Error
                     response.setStatus(500);
                     setErrorState(ErrorState.CLOSE_CLEAN, t);
-                    getAdapter().log(request, response, 0);
+                    getAdapter().logNanos(request, response, 0);
                 }
             }
 
@@ -787,7 +788,7 @@ public class Http11Processor extends AbstractProcessor {
         parseHost(hostValueMB);
 
         if (!getErrorState().isIoAllowed()) {
-            getAdapter().log(request, response, 0);
+            getAdapter().logNanos(request, response, 0);
         }
     }
 

--- a/java/org/apache/coyote/http2/StreamProcessor.java
+++ b/java/org/apache/coyote/http2/StreamProcessor.java
@@ -469,6 +469,7 @@ class StreamProcessor extends AbstractProcessor implements NonPipeliningProcesso
     }
 
 
+    @SuppressWarnings("deprecation")
     @Override
     public final SocketState service(SocketWrapperBase<?> socket) throws IOException {
         try {
@@ -476,7 +477,7 @@ class StreamProcessor extends AbstractProcessor implements NonPipeliningProcesso
                 adapter.service(request, response);
             } else {
                 response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-                adapter.log(request, response, 0);
+                adapter.logNanos(request, response, 0);
                 setErrorState(ErrorState.CLOSE_CLEAN, null);
             }
         } catch (Exception e) {

--- a/test/org/apache/catalina/valves/TesterAccessLogValve.java
+++ b/test/org/apache/catalina/valves/TesterAccessLogValve.java
@@ -19,7 +19,6 @@ package org.apache.catalina.valves;
 import java.io.IOException;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.TimeUnit;
 
 import javax.servlet.ServletException;
 
@@ -45,7 +44,7 @@ public class TesterAccessLogValve extends ValveBase implements AccessLog {
 
     @Override
     public void log(Request request, Response response, long time) {
-        entries.add(new Entry(request.getRequestURI(), response.getStatus(), TimeUnit.NANOSECONDS.toMillis(time)));
+        entries.add(new Entry(request.getRequestURI(), response.getStatus(), time));
     }
 
     @Override

--- a/test/org/apache/catalina/valves/TesterAccessLogValve.java
+++ b/test/org/apache/catalina/valves/TesterAccessLogValve.java
@@ -19,6 +19,7 @@ package org.apache.catalina.valves;
 import java.io.IOException;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
 
 import javax.servlet.ServletException;
 
@@ -44,7 +45,7 @@ public class TesterAccessLogValve extends ValveBase implements AccessLog {
 
     @Override
     public void log(Request request, Response response, long time) {
-        entries.add(new Entry(request.getRequestURI(), response.getStatus(), time));
+        entries.add(new Entry(request.getRequestURI(), response.getStatus(), TimeUnit.NANOSECONDS.toMillis(time)));
     }
 
     @Override

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -128,6 +128,10 @@
       <fix>
         Further performance improvements for ParameterMap. (jengebr/markt)
       </fix>
+      <scode>
+        Refactor access log time stamps to be based on the <code>Instant</code>
+        request processing starts. (markt)
+      </scode>
     </changelog>
   </subsection>
   <subsection name="Coyote">


### PR DESCRIPTION
Adding nanosecond resolution to the access log for 9.0.x is non-trivial because all the interface methods for access logging expect request duration to be passed in milliseconds.

The current state of 9.0.x is that some preparatory commits have been applied that should not change the current behaviour although they do add a little overhead.

I think we have three options:
1. Don't provide nanosecond resolution to the access logs for 9.0.x. Revert the preparatory commits.
2. Apply just the first of the commits in this PR. This is less invasive BUT changes nearly all of the various interface methods for access logging from milliseconds to nanoseconds. This might have backwards compatibility issues for some users although the most likely point of extension - custom access logging - is implemented so that they should be compatible.
3. Apply both commits in this PR. It is more invasive but should be backwards compatible for everyone.

Regardless of what we do with this PR, we have changed the meaning of request duration in the interface methods for access logging between 9.0.x and 10.1.x (actually 10.0.x). That decision has already been made so we just have to live with it.

If we adopt option 2 or 3, there will likely be a clean-up commit afterwards to mark various unused methods as deprecated in 9.0.x to 11.0.x and remove them in 12.0.x