### PR TITLE
catch invalid base64 in MimeUtility encoded-word decoder

### DIFF
--- a/java/org/apache/tomcat/util/http/fileupload/util/mime/MimeUtility.java
+++ b/java/org/apache/tomcat/util/http/fileupload/util/mime/MimeUtility.java
@@ -240,7 +240,7 @@ public final class MimeUtility {
             }
             // Convert decoded byte data into a string.
             return new String(decodedData, javaCharset(charset));
-        } catch (final IOException e) {
+        } catch (final IOException | IllegalArgumentException e) {
             throw new UnsupportedEncodingException("Invalid RFC 2047 encoding");
         }
     }


### PR DESCRIPTION
Base64.getDecoder().decode throws IllegalArgumentException, not IOException, so a Content-Disposition param like `filename="=?utf-8?B?@@@@?="` lets the unchecked exception escape `decodeWord` and `ParameterParser.parse` straight out of multipart parsing, where the only catch handlers are for IOException/IllegalStateException. Adding it to the existing catch keeps the contract that decodeWord throws UnsupportedEncodingException for malformed encodings, which decodeText/ParameterParser already handle by keeping the raw value.