### PR TITLE
Make Cluster digester rules fully conditional on ha and tribes JARs

### DIFF
--- a/java/org/apache/catalina/startup/Catalina.java
+++ b/java/org/apache/catalina/startup/Catalina.java
@@ -597,8 +597,15 @@ public class Catalina {
         Constructor<?> constructor;
         try {
             clazz = Class.forName("org.apache.catalina.ha.ClusterRuleSet");
+            Class.forName("org.apache.catalina.tribes.Channel");
             constructor = clazz.getConstructor(String.class);
             RuleSet ruleSet = (RuleSet) constructor.newInstance(prefix);
+
+            String clusterPrefix = prefix.substring(0, prefix.length() - 1);
+            digester.addObjectCreate(clusterPrefix, null, "className");
+            digester.addSetProperties(clusterPrefix);
+            digester.addSetNext(clusterPrefix, "setCluster", "org.apache.catalina.Cluster");
+
             digester.addRuleSet(ruleSet);
         } catch (Exception e) {
             if (!clusterUnavailabilityLogged) {

--- a/java/org/apache/catalina/startup/EngineRuleSet.java
+++ b/java/org/apache/catalina/startup/EngineRuleSet.java
@@ -64,13 +64,6 @@ public class EngineRuleSet implements RuleSet {
                 new LifecycleListenerRule("org.apache.catalina.startup.EngineConfig", "engineConfigClass"));
         digester.addSetNext(prefix + "Engine", "setContainer", "org.apache.catalina.Engine");
 
-        // Cluster configuration start
-        digester.addObjectCreate(prefix + "Engine/Cluster", null, // MUST be specified in the element
-                "className");
-        digester.addSetProperties(prefix + "Engine/Cluster");
-        digester.addSetNext(prefix + "Engine/Cluster", "setCluster", "org.apache.catalina.Cluster");
-        // Cluster configuration end
-
         digester.addObjectCreate(prefix + "Engine/Listener", null, // MUST be specified in the element
                 "className");
         digester.addSetProperties(prefix + "Engine/Listener");

--- a/java/org/apache/catalina/startup/HostRuleSet.java
+++ b/java/org/apache/catalina/startup/HostRuleSet.java
@@ -67,13 +67,6 @@ public class HostRuleSet implements RuleSet {
 
         digester.addCallMethod(prefix + "Host/Alias", "addAlias", 0);
 
-        // Cluster configuration start
-        digester.addObjectCreate(prefix + "Host/Cluster", null, // MUST be specified in the element
-                "className");
-        digester.addSetProperties(prefix + "Host/Cluster");
-        digester.addSetNext(prefix + "Host/Cluster", "setCluster", "org.apache.catalina.Cluster");
-        // Cluster configuration end
-
         digester.addObjectCreate(prefix + "Host/Listener", null, // MUST be specified in the element
                 "className");
         digester.addSetProperties(prefix + "Host/Listener");

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -367,6 +367,14 @@
         detailed error information (message, description, stack trace) is
         suppressed from error responses. (dsoumis)
       </add>
+      <fix>
+        Avoid a <code>NoClassDefFoundError</code> at startup when
+        <code>catalina-tribes.jar</code> is removed but
+        <code>catalina-ha.jar</code> is present and the
+        <code>Cluster</code> element is enabled in
+        <code>server.xml</code>. Cluster digester rules are now fully
+        conditional on both JARs being available. (dsoumis)
+      </fix>
     </changelog>
   </subsection>
   <subsection name="Coyote">


### PR DESCRIPTION
  The ObjectCreate rules for the <Cluster> element were registered
  unconditionally in EngineRuleSet and HostRuleSet, while the child
  element rules in ClusterRuleSet were already guarded behind a
  try/catch in Catalina.addClusterRuleSet(). This caused a
  NoClassDefFoundError crash when catalina-tribes.jar was removed
  but catalina-ha.jar was present and <Cluster> was enabled in
  server.xml.

  Move the Cluster element rules into addClusterRuleSet() alongside
  the child element rules, and add a probe for tribes availability.
  Either both JARs are present and clustering works, or the <Cluster>
  element is ignored with an INFO log.