### PR TITLE
Make HPACK encoding test deterministic

### DIFF
--- a/java/org/apache/coyote/http2/HpackEncoder.java
+++ b/java/org/apache/coyote/http2/HpackEncoder.java
@@ -109,7 +109,11 @@ class HpackEncoder {
     private final HpackHeaderFunction hpackHeaderFunction;
 
     HpackEncoder() {
-        this.hpackHeaderFunction = DEFAULT_HEADER_FUNCTION;
+        this(DEFAULT_HEADER_FUNCTION);
+    }
+
+    HpackEncoder(HpackHeaderFunction hpackHeaderFunction) {
+        this.hpackHeaderFunction = hpackHeaderFunction;
     }
 
     /**
@@ -398,7 +402,7 @@ class HpackEncoder {
         }
     }
 
-    private interface HpackHeaderFunction {
+    interface HpackHeaderFunction {
         boolean shouldUseIndexing(String header, String value);
 
         /**

--- a/test/org/apache/coyote/http2/TestHpack.java
+++ b/test/org/apache/coyote/http2/TestHpack.java
@@ -32,11 +32,26 @@ public class TestHpack {
         headers.setValue(":status").setString("200");
         headers.setValue("header2").setString("value2");
         ByteBuffer output = ByteBuffer.allocate(512);
-        HpackEncoder encoder = new HpackEncoder();
+        HpackEncoder encoder = new HpackEncoder(new HpackEncoder.HpackHeaderFunction() {
+
+            @Override
+            public boolean shouldUseIndexing(String header, String value) {
+                return true;
+            }
+
+            @Override
+            public boolean shouldUseHuffman(String header, String value) {
+                return true;
+            }
+
+            @Override
+            public boolean shouldUseHuffman(String header) {
+                return true;
+            }
+        });
         encoder.encode(headers, output);
         output.flip();
-        // Size is supposed to be 33 without huffman, or 27 with it
-        // TODO: use the HpackHeaderFunction to enable huffman predictably
+        // Size is 27 with Huffman encoding
         Assert.assertEquals(27, output.remaining());
         output.clear();
         encoder.encode(headers, output);


### PR DESCRIPTION
## Summary

- allow package-local injection of the HPACK header encoding policy
- make `TestHpack.testEncode()` explicitly force Huffman encoding
- remove the checked-in TODO and the test's dependency on the default length heuristic

## Rationale

`TestHpack.testEncode()` asserts a 27-byte encoded result, which assumes Huffman encoding. The default encoder currently chooses Huffman encoding for values longer than five characters, but that heuristic may change. This implements the guidance in `TODO.md` by making the test select Huffman encoding directly.

The default constructor still uses `DEFAULT_HEADER_FUNCTION`, so production behavior is unchanged. The new constructor and the exposed nested interface remain package-private.

## Verification

- `ant test -Dtest.entry=org.apache.coyote.http2.TestHpack -Dtest.silent=true`
- `ant -Dexecute.validate=true validate`
- complete unfiltered suite on Linux/JDK 21: `ant test -Dtest.silent=true -Dtest.threads=4 -Dtest.openssl.path=/usr/bin/openssl`
- clean source build: `ant clean`, then `ant`
- runtime smoke: started the generated distribution, received HTTP 200 from `http://127.0.0.1:8080/`, and stopped Tomcat cleanly
