### PR TITLE
Disable tolerantEol by default for HTTP/1.1 header parsing

### DIFF
--- a/java/org/apache/coyote/http11/Http11InputBuffer.java
+++ b/java/org/apache/coyote/http11/Http11InputBuffer.java
@@ -152,7 +152,7 @@ public class Http11InputBuffer implements InputBuffer, ApplicationBufferHandler,
         parsingRequestLineQPos = -1;
 
         parsingHeader = true;
-        httpHeaderParser = new HttpHeaderParser(this, request.getMimeHeaders(), true);
+        httpHeaderParser = new HttpHeaderParser(this, request.getMimeHeaders(), false);
 
         swallowInput = true;
 

--- a/test/org/apache/coyote/http11/TestHttp11InputBuffer.java
+++ b/test/org/apache/coyote/http11/TestHttp11InputBuffer.java
@@ -197,7 +197,11 @@ public class TestHttp11InputBuffer extends TomcatBaseTest {
                 continue;
             }
             if (i == '\n') {
-                // LF is the optional line terminator
+                // LF is no longer accepted as a line terminator
+                // (tolerantEol is now false). Treat as invalid control char.
+                doTestBug51557InvalidCharInValue((char) i);
+                tearDown();
+                setUp();
                 continue;
             }
             doTestBug51557InvalidCharInValue((char) i);

--- a/test/org/apache/coyote/http11/TestHttp11InputBufferCRLF.java
+++ b/test/org/apache/coyote/http11/TestHttp11InputBufferCRLF.java
@@ -81,9 +81,14 @@ public class TestHttp11InputBufferCRLF extends TomcatBaseTest {
                 "GET /test?a=<b HTTP/1.1" + CRLF + "Host: localhost:8080" + CRLF + "Connection: close" + CRLF + CRLF,
                 Boolean.FALSE, parameterSets);
 
-        // Standard HTTP/1.1 request using LF rather than CRLF
+        // Standard HTTP/1.1 request using LF rather than CRLF - reject for
+        // strict RFC 7230 compliance. While RFC 7230 Section 3.5 permits
+        // recipients to accept bare LF, accepting it by default creates a
+        // security risk (HTTP Header Injection / Request Smuggling) when
+        // Tomcat is deployed behind a reverse proxy that enforces strict
+        // CRLF parsing.
         addRequestWithSplits("GET /test HTTP/1.1" + LF + "Host: localhost:8080" + LF + "Connection: close" + LF + LF,
-                parameterSets);
+                Boolean.FALSE, parameterSets);
 
         // Invalid HTTP/1.1 request using CR rather than CRLF
         addRequestWithSplits("GET /test HTTP/1.1" + CR + "Host: localhost:8080" + CR + "Connection: close" + CR + CR,


### PR DESCRIPTION
Change Http11InputBuffer to construct HttpHeaderParser with tolerantEol=false instead of true, requiring strict CRLF line endings in HTTP headers per RFC 7230.

While RFC 7230 Section 3.5 permits recipients to accept bare LF as a line terminator, doing so by default creates a security risk when Tomcat is deployed behind a reverse proxy (nginx, AWS ALB, Cloudflare, etc.) that enforces strict CRLF parsing.

In this common deployment topology, the proxy and Tomcat interpret the same raw bytes differently: the proxy sees one header value (containing the bare LF), while Tomcat's tolerantEol=true parses the bare LF as a header separator, splitting it into two headers. This semantic discrepancy enables:

- HTTP Header Injection via bare LF in header values
- Trust header forgery (X-Forwarded-For, X-Real-IP, etc.)
- Potential HTTP Request Smuggling with strict-CRLF proxies

This change only affects header parsing. Request line parsing in Http11InputBuffer.parseRequestLine() accepts bare LF independently (for HTTP/1.0 compatibility) and is not affected.

Trailer headers in ChunkedInputFilter already use
tolerantEol=false and are not affected.

Impact: Non-conforming clients that send bare LF in headers will receive a 400 response. Modern clients and proxies all use CRLF.