### PR TITLE
decline invalid permessage-deflate offers rather than fail handshake

### DIFF
--- a/java/org/apache/tomcat/websocket/PerMessageDeflate.java
+++ b/java/org/apache/tomcat/websocket/PerMessageDeflate.java
@@ -87,82 +87,91 @@ public class PerMessageDeflate implements Transformation {
             boolean clientContextTakeover = true;
             int clientMaxWindowBits = -1;
 
-            for (Parameter param : preference) {
-                if (SERVER_NO_CONTEXT_TAKEOVER.equals(param.getName())) {
-                    if (serverContextTakeover) {
-                        serverContextTakeover = false;
-                    } else {
-                        // Duplicate definition
-                        throw new IllegalArgumentException(
-                                sm.getString("perMessageDeflate.duplicateParameter", SERVER_NO_CONTEXT_TAKEOVER));
-                    }
-                } else if (CLIENT_NO_CONTEXT_TAKEOVER.equals(param.getName())) {
-                    if (clientContextTakeover) {
-                        clientContextTakeover = false;
-                    } else {
-                        // Duplicate definition
-                        throw new IllegalArgumentException(
-                                sm.getString("perMessageDeflate.duplicateParameter", CLIENT_NO_CONTEXT_TAKEOVER));
-                    }
-                } else if (SERVER_MAX_WINDOW_BITS.equals(param.getName())) {
-                    if (serverMaxWindowBits == -1) {
-                        serverMaxWindowBits = Integer.parseInt(param.getValue());
-                        if (serverMaxWindowBits < 8 || serverMaxWindowBits > 15) {
-                            throw new IllegalArgumentException(sm.getString("perMessageDeflate.invalidWindowSize",
-                                    SERVER_MAX_WINDOW_BITS, Integer.valueOf(serverMaxWindowBits)));
-                        }
-                        // Java SE API (as of Java 11) does not expose the API to
-                        // control the Window size. It is effectively hard-coded
-                        // to 15
-                        if (isServer && serverMaxWindowBits != 15) {
-                            ok = false;
-                            break;
-                            // Note server window size is not an issue for the
-                            // client since the client will assume 15 and if the
-                            // server uses a smaller window everything will
-                            // still work
-                        }
-                    } else {
-                        // Duplicate definition
-                        throw new IllegalArgumentException(
-                                sm.getString("perMessageDeflate.duplicateParameter", SERVER_MAX_WINDOW_BITS));
-                    }
-                } else if (CLIENT_MAX_WINDOW_BITS.equals(param.getName())) {
-                    if (clientMaxWindowBits == -1) {
-                        if (param.getValue() == null) {
-                            // Hint to server that the client supports this
-                            // option. Java SE API (as of Java 11) does not
-                            // expose the API to control the Window size. It is
-                            // effectively hard-coded to 15
-                            clientMaxWindowBits = 15;
+            try {
+                for (Parameter param : preference) {
+                    if (SERVER_NO_CONTEXT_TAKEOVER.equals(param.getName())) {
+                        if (serverContextTakeover) {
+                            serverContextTakeover = false;
                         } else {
-                            clientMaxWindowBits = Integer.parseInt(param.getValue());
-                            if (clientMaxWindowBits < 8 || clientMaxWindowBits > 15) {
-                                throw new IllegalArgumentException(sm.getString("perMessageDeflate.invalidWindowSize",
-                                        CLIENT_MAX_WINDOW_BITS, Integer.valueOf(clientMaxWindowBits)));
-                            }
+                            // Duplicate definition
+                            throw new IllegalArgumentException(
+                                    sm.getString("perMessageDeflate.duplicateParameter", SERVER_NO_CONTEXT_TAKEOVER));
                         }
-                        // Java SE API (as of Java 11) does not expose the API to
-                        // control the Window size. It is effectively hard-coded
-                        // to 15
-                        if (!isServer && clientMaxWindowBits != 15) {
-                            ok = false;
-                            break;
-                            // Note client window size is not an issue for the
-                            // server since the server will assume 15 and if the
-                            // client uses a smaller window everything will
-                            // still work
+                    } else if (CLIENT_NO_CONTEXT_TAKEOVER.equals(param.getName())) {
+                        if (clientContextTakeover) {
+                            clientContextTakeover = false;
+                        } else {
+                            // Duplicate definition
+                            throw new IllegalArgumentException(
+                                    sm.getString("perMessageDeflate.duplicateParameter", CLIENT_NO_CONTEXT_TAKEOVER));
+                        }
+                    } else if (SERVER_MAX_WINDOW_BITS.equals(param.getName())) {
+                        if (serverMaxWindowBits == -1) {
+                            serverMaxWindowBits = Integer.parseInt(param.getValue());
+                            if (serverMaxWindowBits < 8 || serverMaxWindowBits > 15) {
+                                throw new IllegalArgumentException(sm.getString("perMessageDeflate.invalidWindowSize",
+                                        SERVER_MAX_WINDOW_BITS, Integer.valueOf(serverMaxWindowBits)));
+                            }
+                            // Java SE API (as of Java 11) does not expose the API to
+                            // control the Window size. It is effectively hard-coded
+                            // to 15
+                            if (isServer && serverMaxWindowBits != 15) {
+                                ok = false;
+                                break;
+                                // Note server window size is not an issue for the
+                                // client since the client will assume 15 and if the
+                                // server uses a smaller window everything will
+                                // still work
+                            }
+                        } else {
+                            // Duplicate definition
+                            throw new IllegalArgumentException(
+                                    sm.getString("perMessageDeflate.duplicateParameter", SERVER_MAX_WINDOW_BITS));
+                        }
+                    } else if (CLIENT_MAX_WINDOW_BITS.equals(param.getName())) {
+                        if (clientMaxWindowBits == -1) {
+                            if (param.getValue() == null) {
+                                // Hint to server that the client supports this
+                                // option. Java SE API (as of Java 11) does not
+                                // expose the API to control the Window size. It is
+                                // effectively hard-coded to 15
+                                clientMaxWindowBits = 15;
+                            } else {
+                                clientMaxWindowBits = Integer.parseInt(param.getValue());
+                                if (clientMaxWindowBits < 8 || clientMaxWindowBits > 15) {
+                                    throw new IllegalArgumentException(
+                                            sm.getString("perMessageDeflate.invalidWindowSize", CLIENT_MAX_WINDOW_BITS,
+                                                    Integer.valueOf(clientMaxWindowBits)));
+                                }
+                            }
+                            // Java SE API (as of Java 11) does not expose the API to
+                            // control the Window size. It is effectively hard-coded
+                            // to 15
+                            if (!isServer && clientMaxWindowBits != 15) {
+                                ok = false;
+                                break;
+                                // Note client window size is not an issue for the
+                                // server since the server will assume 15 and if the
+                                // client uses a smaller window everything will
+                                // still work
+                            }
+                        } else {
+                            // Duplicate definition
+                            throw new IllegalArgumentException(
+                                    sm.getString("perMessageDeflate.duplicateParameter", CLIENT_MAX_WINDOW_BITS));
                         }
                     } else {
-                        // Duplicate definition
+                        // Unknown parameter
                         throw new IllegalArgumentException(
-                                sm.getString("perMessageDeflate.duplicateParameter", CLIENT_MAX_WINDOW_BITS));
+                                sm.getString("perMessageDeflate.unknownParameter", param.getName()));
                     }
-                } else {
-                    // Unknown parameter
-                    throw new IllegalArgumentException(
-                            sm.getString("perMessageDeflate.unknownParameter", param.getName()));
                 }
+            } catch (IllegalArgumentException iae) {
+                // An invalid extension parameter has been offered. RFC 7692
+                // section 5.1 requires the offer to be declined and the handshake to
+                // continue (without this extension) rather than failing. Try the
+                // next offered configuration.
+                ok = false;
             }
             if (ok) {
                 return new PerMessageDeflate(serverContextTakeover, serverMaxWindowBits, clientContextTakeover,

--- a/test/org/apache/tomcat/websocket/TestPerMessageDeflate.java
+++ b/test/org/apache/tomcat/websocket/TestPerMessageDeflate.java
@@ -150,6 +150,31 @@ public class TestPerMessageDeflate {
         Assert.assertEquals(mp2, compressedParts.get(1));
     }
 
+
+    /*
+     * RFC 7692 section 5.1 requires a permessage-deflate offer that contains an invalid extension parameter to be
+     * declined so the handshake continues without compression. The offer must not fail the handshake.
+     */
+    @Test
+    public void testInvalidParameterDeclinesOffer() {
+        // client_max_window_bits with an out-of-range value
+        assertDeclined("client_max_window_bits", "16");
+        // client_max_window_bits with a non-numeric value
+        assertDeclined("client_max_window_bits", "x");
+        // server_max_window_bits offered without a value
+        assertDeclined("server_max_window_bits", null);
+    }
+
+
+    private static void assertDeclined(String name, String value) {
+        List<Parameter> parameters = new ArrayList<>();
+        parameters.add(new WsExtensionParameter(name, value));
+        List<List<Parameter>> preferences = new ArrayList<>();
+        preferences.add(parameters);
+
+        Assert.assertNull(PerMessageDeflate.build(preferences, true));
+    }
+
     /*
      * Minimal implementation to enable other transformations to be tested. It is NOT robust.
      */


### PR DESCRIPTION
A WebSocket client that offers permessage-deflate with an invalid window size, for example `Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits=16`, makes `PerMessageDeflate.build()` throw. An out-of-range value raises `IllegalArgumentException` and a non-numeric or value-less `server_max_window_bits` raises `NumberFormatException`; nothing on the server handshake path catches either, so the exception unwinds through `UpgradeUtil.doUpgrade()` and `WsFilter` and the upgrade is aborted with a 500. I traced it from the build stack, which surfaces at the `Integer.parseInt`/range check in `build()`, and since permessage-deflate is a default-installed extension every endpoint is reachable.

RFC 7692 section 5.1 requires the server to decline an offer that carries an invalid parameter, meaning the handshake should complete without that extension rather than fail. `build()` already returns `null` when it cannot agree terms, so wrapping the parameter loop and routing an invalid parameter down that existing decline path keeps the change in the one method that owns extension negotiation, with the validation and its messages untouched. The added test exercises the three trigger values and fails on the current tree.