### PR TITLE
Ensure atomic session persistence in FileStore using write-then-rename pattern

### DIFF
--- a/java/org/apache/catalina/session/FileStore.java
+++ b/java/org/apache/catalina/session/FileStore.java
@@ -24,6 +24,9 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.locks.Lock;
@@ -269,12 +272,27 @@ public final class FileStore extends StoreBase {
                     .trace(sm.getString(getStoreName() + ".saving", session.getIdInternal(), file.getAbsolutePath()));
         }
 
+        File tempFile = new File(file.getAbsolutePath() + ".tmp");
+
         Lock writeLock = sessionLocksById.getLock(session.getIdInternal()).writeLock();
         writeLock.lock();
         try {
-            try (FileOutputStream fos = new FileOutputStream(file.getAbsolutePath());
+            try (FileOutputStream fos = new FileOutputStream(tempFile);
                     ObjectOutputStream oos = new ObjectOutputStream(new BufferedOutputStream(fos))) {
                 ((StandardSession) session).writeObjectData(oos);
+            }
+            try {
+                try {
+                    Files.move(tempFile.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING,
+                            StandardCopyOption.ATOMIC_MOVE);
+                } catch (AtomicMoveNotSupportedException e) {
+                    Files.move(tempFile.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                }
+            } catch (IOException e) {
+                if (tempFile.exists() && !tempFile.delete()) {
+                    log.warn(sm.getString("fileStore.deleteFailed", tempFile));
+                }
+                throw e;
             }
         } finally {
             writeLock.unlock();


### PR DESCRIPTION
Updated FileStore.save(Session) to use an atomic write-then-rename pattern. Previously, session data was written directly to the final file, which could leave partially written or inconsistent session state if the process was interrupted during persistence. The new logic writes to a temporary .tmp file first and renames it only after a successful write, improving persistence reliability and reducing the risk of corruption.