### PR TITLE
Add Brainpool TLS named groups support

### DIFF
--- a/java/org/apache/tomcat/util/net/openssl/ciphers/Group.java
+++ b/java/org/apache/tomcat/util/net/openssl/ciphers/Group.java
@@ -41,6 +41,20 @@ public enum Group {
      */
     secp521r1(0x0019),
     /**
+     * Brainpool P-256 (brainpoolP256r1) elliptic curve group.
+     */
+    brainpoolP256r1(0x001A),
+
+    /**
+     * Brainpool P-384 (brainpoolP384r1) elliptic curve group.
+     */
+    brainpoolP384r1(0x001B),
+
+    /**
+     * Brainpool P-512 (brainpoolP512r1) elliptic curve group.
+     */
+    brainpoolP512r1(0x001C),
+    /**
      * Curve25519 elliptic curve group.
      */
     x25519(0x001D),


### PR DESCRIPTION
Tomcat validates configured TLS groups against the internal Group enum.

When using alternate JSSE providers such as BouncyCastle JSSE, Brainpool groups can be configured via:

-Djdk.tls.namedGroups=brainpoolP256r1,brainpoolP384r1,brainpoolP512r1

However these groups are rejected because they are not present in Group.java.

This prevents Brainpool TLS deployments from functioning correctly.

This change adds support for:

- brainpoolP256r1
- brainpoolP384r1
- brainpoolP512r1