### PR TITLE
reject out-of-range values in range and content-range parsers

### DIFF
--- a/java/org/apache/tomcat/util/http/parser/ContentRange.java
+++ b/java/org/apache/tomcat/util/http/parser/ContentRange.java
@@ -113,24 +113,32 @@ public class ContentRange {
         // token and if that something was anything other than LWS the following
         // call to readLong() will fail.
 
-        // Start
-        long start = HttpParser.readLong(input);
+        long start;
+        long end;
+        long length;
+        try {
+            // Start
+            start = HttpParser.readLong(input);
 
-        // Must be followed by '-'
-        if (HttpParser.skipConstant(input, "-") == SkipResult.NOT_FOUND) {
+            // Must be followed by '-'
+            if (HttpParser.skipConstant(input, "-") == SkipResult.NOT_FOUND) {
+                return null;
+            }
+
+            // End
+            end = HttpParser.readLong(input);
+
+            // Must be followed by '/'
+            if (HttpParser.skipConstant(input, "/") == SkipResult.NOT_FOUND) {
+                return null;
+            }
+
+            // Length
+            length = HttpParser.readLong(input);
+        } catch (NumberFormatException nfe) {
+            // A value that doesn't fit in a long can't be a valid content range
             return null;
         }
-
-        // End
-        long end = HttpParser.readLong(input);
-
-        // Must be followed by '/'
-        if (HttpParser.skipConstant(input, "/") == SkipResult.NOT_FOUND) {
-            return null;
-        }
-
-        // Length
-        long length = HttpParser.readLong(input);
 
         // Doesn't matter what we look for, result should be EOF
         SkipResult skipResult = HttpParser.skipConstant(input, "X");

--- a/java/org/apache/tomcat/util/http/parser/Ranges.java
+++ b/java/org/apache/tomcat/util/http/parser/Ranges.java
@@ -137,12 +137,19 @@ public class Ranges {
 
         SkipResult skipResult;
         do {
-            long start = HttpParser.readLong(input);
-            // Must be followed by '-'
-            if (HttpParser.skipConstant(input, "-") != SkipResult.FOUND) {
+            long start;
+            long end;
+            try {
+                start = HttpParser.readLong(input);
+                // Must be followed by '-'
+                if (HttpParser.skipConstant(input, "-") != SkipResult.FOUND) {
+                    return null;
+                }
+                end = HttpParser.readLong(input);
+            } catch (NumberFormatException nfe) {
+                // A value that doesn't fit in a long can't be a valid range
                 return null;
             }
-            long end = HttpParser.readLong(input);
 
             if (start == -1 && end == -1) {
                 // Invalid range

--- a/test/org/apache/tomcat/util/http/parser/TestRanges.java
+++ b/test/org/apache/tomcat/util/http/parser/TestRanges.java
@@ -74,6 +74,20 @@ public class TestRanges {
 
 
     @Test
+    public void testInvalid07() throws Exception {
+        // End does not fit in a long
+        doTestInvalid("bytes=0-99999999999999999999");
+    }
+
+
+    @Test
+    public void testInvalid08() throws Exception {
+        // Start does not fit in a long
+        doTestInvalid("bytes=99999999999999999999-50");
+    }
+
+
+    @Test
     public void testValid01() throws Exception {
         Ranges r = parse("bytes=1-10,21-30");
         Assert.assertEquals("bytes", r.getUnits());
@@ -115,6 +129,18 @@ public class TestRanges {
         Entry e1 = l.get(0);
         Assert.assertEquals(21, e1.getStart());
         Assert.assertEquals(-1, e1.getEnd());
+    }
+
+
+    @Test
+    public void testValid04() throws Exception {
+        // Long.MAX_VALUE must still be accepted
+        Ranges r = parse("bytes=0-9223372036854775807");
+        List<Entry> l = r.getEntries();
+        Assert.assertEquals(1, l.size());
+        Entry e1 = l.get(0);
+        Assert.assertEquals(0, e1.getStart());
+        Assert.assertEquals(Long.MAX_VALUE, e1.getEnd());
     }
 
 


### PR DESCRIPTION
`Ranges.parse` and `ContentRange.parse` are documented to return null for any value they can't accept, but a numeric field larger than `Long.MAX_VALUE` (e.g. `Range: bytes=0-99999999999999999999`) lets a `NumberFormatException` escape `readLong`. In `DefaultServlet` that turns the usual 416/400 for a bad range into a 500. Catch it where the longs are read and return null, like every other malformed range.