### PR TITLE
Added high-level README files

### DIFF
--- a/java/org/apache/catalina/README.md
+++ b/java/org/apache/catalina/README.md
@@ -1,0 +1,79 @@
+# org.apache.catalina
+
+## Overview
+
+The `org.apache.catalina` package implements the Catalina Servlet container,
+which is responsible for hosting web applications and managing their lifecycle.
+
+Catalina provides the core implementation of the Jakarta Servlet
+specification and forms the heart of Apache Tomcat.
+
+---
+
+## Responsibilities
+
+This package includes components responsible for:
+
+- Managing the server hierarchy
+- Deploying web applications
+- Processing servlet requests
+- Managing sessions
+		  
+							 
+- Lifecycle management
+- Container event processing
+
+---
+
+## Container Hierarchy
+
+```
+Server
+ └── Service
+      ├── Connector
+      └── Engine
+            └── Host
+                  └── Context
+                        └── Wrapper (Servlet)
+```
+
+---
+
+## Important Interfaces
+
+| Interface | Purpose |
+|------------|---------|
+| Container | Base interface for Catalina containers |
+| Context | Represents a web application |
+| Host | Represents a virtual host |
+| Engine | Top-level request processor |
+| Pipeline | Request processing chain |
+| Valve | Request interceptor |
+| Lifecycle | Start/stop components |
+
+---
+
+## Common Entry Points
+
+- StandardServer
+- StandardService
+- StandardEngine
+- StandardHost
+- StandardContext
+
+---
+
+## Related Packages
+
+- org.apache.coyote
+- org.apache.tomcat.util
+- org.apache.naming
+- org.apache.jasper
+
+---
+
+## See Also
+
+- BUILDING.txt
+- RUNNING.txt
+- Architecture documentation

--- a/java/org/apache/coyote/README.md
+++ b/java/org/apache/coyote/README.md
@@ -1,0 +1,54 @@
+# org.apache.coyote
+
+## Overview
+
+The `org.apache.coyote` package provides the protocol implementation layer
+between the network connector and the Catalina servlet container.
+
+It is responsible for translating incoming protocol requests into servlet
+requests that Catalina can process.
+
+---
+
+## Responsibilities
+
+- HTTP/1.1 processing
+- HTTP/2 support
+- AJP protocol
+- Request parsing
+- Response generation
+- Protocol abstraction
+
+---
+
+## Request Flow
+
+```
+Socket
+
+↓
+
+ProtocolHandler
+
+↓
+
+Processor
+
+↓
+
+Adapter
+
+↓
+
+Catalina
+```
+
+---
+
+## Important Classes
+
+- AbstractProtocol
+- Http11Processor
+- Adapter
+- Request
+- Response

--- a/java/org/apache/tomcat/util/README.md
+++ b/java/org/apache/tomcat/util/README.md
@@ -1,0 +1,30 @@
+# org.apache.tomcat.util
+
+## Overview
+
+Utility classes shared across Tomcat components.
+
+This package contains reusable infrastructure that supports networking,
+buffer management, threading, scanning, compatibility utilities, logging,
+and configuration.
+
+---
+
+## Main Modules
+
+- buf
+- net
+- threads
+- compat
+- scan
+- descriptor
+- modeler
+
+---
+
+## Used By
+
+- Catalina
+- Coyote
+- Jasper
+- WebSocket


### PR DESCRIPTION
## Summary

This PR adds package-level `README.md` files for the following core Tomcat packages:

* `java/org/apache/catalina/README.md`
* `java/org/apache/coyote/README.md`
* `java/org/apache/tomcat/util/README.md`

## What’s included

Each README provides a high-level overview of the package, including:

* The package's purpose and responsibilities
* Major components and commonly used classes/interfaces
* How the package fits into Tomcat's overall architecture
* Relationships with other core packages

## Motivation

While Tomcat has comprehensive Javadocs and architecture documentation, it can take some time for new contributors to understand the role of each package when navigating the source tree. These READMEs are intended to serve as quick entry points and improve codebase discoverability without duplicating existing documentation.

## Impact

* Documentation-only change
* No code, API, or behavioral changes
* No impact on build, tests, or runtime
