### PR TITLE
use getEnd() not getLength() when filtering ctls in header writers

### DIFF
--- a/java/org/apache/coyote/ajp/AjpMessage.java
+++ b/java/org/apache/coyote/ajp/AjpMessage.java
@@ -156,7 +156,7 @@ public class AjpMessage {
             // values will be OK. Strings using other encodings may be
             // corrupted.
             byte[] buffer = bc.getBuffer();
-            for (int i = bc.getStart(); i < bc.getLength(); i++) {
+            for (int i = bc.getStart(); i < bc.getEnd(); i++) {
                 // byte values are signed i.e. -128 to 127
                 // The values are used unsigned. 0 to 31 are CTLs so they are
                 // filtered (apart from TAB which is 9). 127 is a control (DEL).

--- a/java/org/apache/coyote/http11/Http11OutputBuffer.java
+++ b/java/org/apache/coyote/http11/Http11OutputBuffer.java
@@ -413,7 +413,7 @@ public class Http11OutputBuffer implements HttpOutputBuffer {
             // values will be OK. Strings using other encodings may be
             // corrupted.
             byte[] buffer = bc.getBuffer();
-            for (int i = bc.getStart(); i < bc.getLength(); i++) {
+            for (int i = bc.getStart(); i < bc.getEnd(); i++) {
                 // byte values are signed i.e. -128 to 127
                 // The values are used unsigned. 0 to 31 are CTLs so they are
                 // filtered (apart from TAB which is 9). 127 is a control (DEL).


### PR DESCRIPTION
while reading the response header write path i noticed the control-character filter in Http11OutputBuffer.write and AjpMessage.appendBytes loops up to bc.getLength() rather than the end of the data. for a ByteChunk the valid range is [getStart(), getEnd()) and getLength() is getEnd() minus getStart(), so when the chunk start is non-zero the bytes past getLength() are never stripped, and if start is past length the loop does not run at all. the same byte filtering loops in Http11Processor, StreamProcessor and UEncoder all use getEnd(). this brings these two into line.