### PR TITLE
Remoteip host header parsing fix

### DIFF
--- a/java/org/apache/catalina/valves/RemoteIpValve.java
+++ b/java/org/apache/catalina/valves/RemoteIpValve.java
@@ -669,6 +669,10 @@ public class RemoteIpValve extends ValveBase {
                 String hostHeaderValue = request.getHeader(hostHeader);
                 if (hostHeaderValue != null) {
                     try {
+                        int commaIndex = hostHeaderValue.indexOf(',');
+                        if (commaIndex > -1) {
+                            hostHeaderValue = hostHeaderValue.substring(0, commaIndex).trim();
+                        }
                         int portIndex = Host.parse(hostHeaderValue);
                         if (portIndex > -1) {
                             log.debug(sm.getString("remoteIpValve.invalidHostWithPort", hostHeaderValue, hostHeader));

--- a/java/org/apache/catalina/valves/RemoteIpValve.java
+++ b/java/org/apache/catalina/valves/RemoteIpValve.java
@@ -673,15 +673,19 @@ public class RemoteIpValve extends ValveBase {
                         if (commaIndex > -1) {
                             hostHeaderValue = hostHeaderValue.substring(0, commaIndex).trim();
                         }
-                        int portIndex = Host.parse(hostHeaderValue);
-                        if (portIndex > -1) {
-                            log.debug(sm.getString("remoteIpValve.invalidHostWithPort", hostHeaderValue, hostHeader));
-                            hostHeaderValue = hostHeaderValue.substring(0, portIndex);
-                        }
+                        if (hostHeaderValue.isEmpty()) {
+                            log.debug(sm.getString("remoteIpValve.invalidHostHeader", hostHeaderValue, hostHeader));
+                        } else {
+                            int portIndex = Host.parse(hostHeaderValue);
+                            if (portIndex > -1) {
+                                log.debug(sm.getString("remoteIpValve.invalidHostWithPort", hostHeaderValue, hostHeader));
+                                hostHeaderValue = hostHeaderValue.substring(0, portIndex);
+                            }
 
-                        request.getCoyoteRequest().serverName().setString(hostHeaderValue);
-                        if (isChangeLocalName()) {
-                            request.getCoyoteRequest().localName().setString(hostHeaderValue);
+                            request.getCoyoteRequest().serverName().setString(hostHeaderValue);
+                            if (isChangeLocalName()) {
+                                request.getCoyoteRequest().localName().setString(hostHeaderValue);
+                            }
                         }
 
                     } catch (IllegalArgumentException iae) {


### PR DESCRIPTION
Add validation to check whether the host header value becomes empty after comma parsing and trimming. If the resulting value is empty, skip host header processing and log a debug message, allowing the request to continue using the original server name instead of attempting to parse an invalid host value.
