### PR TITLE
Fix subsection heading levels for nested subsections (h5/h6)

### DIFF
--- a/webapps/docs/tomcat-docs.xsl
+++ b/webapps/docs/tomcat-docs.xsl
@@ -231,11 +231,23 @@
 
     <div class="subsection">
       <!-- Subsection heading -->
-      <!-- TODO: When a <subsection> is nested in another <subsection>,
-           the output should be <h5>, not <h4>. Same with <h6>. -->
-      <h4 id="{$name}">
-        <xsl:value-of select="@name"/>
-      </h4>
+      <xsl:choose>
+        <xsl:when test="not(parent::subsection)">
+          <h4 id="{$name}">
+            <xsl:value-of select="@name"/>
+          </h4>
+        </xsl:when>
+        <xsl:when test="parent::subsection and not(parent::subsection/parent::subsection)">
+          <h5 id="{$name}">
+            <xsl:value-of select="@name"/>
+          </h5>
+        </xsl:when>
+        <xsl:otherwise>
+          <h6 id="{$name}">
+            <xsl:value-of select="@name"/>
+          </h6>
+        </xsl:otherwise>
+      </xsl:choose>
       <!-- Subsection body -->
       <div class="text">
         <xsl:apply-templates/>


### PR DESCRIPTION
Fix the XSLT template for nested `<subsection>` elements so that the
generated heading level reflects the nesting depth.

Previously, every `<subsection>` was rendered as `<h4>`, regardless of
whether it was nested inside another subsection.

The template now generates:
- `<h4>` for subsections directly under a `<section>`
- `<h5>` for subsections nested one level deep
- `<h6>` for subsections nested two or more levels deep

Testing:
- `ant build-docs` - confirmed the generated documentation builds
  successfully and the headings are rendered correctly in the output
- Verified visually with a local test XML document containing nested
  subsections; the generated headings now use the expected h4 → h5 → h6
  hierarchy.

Screenshots attached showing the correct rendering in both:
- an actual Tomcat documentation page
  
<img width="851" height="512" alt="test" src="https://github.com/user-attachments/assets/9ea1a7f8-14fc-4e61-89fa-cb32435bea5e" />

- the local nested-subsection test XML output

<img width="570" height="619" alt="nesting test" src="https://github.com/user-attachments/assets/c2522558-f325-4d08-9c72-eb712b45224f" />


