### PR TITLE
Add virtual thread attribute to WsWebSocketContainer

### DIFF
--- a/java/org/apache/tomcat/websocket/WsWebSocketContainer.java
+++ b/java/org/apache/tomcat/websocket/WsWebSocketContainer.java
@@ -305,7 +305,11 @@ public class WsWebSocketContainer implements WebSocketContainer, BackgroundProce
                 // proxy CONNECT, need to use TLS from this point on so wrap the
                 // original AsynchronousSocketChannel
                 SSLEngine sslEngine = createSSLEngine(clientEndpointConfiguration, host, port);
-                channel = new AsyncChannelWrapperSecure(socketChannel, sslEngine);
+                if (useVirtualThreads()) {
+                    channel = new AsyncChannelWrapperSecure(socketChannel, sslEngine, virtualThreadExecutor);
+                } else {
+                    channel = new AsyncChannelWrapperSecure(socketChannel, sslEngine);
+                }
             } else if (channel == null) {
                 // Only need to wrap as this point if it wasn't wrapped to process a
                 // proxy CONNECT

--- a/java/org/apache/tomcat/websocket/WsWebSocketContainer.java
+++ b/java/org/apache/tomcat/websocket/WsWebSocketContainer.java
@@ -70,6 +70,7 @@ import org.apache.tomcat.InstanceManagerBindings;
 import org.apache.tomcat.util.buf.StringUtils;
 import org.apache.tomcat.util.collections.CaseInsensitiveKeyMap;
 import org.apache.tomcat.util.res.StringManager;
+import org.apache.tomcat.util.threads.VirtualThreadExecutor;
 
 public class WsWebSocketContainer implements WebSocketContainer, BackgroundProcess {
 
@@ -101,6 +102,8 @@ public class WsWebSocketContainer implements WebSocketContainer, BackgroundProce
     private int processPeriod = Constants.DEFAULT_PROCESS_PERIOD;
 
     private InstanceManager instanceManager;
+
+    private VirtualThreadExecutor virtualThreadExecutor;
 
     protected InstanceManager getInstanceManager(ClassLoader classLoader) {
         if (instanceManager != null) {
@@ -1010,6 +1013,10 @@ public class WsWebSocketContainer implements WebSocketContainer, BackgroundProce
                 }
             }
         }
+
+        if (useVirtualThreads()) {
+            virtualThreadExecutor.close();
+        }
     }
 
 
@@ -1026,6 +1033,18 @@ public class WsWebSocketContainer implements WebSocketContainer, BackgroundProce
             }
         }
         return result;
+    }
+
+    public void setUseVirtualThreads(boolean useVirtualThreads) {
+        if (useVirtualThreads) {
+            virtualThreadExecutor = new VirtualThreadExecutor("WebSocketClient-IO-");
+        } else {
+            virtualThreadExecutor = null;
+        }
+    }
+
+    public boolean useVirtualThreads() {
+        return virtualThreadExecutor != null;
     }
 
 


### PR DESCRIPTION
In my app, I use WsWebSocketContainer to create websocket client.
As the number of sessions increases, memory usage also increased. So "OOM Killed" occured frequently.
I know that It is a normal situation in thread-per-connection model which is current applied.
Current model have advantage that It is very intuitive and sometimes it behaves like kind of rate limiter.

But I think that threads for R/W may not working busy in some case.
Also platform thread will be created twice of session count and it allocate a lot of default stack memory.
furthermore context switching cost expensive too when using platform thread.

So I think that instead of create two platform thread per session, using virtual thread will be helpful in some cases.
Since I may not understand overall about websocket codes and architecture, I just create draft pull request.
Adding choice to use virtual threads would be helpful for optimizing memory usage.