### PR TITLE
fix: Escape directory labels in DefaultServlet HTML listings

### DIFF
--- a/java/org/apache/catalina/servlets/DefaultServlet.java
+++ b/java/org/apache/catalina/servlets/DefaultServlet.java
@@ -1769,6 +1769,7 @@ public class DefaultServlet extends HttpServlet {
         StringManager sm = StringManager.getManager(DefaultServlet.class.getPackageName(), request.getLocales());
 
         String directoryWebappPath = resource.getWebappPath();
+        String escapedDirectoryWebappPath = Escape.htmlElementContent(directoryWebappPath);
         WebResource[] entries = resources.listResources(directoryWebappPath);
 
         // rewriteUrl(contextPath) is expensive. cache result for later reuse
@@ -1779,7 +1780,7 @@ public class DefaultServlet extends HttpServlet {
         sb.append("<html lang=\"").append(sm.getLocale().getLanguage()).append("\">\r\n");
         sb.append("<head>\r\n");
         sb.append("<title>");
-        sb.append(sm.getString("defaultServlet.directory.title", directoryWebappPath));
+        sb.append(sm.getString("defaultServlet.directory.title", escapedDirectoryWebappPath));
         sb.append("</title>\r\n");
         sb.append("<style>");
         sb.append(org.apache.catalina.util.TomcatCSS.TOMCAT_CSS);
@@ -1787,7 +1788,7 @@ public class DefaultServlet extends HttpServlet {
         sb.append("</head>\r\n");
         sb.append("<body>\r\n");
         sb.append("<h1>");
-        sb.append(sm.getString("defaultServlet.directory.title", directoryWebappPath));
+        sb.append(sm.getString("defaultServlet.directory.title", escapedDirectoryWebappPath));
 
         // Render the link to our parent (if required)
         String parentDirectory = directoryWebappPath;
@@ -1808,7 +1809,7 @@ public class DefaultServlet extends HttpServlet {
             }
             sb.append("\">");
             sb.append("<b>");
-            sb.append(sm.getString("defaultServlet.directory.parent", parent));
+            sb.append(sm.getString("defaultServlet.directory.parent", Escape.htmlElementContent(parent)));
             sb.append("</b>");
             sb.append("</a>");
         }

--- a/test/org/apache/catalina/servlets/TestDefaultServlet.java
+++ b/test/org/apache/catalina/servlets/TestDefaultServlet.java
@@ -776,4 +776,43 @@ public class TestDefaultServlet extends TomcatBaseTest {
         client.processRequest(true);
         Assert.assertEquals(HttpServletResponse.SC_OK, client.getStatusCode());
     }
+
+    @Test
+    public void testDirectoryListingEscapesCurrentDirectoryName() throws Exception {
+        File appDir = new File(getTemporaryDirectory(), "listing-xss");
+        File webInf = new File(appDir, "WEB-INF");
+        File maliciousDir = new File(appDir, "<img src=x onerror=alert(1)>");
+        addDeleteOnTearDown(appDir);
+
+        if (!webInf.mkdirs() && !webInf.isDirectory()) {
+            Assert.fail("Unable to create directory [" + webInf + "]");
+        }
+        if (!maliciousDir.mkdirs() && !maliciousDir.isDirectory()) {
+            Assert.fail("Unable to create directory [" + maliciousDir + "]");
+        }
+
+        File index = new File(maliciousDir, "index.txt");
+        try (FileOutputStream fos = new FileOutputStream(index);
+                Writer w = new OutputStreamWriter(fos, "UTF-8")) {
+            w.write("owned\n");
+        }
+
+        Tomcat tomcat = getTomcatInstance();
+        Context ctxt = tomcat.addContext("", appDir.getAbsolutePath());
+
+        Wrapper defaultServlet = Tomcat.addServlet(ctxt, "default", new DefaultServlet());
+        defaultServlet.addInitParameter("listings", "true");
+        ctxt.addServletMappingDecoded("/", "default");
+
+        tomcat.start();
+
+        ByteChunk out = new ByteChunk();
+        int rc = getUrl("http://localhost:" + getPort() + "/%3Cimg%20src=x%20onerror=alert(1)%3E/", out, null);
+        Assert.assertEquals(HttpServletResponse.SC_OK, rc);
+
+        String body = out.toString();
+        Assert.assertFalse(body.contains("<title>Directory Listing For [/<img src=x onerror=alert(1)>/]</title>"));
+        Assert.assertFalse(body.contains("<h1>Directory Listing For [/<img src=x onerror=alert(1)>/]"));
+        Assert.assertTrue(body.contains("&lt;img src=x onerror=alert(1)&gt;"));
+    }
 }

--- a/test/org/apache/catalina/servlets/TestDefaultServlet.java
+++ b/test/org/apache/catalina/servlets/TestDefaultServlet.java
@@ -19,9 +19,12 @@ package org.apache.catalina.servlets;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -30,9 +33,13 @@ import java.util.Map;
 import java.util.TimeZone;
 
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
 
+import org.apache.catalina.WebResource;
+import org.apache.catalina.WebResourceRoot;
 import org.junit.Assert;
 import org.junit.Test;
+import org.easymock.EasyMock;
 
 import static org.apache.catalina.startup.SimpleHttpClient.CRLF;
 import org.apache.catalina.Context;
@@ -779,40 +786,31 @@ public class TestDefaultServlet extends TomcatBaseTest {
 
     @Test
     public void testDirectoryListingEscapesCurrentDirectoryName() throws Exception {
-        File appDir = new File(getTemporaryDirectory(), "listing-xss");
-        File webInf = new File(appDir, "WEB-INF");
-        File maliciousDir = new File(appDir, "<img src=x onerror=alert(1)>");
-        addDeleteOnTearDown(appDir);
+        DefaultServlet defaultServlet = new DefaultServlet();
 
-        if (!webInf.mkdirs() && !webInf.isDirectory()) {
-            Assert.fail("Unable to create directory [" + webInf + "]");
+        WebResourceRoot resourceRoot = EasyMock.createMock(WebResourceRoot.class);
+        WebResource resource = EasyMock.createMock(WebResource.class);
+        HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
+
+        EasyMock.expect(resource.getWebappPath()).andStubReturn("/<img src=x onerror=alert(1)>/child/");
+        EasyMock.expect(resourceRoot.listResources("/<img src=x onerror=alert(1)>/child/"))
+                .andReturn(new WebResource[0]);
+        EasyMock.expect(request.getLocales()).andStubReturn(Collections.enumeration(List.of(Locale.ENGLISH)));
+
+        EasyMock.replay(resourceRoot, resource, request);
+
+        defaultServlet.resources = resourceRoot;
+
+        String body;
+        try (InputStream is = defaultServlet.renderHtml(request, "", resource, null)) {
+            body = new String(is.readAllBytes(), StandardCharsets.UTF_8);
         }
-        if (!maliciousDir.mkdirs() && !maliciousDir.isDirectory()) {
-            Assert.fail("Unable to create directory [" + maliciousDir + "]");
-        }
 
-        File index = new File(maliciousDir, "index.txt");
-        try (FileOutputStream fos = new FileOutputStream(index);
-                Writer w = new OutputStreamWriter(fos, "UTF-8")) {
-            w.write("owned\n");
-        }
+        EasyMock.verify(resourceRoot, resource, request);
 
-        Tomcat tomcat = getTomcatInstance();
-        Context ctxt = tomcat.addContext("", appDir.getAbsolutePath());
-
-        Wrapper defaultServlet = Tomcat.addServlet(ctxt, "default", new DefaultServlet());
-        defaultServlet.addInitParameter("listings", "true");
-        ctxt.addServletMappingDecoded("/", "default");
-
-        tomcat.start();
-
-        ByteChunk out = new ByteChunk();
-        int rc = getUrl("http://localhost:" + getPort() + "/%3Cimg%20src=x%20onerror=alert(1)%3E/", out, null);
-        Assert.assertEquals(HttpServletResponse.SC_OK, rc);
-
-        String body = out.toString();
-        Assert.assertFalse(body.contains("<title>Directory Listing For [/<img src=x onerror=alert(1)>/]</title>"));
-        Assert.assertFalse(body.contains("<h1>Directory Listing For [/<img src=x onerror=alert(1)>/]"));
+        Assert.assertFalse(body.contains("<title>Directory Listing For [/<img src=x onerror=alert(1)>/child/]</title>"));
+        Assert.assertFalse(body.contains("<h1>Directory Listing For [/<img src=x onerror=alert(1)>/child/]"));
+        Assert.assertFalse(body.contains("Up To [/<img src=x onerror=alert(1)>/]"));
         Assert.assertTrue(body.contains("&lt;img src=x onerror=alert(1)&gt;"));
     }
 }


### PR DESCRIPTION
## Summary

Escape the current directory label and parent label in `DefaultServlet` HTML directory listings.

This fixes a stored XSS issue in shared-hosting or otherwise untrusted-content deployments where directory listings are enabled and an attacker can influence listed directory names.

## Attack scenario

1. An untrusted content publisher can create directories under a served path.
2. Directory listings are enabled for that shared content root.
3. The attacker creates a directory named `<img src=x onerror=fetch('/manager/text/list',{credentials:'include'})>`.
4. An operator browses the listing page to inspect uploaded content.
5. Tomcat renders the directory name unescaped in the generated listing page.
6. The browser executes the injected JavaScript in the origin of that site.

## Changes

- escape the current directory label in the generated listing title and heading
- escape the parent directory label in the generated listing breadcrumb
- add a regression test for malicious directory labels in `TestDefaultServlet`

## Verification

- `ant test-compile test-only -Dtest.entry=org.apache.catalina.servlets.TestDefaultServlet`