### PR TITLE
Add explicit read-only permissions to CI workflows

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -20,6 +20,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   LC_ALL: en_US.UTF-8
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   LC_ALL: en_US.UTF-8
 

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -20,6 +20,9 @@ on:
   schedule:
     - cron: 53 5 * * 0
 
+permissions:
+  contents: read
+
 jobs:
   coverity:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,6 +20,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   LC_ALL: en_US.UTF-8
 
@@ -48,4 +51,3 @@ jobs:
 
       continue-on-error:
         false
-


### PR DESCRIPTION
## Summary
- Add explicit workflow `permissions` blocks to:
  - `.github/workflows/ci.yml`
  - `.github/workflows/ci-macos.yml`
  - `.github/workflows/coverity.yml`
  - `.github/workflows/validate.yml`
- Set each workflow to least privilege with `contents: read`.

## Why
These workflows only need repository read access for checkout and build/test tasks. Explicit permissions improve GitHub Actions hardening and avoid relying on broader default token scopes.