### PR TITLE
Fix populate a malformed remote ip / host header value by remote ip valve (filter)

### DIFF
--- a/java/org/apache/catalina/filters/RemoteIpFilter.java
+++ b/java/org/apache/catalina/filters/RemoteIpFilter.java
@@ -884,10 +884,10 @@ public class RemoteIpFilter extends GenericFilter {
     }
 
     private boolean isValidRemoteIp(String value) {
-        // Valid chars of remote ip: 0123456789abcdeABCDE[]:
+        // Valid chars of remote ip: 0123456789abcdeABCDE[]:.-_
         for (char c : value.toCharArray()) {
-            if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'e') || (c >= 'A' && c <= 'E') || c == '[' || c == ']'
-                    || c == ':') {
+            if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '[' || c == ']'
+                    || c == ':' || c == '.' || c == '-' || c == '_') {
                 continue;
             } else {
                 return false;

--- a/java/org/apache/catalina/filters/RemoteIpFilter.java
+++ b/java/org/apache/catalina/filters/RemoteIpFilter.java
@@ -883,11 +883,20 @@ public class RemoteIpFilter extends GenericFilter {
         return false;
     }
 
-    private boolean isValidRemoteIp(String value) {
-        // Valid chars of remote ip: 0123456789abcdeABCDE[]:.-_
-        for (char c : value.toCharArray()) {
-            if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '[' || c == ']'
-                    || c == ':' || c == '.' || c == '-' || c == '_') {
+    /**
+     * Check the remote ip value with a basic syntax formating.
+     * @param remoteIp the header value from request
+     * @return <code>false</code> if the remote ip is null, empty, or malformed. Otherwise returns <code>true</code>
+     */
+    private boolean isValidRemoteIp(String remoteIp) {
+        if (remoteIp == null || remoteIp.isBlank()) {
+            return false;
+        }
+        // acceptable regular chars: 0-9/A-Z/a-z
+        // acceptable special chars: []:.-
+        for (char c : remoteIp.toCharArray()) {
+            if ((c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '[' || c == ']'
+                    || c == ':' || c == '.' || c == '-') {
                 continue;
             } else {
                 return false;

--- a/java/org/apache/catalina/filters/RemoteIpFilter.java
+++ b/java/org/apache/catalina/filters/RemoteIpFilter.java
@@ -726,8 +726,11 @@ public class RemoteIpFilter extends GenericFilter {
             // loop on remoteIpHeaderValue to find the first trusted remote ip and to build the proxies chain
             for (idx = remoteIpHeaderValue.length - 1; idx >= 0; idx--) {
                 String currentRemoteIp = remoteIpHeaderValue[idx];
+                if (!isValidRemoteIp(currentRemoteIp)) {
+                    // Ignore invalid remote ip header value
+                    continue;
+                }
                 remoteIp = currentRemoteIp;
-
                 if (isInternalProxy(currentRemoteIp)) {
                     // do nothing, internalProxies IPs are not appended to the
                 } else if (isTrustedProxy(currentRemoteIp)) {
@@ -878,6 +881,19 @@ public class RemoteIpFilter extends GenericFilter {
             log.debug(sm.getString("remoteIpFilter.invalidRemoteAddress", remoteIp), uhe);
         }
         return false;
+    }
+
+    private boolean isValidRemoteIp(String value) {
+        // Valid chars of remote ip: 0123456789abcdeABCDE[]:
+        for (char c : value.toCharArray()) {
+            if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'e') || (c >= 'A' && c <= 'E') || c == '[' || c == ']'
+                    || c == ':') {
+                continue;
+            } else {
+                return false;
+            }
+        }
+        return true;
     }
 
     /*

--- a/java/org/apache/catalina/valves/RemoteIpValve.java
+++ b/java/org/apache/catalina/valves/RemoteIpValve.java
@@ -555,6 +555,10 @@ public class RemoteIpValve extends ValveBase {
             // loop on remoteIpHeaderValue to find the first trusted remote ip and to build the proxies chain
             for (idx = remoteIpHeaderValue.length - 1; idx >= 0; idx--) {
                 String currentRemoteIp = remoteIpHeaderValue[idx];
+                if(!isValidRemoteIp(currentRemoteIp)) {
+                    // Ignore invalid remote ip header value
+                    continue;
+                }
                 remoteIp = currentRemoteIp;
                 if (isInternalProxy(currentRemoteIp)) {
                     // do nothing, internalProxies IPs are not appended to the
@@ -735,6 +739,18 @@ public class RemoteIpValve extends ValveBase {
             log.debug(sm.getString("remoteIpFilter.invalidRemoteAddress", remoteIp), uhe);
         }
         return false;
+    }
+
+    private boolean isValidRemoteIp(String value) {
+        // Valid chars of remote ip: 0123456789abcdeABCDE[]:
+        for (char c : value.toCharArray()) {
+            if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'e') || (c >= 'A' && c <= 'E') || c == '[' || c == ']'
+                    || c == ':') {
+            } else {
+                return false;
+            }
+        }
+        return true;
     }
 
     /*

--- a/java/org/apache/catalina/valves/RemoteIpValve.java
+++ b/java/org/apache/catalina/valves/RemoteIpValve.java
@@ -742,10 +742,11 @@ public class RemoteIpValve extends ValveBase {
     }
 
     private boolean isValidRemoteIp(String value) {
-        // Valid chars of remote ip: 0123456789abcdeABCDE[]:
+        // Valid chars of remote ip: 0123456789abcdeABCDE[]:.-_
         for (char c : value.toCharArray()) {
-            if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'e') || (c >= 'A' && c <= 'E') || c == '[' || c == ']'
-                    || c == ':') {
+            if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '[' || c == ']'
+                    || c == ':' || c == '.' || c == '-' || c == '_') {
+                continue;
             } else {
                 return false;
             }

--- a/java/org/apache/catalina/valves/RemoteIpValve.java
+++ b/java/org/apache/catalina/valves/RemoteIpValve.java
@@ -741,11 +741,20 @@ public class RemoteIpValve extends ValveBase {
         return false;
     }
 
-    private boolean isValidRemoteIp(String value) {
-        // Valid chars of remote ip: 0123456789abcdeABCDE[]:.-_
-        for (char c : value.toCharArray()) {
-            if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '[' || c == ']'
-                    || c == ':' || c == '.' || c == '-' || c == '_') {
+    /**
+     * Check the remote ip value with a basic syntax formating.
+     * @param remoteIp the header value from request
+     * @return <code>false</code> if the remote ip is null, empty, or malformed. Otherwise returns <code>true</code>
+     */
+    private boolean isValidRemoteIp(String remoteIp) {
+        if (remoteIp == null || remoteIp.isBlank()) {
+            return false;
+        }
+        // acceptable regular chars: 0-9/A-Z/a-z
+        // acceptable special chars: []:.-
+        for (char c : remoteIp.toCharArray()) {
+            if ((c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '[' || c == ']'
+                    || c == ':' || c == '.' || c == '-') {
                 continue;
             } else {
                 return false;

--- a/test/org/apache/catalina/filters/TestRemoteIpFilter.java
+++ b/test/org/apache/catalina/filters/TestRemoteIpFilter.java
@@ -559,6 +559,40 @@ public class TestRemoteIpFilter extends TomcatBaseTest {
     }
 
     @Test
+    public void testInvokeInvalidProxyInTheChain() throws Exception {
+        // PREPARE
+        FilterDef filterDef = new FilterDef();
+        filterDef.addInitParameter("internalProxies", "192.168.0.10/31");
+        filterDef.addInitParameter("trustedProxies", "200.0.0.1,200.0.0.2,200.0.0.3");
+        filterDef.addInitParameter("remoteIpHeader", "x-forwarded-for");
+        filterDef.addInitParameter("proxiesHeader", "x-forwarded-by");
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        request.setRemoteAddr("192.168.0.10");
+        request.setRemoteHost("remote-host-original-value");
+        request.setHeader("x-forwarded-for", "140.211.11.130, 200.0.0.1, untrusted-proxy, invalid-proxy 01, 200.0.0.2");
+
+        // TEST
+        HttpServletRequest actualRequest = testRemoteIpFilter(filterDef, request).getRequest();
+
+        // VERIFY
+        String actualXForwardedFor = actualRequest.getHeader("x-forwarded-for");
+        Assert.assertEquals("syntax invalid proxy should ignore, ip/host before untrusted-proxy must appear in x-forwarded-for", "140.211.11.130,200.0.0.1",
+                actualXForwardedFor);
+
+        String actualXForwardedBy = actualRequest.getHeader("x-forwarded-by");
+        Assert.assertEquals("syntax invalid proxy should ignore, ip/host after untrusted-proxy must appear in  x-forwarded-by", "200.0.0.2",
+                actualXForwardedBy);
+
+        String actualRemoteAddr = actualRequest.getRemoteAddr();
+        Assert.assertEquals("remoteAddr", "untrusted-proxy", actualRemoteAddr);
+
+        String actualRemoteHost = actualRequest.getRemoteHost();
+        Assert.assertEquals("remoteHost", "untrusted-proxy", actualRemoteHost);
+    }
+
+    @Test
     public void testInvokeXforwardedHost() throws Exception {
         // PREPARE
         FilterDef filterDef = new FilterDef();

--- a/test/org/apache/catalina/valves/TestRemoteIpValve.java
+++ b/test/org/apache/catalina/valves/TestRemoteIpValve.java
@@ -1103,6 +1103,34 @@ public class TestRemoteIpValve {
                 request.getAttribute(Globals.REQUEST_FORWARDED_ATTRIBUTE));
     }
 
+    @Test
+    public void testIgnoreInvalidRequestForwardedFor() throws Exception {
+
+        // PREPARE
+        RemoteIpValve remoteIpValve = new RemoteIpValve();
+        remoteIpValve.setRemoteIpHeader("x-forwarded-for");
+        remoteIpValve.setProtocolHeader("x-forwarded-proto");
+        RemoteAddrAndHostTrackerValve remoteAddrAndHostTrackerValve = new RemoteAddrAndHostTrackerValve();
+        remoteIpValve.setNext(remoteAddrAndHostTrackerValve);
+
+        Request request = new MockRequest(new org.apache.coyote.Request());
+        // client ip
+        request.setRemoteAddr("192.168.0.10");
+        request.setRemoteHost("192.168.0.10");
+        request.getCoyoteRequest().getMimeHeaders().addValue("x-forwarded-for").setString("140.211.11.130,\"proxy \"01");
+        // protocol
+        request.setServerPort(8080);
+        request.getCoyoteRequest().scheme().setString("http");
+
+        // TEST
+        remoteIpValve.invoke(request, null);
+
+        // VERIFY
+        Assert.assertEquals("org.apache.tomcat.request.forwarded", Boolean.TRUE,
+                request.getAttribute(Globals.REQUEST_FORWARDED_ATTRIBUTE));
+        Assert.assertEquals("Valid remote ip header expected", "140.211.11.130", request.getAttribute(AccessLog.REMOTE_ADDR_ATTRIBUTE));
+    }
+
     private void assertArrayEquals(String[] expected, String[] actual) {
         if (expected == null) {
             Assert.assertNull(actual);

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -210,6 +210,11 @@
         <bug>70000</bug>: fix duplication of special headers in the response
         after commit, following fix for <bug>69967</bug>. (remm)
       </fix>
+      <fix>
+        Fix remote ip/host header population in remote ip valve or filter,
+        ignore malformed header value. Those unexpected malformed remote ip/host
+        header value may mislead downstream components. Patch submitted by Chenjp.
+      </fix>
     </changelog>
   </subsection>
   <subsection name="Coyote">


### PR DESCRIPTION
Remote ip valve / filter may populate a malformed header value into request attribute without basic validation, those unexpected remote ip/host values may mislead downstream components.

Per de-facto standards, ignore malformed xff header rather than Raise 400.