### PR TITLE
11.0.x of PR#1002: Add access-log pattern: %%

### DIFF
--- a/java/org/apache/catalina/valves/AbstractAccessLogValve.java
+++ b/java/org/apache/catalina/valves/AbstractAccessLogValve.java
@@ -1624,17 +1624,6 @@ public abstract class AbstractAccessLogValve extends ValveBase implements Access
             this.style = style;
         }
 
-        /**
-         * Creates a new ElapsedTimeElement that will log the time in the specified style.
-         *
-         * @param micros <code>true</code>, write time in microseconds - %D
-         * @param millis <code>true</code>, write time in milliseconds, if both arguments are <code>false</code>, write
-         *                   time in seconds - %T
-         */
-        public ElapsedTimeElement(boolean micros, boolean millis) {
-            this(micros ? Style.MICROSECONDS : millis ? Style.MILLISECONDS : Style.SECONDS);
-        }
-
         @Override
         public void addElement(CharArrayWriter buf, Request request, Response response, long time) {
             style.append(buf, time);
@@ -2166,6 +2155,20 @@ public abstract class AbstractAccessLogValve extends ValveBase implements Access
                 return new RemoteAddrElement(name);
             case 'c':
                 return new CookieElement(name);
+            case 'D':
+                if ("ns".equals(name)) {
+                    return new ElapsedTimeElement(ElapsedTimeElement.Style.NANOSECONDS);
+                } else if ("us".equals(name)) {
+                    return new ElapsedTimeElement(ElapsedTimeElement.Style.MICROSECONDS);
+                } else if ("ms".equals(name)) {
+                    return new ElapsedTimeElement(ElapsedTimeElement.Style.MILLISECONDS);
+                } else if ("s".equals(name)) {
+                    return new ElapsedTimeElement(ElapsedTimeElement.Style.SECONDS);
+                } else if ("fracsec".equals(name)) {
+                    return new ElapsedTimeElement(ElapsedTimeElement.Style.SECONDS_FRACTIONAL);
+                } else {
+                    return new StringElement("???" + name + "???");
+                }
             case 'i':
                 return new HeaderElement(name);
             case 'L':
@@ -2191,10 +2194,12 @@ public abstract class AbstractAccessLogValve extends ValveBase implements Access
                     return new ElapsedTimeElement(ElapsedTimeElement.Style.MICROSECONDS);
                 } else if ("ms".equals(name)) {
                     return new ElapsedTimeElement(ElapsedTimeElement.Style.MILLISECONDS);
+                } else if ("s".equals(name)) {
+                    return new ElapsedTimeElement(ElapsedTimeElement.Style.SECONDS);
                 } else if ("fracsec".equals(name)) {
                     return new ElapsedTimeElement(ElapsedTimeElement.Style.SECONDS_FRACTIONAL);
                 } else {
-                    return new ElapsedTimeElement(false, false);
+                    return new StringElement("???" + name + "???");
                 }
             default:
                 return new StringElement("???");
@@ -2210,6 +2215,8 @@ public abstract class AbstractAccessLogValve extends ValveBase implements Access
      */
     protected AccessLogElement createAccessLogElement(char pattern) {
         switch (pattern) {
+            case '%':
+                return new StringElement("%");
             case 'a':
                 return new RemoteAddrElement();
             case 'A':
@@ -2219,7 +2226,7 @@ public abstract class AbstractAccessLogValve extends ValveBase implements Access
             case 'B':
                 return new ByteSentElement(false);
             case 'D':
-                return new ElapsedTimeElement(true, false);
+                return new ElapsedTimeElement(ElapsedTimeElement.Style.MICROSECONDS);
             case 'F':
                 return new FirstByteTimeElement();
             case 'h':
@@ -2243,7 +2250,7 @@ public abstract class AbstractAccessLogValve extends ValveBase implements Access
             case 't':
                 return new DateAndTimeElement();
             case 'T':
-                return new ElapsedTimeElement(false, false);
+                return new ElapsedTimeElement(ElapsedTimeElement.Style.SECONDS);
             case 'u':
                 return new UserElement();
             case 'U':

--- a/java/org/apache/catalina/valves/ExtendedAccessLogValve.java
+++ b/java/org/apache/catalina/valves/ExtendedAccessLogValve.java
@@ -518,10 +518,12 @@ public class ExtendedAccessLogValve extends AccessLogValve {
                             return new ElapsedTimeElement(ElapsedTimeElement.Style.MICROSECONDS);
                         } else if ("ms".equals(nextToken)) {
                             return new ElapsedTimeElement(ElapsedTimeElement.Style.MILLISECONDS);
+                        } else if ("s".equals(nextToken)) {
+                            return new ElapsedTimeElement(ElapsedTimeElement.Style.SECONDS);
                         } else if ("fracsec".equals(nextToken)) {
                             return new ElapsedTimeElement(ElapsedTimeElement.Style.SECONDS_FRACTIONAL);
                         } else {
-                            return new ElapsedTimeElement(ElapsedTimeElement.Style.SECONDS);
+                            return new StringElement("???" + nextToken + "???");
                         }
                     } else {
                         return new ElapsedTimeElement(ElapsedTimeElement.Style.SECONDS);

--- a/test/org/apache/catalina/valves/TestAccessLogValve.java
+++ b/test/org/apache/catalina/valves/TestAccessLogValve.java
@@ -90,6 +90,7 @@ public class TestAccessLogValve extends TomcatBaseTest {
     public static Collection<Object[]> parameters() {
         List<Object[]> parameterSets = new ArrayList<>();
 
+        parameterSets.add(new Object[] {"pct-pct", TEXT_TYPE, "/", "%%", "%"});
         parameterSets.add(new Object[] {"pct-a", TEXT_TYPE, "/", "%a", LOCAL_IP_PATTERN});
         parameterSets.add(new Object[] {"pct-a", JSON_TYPE, "/", "%a", "\\{\"remoteAddr\":\"" + LOCAL_IP_PATTERN + "\"\\}"});
         parameterSets.add(new Object[] {"pct-A", TEXT_TYPE, "/", "%A", IP_PATTERN});

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -169,6 +169,10 @@
         <code>false</code>, meaning user names are treated in a case insensitive
         manner. (markt)
       </add>
+      <add>
+        Add <code>%%</code> in AccessLogValve pattern. Align <code>%{xxx}D</code> modifiers with <code>%{xxx}T</code>.
+        Pull request <pr>1003</pr> provided by effhaa.
+      </add>
     </changelog>
   </subsection>
   <subsection name="Coyote">
@@ -5649,4 +5653,3 @@
 </section>
 </body>
 </document>
-

--- a/webapps/docs/config/valve.xml
+++ b/webapps/docs/config/valve.xml
@@ -282,6 +282,7 @@
     the current request and response.  The following pattern codes are
     supported:</p>
     <ul>
+    <li><b><code>%%</code></b> - Literal '%' character</li>
     <li><b><code>%a</code></b> - Remote IP address.
         See also <code>%{xxx}a</code> below.</li>
     <li><b><code>%A</code></b> - Local IP address</li>

--- a/webapps/docs/config/valve.xml
+++ b/webapps/docs/config/valve.xml
@@ -288,7 +288,7 @@
     <li><b><code>%A</code></b> - Local IP address</li>
     <li><b><code>%b</code></b> - Bytes sent, excluding HTTP headers, or '-' if zero</li>
     <li><b><code>%B</code></b> - Bytes sent, excluding HTTP headers</li>
-    <li><b><code>%D</code></b> - Time taken to process the request in microseconds</li>
+    <li><b><code>%D</code></b> - Time taken to process the request, in microseconds</li>
     <li><b><code>%F</code></b> - Time taken to commit the response, in milliseconds</li>
     <li><b><code>%h</code></b> - Remote host name (or IP address if
         <code>enableLookups</code> for the connector is false)</li>


### PR DESCRIPTION
- Support for `%%` in access-log format string, as in Apache httpd.
- Support for `{xxx}` modifiers in `%D` pattern (undocumented).
- Test-case for `%%` pattern in log format.

Back port of PR#1002 for <= 11.0.x