### PR TITLE
Fix connection window credit loss in HTTP/2 backlog accounting

### DIFF
--- a/java/org/apache/coyote/http2/Http2UpgradeHandler.java
+++ b/java/org/apache/coyote/http2/Http2UpgradeHandler.java
@@ -172,6 +172,9 @@ class Http2UpgradeHandler extends AbstractStream implements InternalHttpUpgradeH
     private final PingManager pingManager = getPingManager();
     private volatile int newStreamsSinceLastPrune = 0;
     private final Set<Stream> backLogStreams = new HashSet<>();
+    // The sum of the connection allocations requested by the streams in backLogStreams. Any change to a stream's
+    // requested allocation must be mirrored here so releaseBackLog() can correctly determine whether an increment
+    // clears the backlog.
     private long backLogSize = 0;
     // The time at which the connection will timeout unless data arrives before
     // then. -1 means no timeout.
@@ -1332,6 +1335,7 @@ class Http2UpgradeHandler extends AbstractStream implements InternalHttpUpgradeH
                 int allocatedThisTime = Math.min(allocation, stream.getConnectionAllocationRequested());
                 stream.setConnectionAllocationRequested(stream.getConnectionAllocationRequested() - allocatedThisTime);
                 stream.setConnectionAllocationMade(stream.getConnectionAllocationMade() + allocatedThisTime);
+                backLogSize -= allocatedThisTime;
                 leftToAllocate = leftToAllocate - allocatedThisTime;
             }
 

--- a/test/org/apache/coyote/http2/TestRfc9218.java
+++ b/test/org/apache/coyote/http2/TestRfc9218.java
@@ -187,7 +187,7 @@ public class TestRfc9218 extends Http2TestBase {
         trace = trace.replace("21-Body-1365\n", "");
         Assert.assertEquals(0, trace.length());
 
-        // 19 - 5641 body left
+        // 19 - 5461 body left
         // 21 - 4778 body left
 
         // Add 16k to the connection window. Should fully allocate 19 and 21.
@@ -200,6 +200,29 @@ public class TestRfc9218 extends Http2TestBase {
             // Dump for debugging purposes
             ioe.printStackTrace();
         }
+
+        output.clearTrace();
+
+        /*
+         * The final window update was 6145 bytes larger than the outstanding backlog. Those bytes must remain available
+         * in the connection window for the next stream.
+         */
+        sendSimpleGetRequest(23);
+        parser.readFrame();
+        // The headers for stream 23 will always arrive. If the surplus was lost, no body will be sent and the read
+        // below would block for the default timeout - so use a short timeout to fail quickly.
+        s.setSoTimeout(1000);
+        parser.readFrame();
+
+        Assert.assertTrue(output.getTrace().contains("23-Body-6145\n"));
+        output.clearTrace();
+
+        // 2047 completes the 8192 byte response body for stream 23, confirming that exactly 6145 surplus bytes were
+        // available in the connection window.
+        sendWindowUpdate(0, 2047);
+        parser.readFrame();
+
+        Assert.assertEquals("23-Body-2047\n23-EndOfStream\n", output.getTrace());
     }
 
 


### PR DESCRIPTION
`backLogSize` is incremented when streams join the backlog, but `allocate()` never decrements it when granting connection window capacity to a backlogged stream. Only the full-clear branch of `releaseBackLog()` resets it. After any partial allocation the aggregate is larger than the sum of the outstanding per-stream requests.

A later `WINDOW_UPDATE` that covers all outstanding requests is then compared against the stale aggregate, takes the partial-allocation branch, and the surplus is discarded instead of being returned to the connection flow control window. Subsequent streams stall waiting for credit the client has already sent, until the write timeout closes the connection with ENHANCE_YOUR_CALM.

In the extended `TestRfc9218` scenario: 10,239 bytes of real backlog, a 16,384-byte update — the 6,145-byte surplus is lost and the next stream receives headers but no data.

This is a regression from 169b81341f9b ("Switch HTTP/2 to use RFC 9218 priorities rather than RFC 7540", shipped in 10.1.10 / 9.0.76 / 11.0.0-M6). The previous RFC 7540 allocation path decremented the aggregate (`backLogSize -= stream.getConnectionAllocationMade()` / `...Requested()`); the rewritten urgency-based path did not carry that over.

Fix: decrement `backLogSize` as allocations are made, keeping it equal to the sum of outstanding requests. The invariant is documented on the field. Also fixes a digit transposition in an existing test comment (5641 -> 5461).

Testing: the extended `TestRfc9218` fails without the fix (next stream starves until read timeout) and passes with it, asserting the exact 6,145-byte surplus plus a 2,047-byte update completing the 8,192-byte body. Full `org.apache.coyote.http2` package passes. The same issue exists on 9.0.x and 10.1.x.
