### PR TITLE
Fix typo in test method name

### DIFF
--- a/test/org/apache/catalina/startup/TestTomcat.java
+++ b/test/org/apache/catalina/startup/TestTomcat.java
@@ -443,7 +443,7 @@ public class TestTomcat extends TomcatBaseTest {
     }
 
     @Test
-    public void testGetBrokenContextPerAddWepapp() {
+    public void testGetBrokenContextPerAddWebapp() {
         Tomcat tomcat = getTomcatInstance();
         Host host = tomcat.getHost();
         if (host instanceof StandardHost) {


### PR DESCRIPTION
`testGetBrokenContextPerAddWepapp()` → `testGetBrokenContextPerAddWebapp()`
