### PR TITLE
9.0.x of PR#1002: Add access-log pattern: %%

### DIFF
--- a/java/org/apache/catalina/valves/AbstractAccessLogValve.java
+++ b/java/org/apache/catalina/valves/AbstractAccessLogValve.java
@@ -2040,6 +2040,8 @@ public abstract class AbstractAccessLogValve extends ValveBase implements Access
      */
     protected AccessLogElement createAccessLogElement(char pattern) {
         switch (pattern) {
+            case '%':
+                return new StringElement("%");
             case 'a':
                 return new RemoteAddrElement();
             case 'A':

--- a/test/org/apache/catalina/valves/TestAccessLogValve.java
+++ b/test/org/apache/catalina/valves/TestAccessLogValve.java
@@ -90,6 +90,7 @@ public class TestAccessLogValve extends TomcatBaseTest {
     public static Collection<Object[]> parameters() {
         List<Object[]> parameterSets = new ArrayList<>();
 
+        parameterSets.add(new Object[] {"pct-pct", TEXT_TYPE, "/", "%%", "%"});
         parameterSets.add(new Object[] {"pct-a", TEXT_TYPE, "/", "%a", LOCAL_IP_PATTERN});
         parameterSets.add(new Object[] {"pct-a", JSON_TYPE, "/", "%a", "\\{\"remoteAddr\":\"" + LOCAL_IP_PATTERN + "\"\\}"});
         parameterSets.add(new Object[] {"pct-A", TEXT_TYPE, "/", "%A", IP_PATTERN});

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -169,6 +169,10 @@
         <code>false</code>, meaning user names are treated in a case insensitive
         manner. (markt)
       </add>
+      <add>
+        Add <code>%%</code> in AccessLogValve pattern.
+        Pull request <pr>1004</pr> provided by effhaa.
+      </add>
     </changelog>
   </subsection>
   <subsection name="Coyote">
@@ -18287,4 +18291,3 @@
 </section>
 </body>
 </document>
-

--- a/webapps/docs/config/valve.xml
+++ b/webapps/docs/config/valve.xml
@@ -282,12 +282,13 @@
     the current request and response.  The following pattern codes are
     supported:</p>
     <ul>
+    <li><b><code>%%</code></b> - Literal '%' character</li>
     <li><b><code>%a</code></b> - Remote IP address.
         See also <code>%{xxx}a</code> below.</li>
     <li><b><code>%A</code></b> - Local IP address</li>
     <li><b><code>%b</code></b> - Bytes sent, excluding HTTP headers, or '-' if zero</li>
     <li><b><code>%B</code></b> - Bytes sent, excluding HTTP headers</li>
-    <li><b><code>%D</code></b> - Time taken to process the request in millis. Note: In
+    <li><b><code>%D</code></b> - Time taken to process the request, in millis. Note: In
         httpd %D is microseconds. Behaviour will be aligned to httpd
         in Tomcat 10 onwards.</li>
     <li><b><code>%F</code></b> - Time taken to commit the response, in milliseconds</li>


### PR DESCRIPTION
- Support for `%%` in access-log format string, as in Apache httpd.
- Test-case for `%%` pattern in log format.

Back port of PR#1002 for = 9.0.x