### PR TITLE
Improve test feedback by logging the availability checks for OpenSSL and Tomcat Native libraries when they're missing

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2109,13 +2109,13 @@
   </target>
 
   <target name="test-nio" description="Runs the JUnit test cases for NIO. Does not stop on errors."
-          depends="-test-name-default,setup-jacoco,test-compile,deploy,test-openssl-exists" if="${execute.test.nio}">
+          depends="-test-name-default,setup-jacoco,test-compile,deploy,test-openssl-exists,test-tcnative-exists" if="${execute.test.nio}">
     <runtests protocol="org.apache.coyote.http11.Http11NioProtocol"
               extension=".NIO" />
   </target>
 
   <target name="test-only-nio" description="Runs the JUnit test cases or NIO without test preparations. Does not stop on errors."
-          depends="-test-name-default,setup-jacoco,test-openssl-exists" if="${execute.test.nio}">
+          depends="-test-name-default,setup-jacoco,test-openssl-exists,test-tcnative-exists" if="${execute.test.nio}">
     <runtests protocol="org.apache.coyote.http11.Http11NioProtocol"
               extension=".NIO" />
   </target>
@@ -2134,6 +2134,48 @@
         </and>
       </or>
     </condition>
+    <echo message="OpenSSL is not available. OpenSSL-related tests will be skipped or may fail." level="warning" unless:set="test.openssl.exists"/>
+  </target>
+
+  <target name="test-tcnative-exists" description="Verifies tomcat-native library can be loaded">
+    <!-- Check if main classes are built -->
+    <available file="${test.run.classes}/org/apache/tomcat/jni/Library.class"
+               property="tomcat.classes.available"/>
+
+    <!-- If main classes don't exist, compile just what we need -->
+    <mkdir dir="${test.run.classes}" unless:set="tomcat.classes.available"/>
+    <javac srcdir="java" destdir="${test.run.classes}"
+           includes="org/apache/tomcat/jni/Library.java,org/apache/tomcat/jni/LibraryNotFoundError.java"
+           debug="${compile.debug}"
+           includeantruntime="false"
+           encoding="UTF-8"
+           unless:set="tomcat.classes.available">
+      <compilerarg line="-Xlint:-options"/>
+    </javac>
+
+    <!-- Compile the test class -->
+    <mkdir dir="${test.classes}"/>
+    <javac srcdir="test" destdir="${test.classes}"
+           includes="org/apache/tomcat/jni/TesterLibraryLoad.java"
+           debug="${compile.debug}"
+           includeantruntime="false"
+           encoding="UTF-8">
+      <classpath>
+        <pathelement location="${test.run.classes}"/>
+        <pathelement location="${junit.jar}"/>
+      </classpath>
+    </javac>
+
+    <!-- Run test - it will check both test.apr.loc and system library paths -->
+    <junit printsummary="no" fork="yes" showoutput="false" haltonfailure="false"
+           failureproperty="test.tcnative.error" logfailedtests="false">
+      <jvmarg value="${runtests.librarypath}"/>
+      <jvmarg value="${native.nativeaccess}"/>
+      <classpath refid="tomcat.test.classpath"/>
+      <test name="org.apache.tomcat.jni.TesterLibraryLoad"/>
+    </junit>
+
+    <echo message="Tomcat Native is not available. Tomcat Native (JNI) tests will be skipped." if:set="test.tcnative.error" level="warning"/>
   </target>
 
   <target name="test-httpd-exists" description="Checks for the httpd binary">

--- a/test/org/apache/tomcat/jni/TesterLibraryLoad.java
+++ b/test/org/apache/tomcat/jni/TesterLibraryLoad.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tomcat.jni;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Simple test to verify tomcat-native library can be loaded.
+ */
+public class TesterLibraryLoad {
+
+    @Test
+    public void testLibraryLoads() throws Exception {
+        try {
+            Library.initialize(null);
+            Library.terminate();
+        } catch (LibraryNotFoundError e) {
+            // Library not available - fail test to set property
+            Assert.fail("Library not found");
+        }
+    }
+}

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -343,6 +343,13 @@
       <update>
         Update Derby to 10.17.1.0. (markt)
       </update>
+      <add>
+        Add warning when OpenSSL binary is not found. (csutherl)
+      </add>
+      <add>
+        Add check for Tomcat Native library, and log warning when it's not found
+        to make it easier to see when it's not used by the suite. (csutherl)
+      </add>
       <!-- Entries for backport and removal before 12.0.0-M1 below this line -->
     </changelog>
   </subsection>


### PR DESCRIPTION
When running the tests without OpenSSL or Tomcat Native installed, there are several things happening without a clear explanation (without having to dig into individual test outputs):

- OpenSSL cipher tests are silently excluded via build configuration
- Tomcat Native tests are skipped via `Assume.assumeTrue()` checks
- Users only see "Skipped: N" in test results, which requires looking into which were skipped
- There's no proactive feedback about these missing libraries

Adding a warning when the libraries are missing allows you to check the target output to confirm that natives are being included in the tests without prior knowledge of which tests would be skipped when they're missing.