### PR TITLE
Xxe protection servlets hardening

### DIFF
--- a/java/org/apache/catalina/servlets/DefaultServlet.java
+++ b/java/org/apache/catalina/servlets/DefaultServlet.java
@@ -44,8 +44,10 @@ import java.util.List;
 import java.util.Locale;
 import java.util.function.Function;
 
+import javax.xml.XMLConstants;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
@@ -1759,6 +1761,11 @@ public class DefaultServlet extends HttpServlet {
             currentThread.setContextClassLoader(DefaultServlet.class.getClassLoader());
 
             TransformerFactory tFactory = TransformerFactory.newInstance();
+            try {
+                tFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            } catch (TransformerConfigurationException e) {
+                log(sm.getString("defaultServlet.xslError"), e);
+            }
             Source xmlSource = new StreamSource(new StringReader(sb.toString()));
             Transformer transformer = tFactory.newTransformer(xsltSource);
 

--- a/java/org/apache/catalina/servlets/WebdavServlet.java
+++ b/java/org/apache/catalina/servlets/WebdavServlet.java
@@ -43,6 +43,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -576,6 +577,12 @@ public class WebdavServlet extends DefaultServlet implements PeriodicEventListen
         try {
             DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
             documentBuilderFactory.setNamespaceAware(true);
+            try {
+                documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            } catch (ParserConfigurationException | SAXNotRecognizedException | SAXNotSupportedException e) {
+                log(sm.getString("webdavservlet.jaxpfailed"), e);
+            }
             documentBuilderFactory.setExpandEntityReferences(false);
             documentBuilder = documentBuilderFactory.newDocumentBuilder();
             documentBuilder.setEntityResolver(new WebdavResolver(this.getServletContext()));


### PR DESCRIPTION
Enable secure JAXP processing in DefaultServlet and WebdavServlet as defense-in-depth against XXE attacks.

Changes
Enabled FEATURE_SECURE_PROCESSING on TransformerFactory in DefaultServlet
Enabled FEATURE_SECURE_PROCESSING and disallowed DTDs on DocumentBuilderFactory in WebdavServlet

These changes strengthen XML parser security and align with JAXP best practices.