### PR TITLE
Fix implicit type‑conversion precision issues in equalsIgnoreCase

### DIFF
--- a/java/org/apache/tomcat/util/buf/ByteChunk.java
+++ b/java/org/apache/tomcat/util/buf/ByteChunk.java
@@ -705,7 +705,7 @@ public final class ByteChunk extends AbstractChunk {
         }
         int off = start;
         for (int i = 0; i < len; i++) {
-            if (Ascii.toLower(b[off++]) != Ascii.toLower(s.charAt(i))) {
+            if (s.charAt(i) > 0xff || Ascii.toLower(b[off++]) != Ascii.toLower(s.charAt(i))) {
                 return false;
             }
         }

--- a/test/org/apache/tomcat/util/buf/TestByteChunk.java
+++ b/test/org/apache/tomcat/util/buf/TestByteChunk.java
@@ -143,6 +143,14 @@ public class TestByteChunk {
         Assert.assertEquals(-1, ByteChunk.findBytes(bytes, 2, 5, new byte[] { 'w' }));
     }
 
+    @Test
+    public void testEqualsIgnoreCase() {
+        byte[] bytes = "Hello".getBytes();
+        ByteChunk bc = new ByteChunk();
+        bc.setBytes(bytes, 0, bytes.length);
+        Assert.assertTrue(bc.equalsIgnoreCase("heLLo"));
+        Assert.assertFalse(bc.equalsIgnoreCase("\u8a48\u8a65\u8a6c\u8a6c\u8a6f"));
+    }
 
     @Test
     public void testSerialization() throws Exception {

--- a/test/org/apache/tomcat/util/http/TestMimeHeaders.java
+++ b/test/org/apache/tomcat/util/http/TestMimeHeaders.java
@@ -16,6 +16,7 @@
  */
 package org.apache.tomcat.util.http;
 
+import java.io.UnsupportedEncodingException;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
@@ -31,6 +32,16 @@ public class TestMimeHeaders {
     public static final String HEADER_NAME_A = "aaa";
     public static final String HEADER_NAME_B = "bbb";
     public static final String HEADER_NAME_C = "ccc";
+
+    @Test
+    public void testSetValueBytesIgnoresCase01() throws UnsupportedEncodingException {
+        MimeHeaders mh = new MimeHeaders();
+
+        byte[] bytes = HEADER_NAME_UC_STRING.getBytes("utf-8");
+        mh.setValue(HEADER_NAME_UC_STRING).setBytes(bytes, 0, bytes.length);
+        Assert.assertTrue(mh.getValue(HEADER_NAME_UC_STRING).equalsIgnoreCase(HEADER_NAME_MIXED_STRING));
+        Assert.assertFalse(mh.getValue(HEADER_NAME_UC_STRING).equalsIgnoreCase("\u8a54\u8a45\u8a53\u8a54"));
+    }
 
     @Test
     public void testSetValueStringIgnoresCase01() {


### PR DESCRIPTION
See testcase, 
```java
        // bc ByteChunk bytes: Hello
        Assert.assertTrue(bc.equalsIgnoreCase("heLLo"));
        Assert.assertFalse(bc.equalsIgnoreCase("\u8a48\u8a65\u8a6c\u8a6c\u8a6f"));
```
Ascii.toLower(c) implicitly assume c<=0xff.
It is hard to exploit with this weakness. Now add an explicit check to improve robustness.

