### PR TITLE
Make default value of StuckThreadDetectionValve#interruptThreadThreshold explicit

### DIFF
--- a/java/org/apache/catalina/valves/StuckThreadDetectionValve.java
+++ b/java/org/apache/catalina/valves/StuckThreadDetectionValve.java
@@ -71,7 +71,7 @@ public class StuckThreadDetectionValve extends ValveBase {
     /**
      * In seconds. Default is -1 to disable interruption.
      */
-    private int interruptThreadThreshold;
+    private int interruptThreadThreshold = -1;
 
     /**
      * The only references we keep to actual running Thread objects are in this Map (which is automatically cleaned in


### PR DESCRIPTION
The `interruptThreadThreshold` field of `StuckThreadDetectionValve` had no explicit initialiser, so it relied on the Java default of `0`. This value disables thread interruption.

However, the Javadoc for the field (line 72) and the setter (line 118), as well as the user-facing documentation in `webapps/docs/config/valve.xml` (line 2677), all state that the default is `-1`:

- `StuckThreadDetectionValve.java:72` — "In seconds. Default is -1 to disable interruption."
- `StuckThreadDetectionValve.java:118` — "The default is -1."
- `valve.xml:2677` — "Default is -1 which disables the feature."

This patch makes the default explicit (`= -1`) so the code matches the documented behaviour.

**Behaviour impact:** none. The interruption logic uses `interruptThreadThreshold > 0` (lines 190 and 222), so both `0` and `-1` disable the feature. This change only aligns the code with its documented default.

**Testing:** the existing test (`TestStuckThreadDetectionValve`) calls `setInterruptThreadThreshold(5)` and does not rely on the default value, so it is unaffected.

**Backport note:** The same issue exists on the 9.0.x and 10.1.x branches
(the `interruptThreadThreshold` field is also uninitialised there while the
Javadoc states the default is `-1`). I have only raised this PR against
11.0.x for now - happy to provide backports if desired.