### PR TITLE
pom: split compound licenses

### DIFF
--- a/res/maven/tomcat-jsp-api.pom
+++ b/res/maven/tomcat-jsp-api.pom
@@ -28,17 +28,27 @@
   <licenses>
     <license>
       <name>
-        Apache License, Version 2.0 and
-        Common Development And Distribution License (CDDL) Version 1.0
+        Apache License, Version 2.0
       </name>
       <url>
-        http://www.apache.org/licenses/LICENSE-2.0.txt and
-        http://www.opensource.org/licenses/cddl1.txt
+        http://www.apache.org/licenses/LICENSE-2.0.txt
       </url>
       <distribution>repo</distribution>
       <comments>
         The Apache License, version 2.0 applies to all files apart from
-        jsp_2_2.xsd to which the CDDL version 1.0 applies.
+        jsp_2_2.xsd.
+      </comments>
+    </license>
+    <license>
+      <name>
+        Common Development And Distribution License (CDDL) Version 1.0
+      </name>
+      <url>
+        http://www.opensource.org/licenses/cddl1.txt
+      </url>
+      <distribution>repo</distribution>
+      <comments>
+        The CDDL version 1.0 applies to jsp_2_2.xsd.
       </comments>
     </license>
   </licenses>

--- a/res/maven/tomcat-servlet-api.pom
+++ b/res/maven/tomcat-servlet-api.pom
@@ -28,12 +28,10 @@
   <licenses>
     <license>
       <name>
-        Apache License, Version 2.0 and
-        Common Development And Distribution License (CDDL) Version 1.0
+        Apache License, Version 2.0
       </name>
       <url>
-        http://www.apache.org/licenses/LICENSE-2.0.txt and
-        http://www.opensource.org/licenses/cddl1.txt
+        http://www.apache.org/licenses/LICENSE-2.0.txt
       </url>
       <distribution>repo</distribution>
       <comments>
@@ -46,8 +44,28 @@
         javaee_web_services_client_1_3.xsd,
         web-app_3_0.xsd,
         web-common_3_0.xsd,
-        web-fragment_3_0.xsd,
-        to which the CDDL version 1.0 applies.
+        and web-fragment_3_0.xsd.
+      </comments>
+    </license>
+    <license>
+      <name>
+        Common Development And Distribution License (CDDL) Version 1.0
+      </name>
+      <url>
+        http://www.opensource.org/licenses/cddl1.txt
+      </url>
+      <distribution>repo</distribution>
+      <comments>
+        The CDDL version 1.0 applies to
+        javaee_5.xsd,
+        javaee_6.xsd,
+        javaee_web_services_1_2.xsd,
+        javaee_web_services_client_1_2.xsd,
+        javaee_web_services_1_3.xsd,
+        javaee_web_services_client_1_3.xsd,
+        web-app_3_0.xsd,
+        web-common_3_0.xsd,
+        and web-fragment_3_0.xsd.
       </comments>
     </license>
   </licenses>


### PR DESCRIPTION
Combining the licenses creates invalid URLs:

```
<licenses>
  <license>
    <url>
      http://www.apache.org/licenses/LICENSE-2.0.txt and
      http://www.opensource.org/licenses/cddl1.txt
    </url>
  </license>
</licenses>
```

Compared to using separate entries for each license:

```
<licenses>
  <license>
    <url>
      http://www.apache.org/licenses/LICENSE-2.0.txt
    </url>
  </license>
  <license>
    <url>
      http://www.opensource.org/licenses/cddl1.txt
    </url>
  </license>
</licenses>
```

This breaks tools that validate the URLs, including BOM standards such as CycloneDX:

```
license.url: does not match the iri-reference pattern must be a valid RFC 3987 IRI-reference
```