### PR TITLE
Add access-log pattern: %%, align %{xxx}D with %{xxx}T

### DIFF
--- a/java/org/apache/catalina/valves/AbstractAccessLogValve.java
+++ b/java/org/apache/catalina/valves/AbstractAccessLogValve.java
@@ -1578,17 +1578,6 @@ public abstract class AbstractAccessLogValve extends ValveBase implements Access
             this.style = style;
         }
 
-        /**
-         * Creates a new ElapsedTimeElement that will log the time in the specified style.
-         *
-         * @param micros <code>true</code>, write time in microseconds - %D
-         * @param millis <code>true</code>, write time in milliseconds, if both arguments are <code>false</code>, write
-         *                   time in seconds - %T
-         */
-        public ElapsedTimeElement(boolean micros, boolean millis) {
-            this(micros ? Style.MICROSECONDS : millis ? Style.MILLISECONDS : Style.SECONDS);
-        }
-
         @Override
         public void addElement(CharArrayWriter buf, Request request, Response response, long time) {
             style.append(buf, time);
@@ -2115,6 +2104,15 @@ public abstract class AbstractAccessLogValve extends ValveBase implements Access
         return switch (pattern) {
             case 'a' -> new RemoteAddrElement(name);
             case 'c' -> new CookieElement(name);
+            case 'D' ->
+                    switch (name) {
+                        case "ns" -> new ElapsedTimeElement(ElapsedTimeElement.Style.NANOSECONDS);
+                        case "ms" -> new ElapsedTimeElement(ElapsedTimeElement.Style.MILLISECONDS);
+                        case "us" -> new ElapsedTimeElement(ElapsedTimeElement.Style.MICROSECONDS);
+                        case "s"  -> new ElapsedTimeElement(ElapsedTimeElement.Style.SECONDS);
+                        case "fracsec" -> new ElapsedTimeElement(ElapsedTimeElement.Style.SECONDS_FRACTIONAL);
+                        case null, default -> new StringElement("???" + name + "???");
+                    };
             case 'i' -> new HeaderElement(name);
             case 'L' -> new IdentifierElement(name);
             case 'o' -> new ResponseHeaderElement(name);
@@ -2133,8 +2131,9 @@ public abstract class AbstractAccessLogValve extends ValveBase implements Access
                         case "ns" -> new ElapsedTimeElement(ElapsedTimeElement.Style.NANOSECONDS);
                         case "us" -> new ElapsedTimeElement(ElapsedTimeElement.Style.MICROSECONDS);
                         case "ms" -> new ElapsedTimeElement(ElapsedTimeElement.Style.MILLISECONDS);
+                        case "s"  -> new ElapsedTimeElement(ElapsedTimeElement.Style.SECONDS);
                         case "fracsec" -> new ElapsedTimeElement(ElapsedTimeElement.Style.SECONDS_FRACTIONAL);
-                        case null, default -> new ElapsedTimeElement(false, false);
+                        case null, default -> new StringElement("???" + name + "???");
                     };
             default -> new StringElement("???");
         };
@@ -2149,11 +2148,12 @@ public abstract class AbstractAccessLogValve extends ValveBase implements Access
      */
     protected AccessLogElement createAccessLogElement(char pattern) {
         return switch (pattern) {
+            case '%' -> new StringElement("%");
             case 'a' -> new RemoteAddrElement();
             case 'A' -> new LocalAddrElement(ipv6Canonical);
             case 'b' -> new ByteSentElement(true);
             case 'B' -> new ByteSentElement(false);
-            case 'D' -> new ElapsedTimeElement(true, false);
+            case 'D' -> new ElapsedTimeElement(ElapsedTimeElement.Style.MICROSECONDS);
             case 'F' -> new FirstByteTimeElement();
             case 'h' -> new HostElement();
             case 'H' -> new ProtocolElement();
@@ -2165,7 +2165,7 @@ public abstract class AbstractAccessLogValve extends ValveBase implements Access
             case 's' -> new HttpStatusCodeElement();
             case 'S' -> new SessionIdElement();
             case 't' -> new DateAndTimeElement();
-            case 'T' -> new ElapsedTimeElement(false, false);
+            case 'T' -> new ElapsedTimeElement(ElapsedTimeElement.Style.SECONDS);
             case 'u' -> new UserElement();
             case 'U' -> new RequestURIElement();
             case 'v' -> new LocalServerNameElement();

--- a/java/org/apache/catalina/valves/ExtendedAccessLogValve.java
+++ b/java/org/apache/catalina/valves/ExtendedAccessLogValve.java
@@ -520,7 +520,7 @@ public class ExtendedAccessLogValve extends AccessLogValve {
                                 case "ms" -> new ElapsedTimeElement(ElapsedTimeElement.Style.MILLISECONDS);
                                 case "s"  -> new ElapsedTimeElement(ElapsedTimeElement.Style.SECONDS);
                                 case "fracsec" -> new ElapsedTimeElement(ElapsedTimeElement.Style.SECONDS_FRACTIONAL);
-                                case null, default -> new StringElement("???");
+                                case null, default -> new StringElement("???" + nextToken + "???");
                             };
                         } else {
                             return new ElapsedTimeElement(ElapsedTimeElement.Style.SECONDS);

--- a/java/org/apache/catalina/valves/ExtendedAccessLogValve.java
+++ b/java/org/apache/catalina/valves/ExtendedAccessLogValve.java
@@ -518,8 +518,9 @@ public class ExtendedAccessLogValve extends AccessLogValve {
                                 case "ns" -> new ElapsedTimeElement(ElapsedTimeElement.Style.NANOSECONDS);
                                 case "us" -> new ElapsedTimeElement(ElapsedTimeElement.Style.MICROSECONDS);
                                 case "ms" -> new ElapsedTimeElement(ElapsedTimeElement.Style.MILLISECONDS);
+                                case "s"  -> new ElapsedTimeElement(ElapsedTimeElement.Style.SECONDS);
                                 case "fracsec" -> new ElapsedTimeElement(ElapsedTimeElement.Style.SECONDS_FRACTIONAL);
-                                case null, default -> new ElapsedTimeElement(ElapsedTimeElement.Style.SECONDS);
+                                case null, default -> new StringElement("???");
                             };
                         } else {
                             return new ElapsedTimeElement(ElapsedTimeElement.Style.SECONDS);

--- a/test/org/apache/catalina/valves/TestAccessLogValve.java
+++ b/test/org/apache/catalina/valves/TestAccessLogValve.java
@@ -90,6 +90,7 @@ public class TestAccessLogValve extends TomcatBaseTest {
     public static Collection<Object[]> parameters() {
         List<Object[]> parameterSets = new ArrayList<>();
 
+        parameterSets.add(new Object[] {"pct-pct", TEXT_TYPE, "/", "%%", "%"});
         parameterSets.add(new Object[] {"pct-a", TEXT_TYPE, "/", "%a", LOCAL_IP_PATTERN});
         parameterSets.add(new Object[] {"pct-a", JSON_TYPE, "/", "%a", "\\{\"remoteAddr\":\"" + LOCAL_IP_PATTERN + "\"\\}"});
         parameterSets.add(new Object[] {"pct-A", TEXT_TYPE, "/", "%A", IP_PATTERN});

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -250,7 +250,7 @@
       </add>
       <add>
         Add <code>%%</code> in AccessLogValve pattern. Align <code>%{xxx}D</code> modifiers with <code>%{xxx}T</code>.
-        Pull request #yyy provided by effhaa.
+        Pull request #1002 provided by effhaa.
       </add>
     </changelog>
   </subsection>

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -248,6 +248,10 @@
         <code>false</code>, meaning user names are treated in a case insensitive
         manner. (markt)
       </add>
+      <add>
+        Add <code>%%</code> in AccessLogValve pattern. Align <code>%{xxx}D</code> modifiers with <code>%{xxx}T</code>.
+        Pull request #yyy provided by effhaa.
+      </add>
     </changelog>
   </subsection>
   <subsection name="Coyote">
@@ -358,7 +362,7 @@
       </add>
       <add>
         Extend the existing <code>+=</code> operator in Jakarta Expression
-        Language to support merging <code>Map</code>Map and <code>Set</code>Set
+        Language to support merging <code>Map</code> and <code>Set</code>
         and concatenating <code>List</code>s. (markt)
       </add>
       <update>
@@ -494,4 +498,3 @@
 </section>
 </body>
 </document>
-

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -250,7 +250,7 @@
       </add>
       <add>
         Add <code>%%</code> in AccessLogValve pattern. Align <code>%{xxx}D</code> modifiers with <code>%{xxx}T</code>.
-        Pull request #1002 provided by effhaa.
+        Pull request <pr>1002</pr> provided by effhaa.
       </add>
     </changelog>
   </subsection>

--- a/webapps/docs/config/valve.xml
+++ b/webapps/docs/config/valve.xml
@@ -282,12 +282,13 @@
     the current request and response.  The following pattern codes are
     supported:</p>
     <ul>
+    <li><b><code>%%</code></b> - Literal '%' character</li>
     <li><b><code>%a</code></b> - Remote IP address.
         See also <code>%{xxx}a</code> below.</li>
     <li><b><code>%A</code></b> - Local IP address</li>
     <li><b><code>%b</code></b> - Bytes sent, excluding HTTP headers, or '-' if zero</li>
     <li><b><code>%B</code></b> - Bytes sent, excluding HTTP headers</li>
-    <li><b><code>%D</code></b> - Time taken to process the request in microseconds</li>
+    <li><b><code>%D</code></b> - Time taken to process the request, in microseconds</li>
     <li><b><code>%F</code></b> - Time taken to commit the response, in milliseconds</li>
     <li><b><code>%h</code></b> - Remote host name (or IP address if
         <code>enableLookups</code> for the connector is false)</li>


### PR DESCRIPTION
- Support for <code>%%</code> in access-log format string, as in Apache httpd.
- Support for {xxx} modifiers in <code>%D</code> pattern (undocumented).

Down-version PR forthcoming.