### PR TITLE
Wrap Instant conversion failures in ELException

### DIFF
--- a/java/org/apache/el/lang/ELSupport.java
+++ b/java/org/apache/el/lang/ELSupport.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Proxy;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Clock;
+import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.temporal.TemporalAccessor;
 import java.util.Collections;
@@ -551,10 +552,24 @@ public class ELSupport {
 
         return switch (obj) {
             case null -> null;
-            case TemporalAccessor t -> Instant.from(t);
+            case TemporalAccessor t -> {
+                try {
+                    yield Instant.from(t);
+                } catch (DateTimeException e) {
+                    throw new ELException(
+                            MessageFactory.get("error.convert", obj, obj.getClass().getName(), Instant.class), e);
+                }
+            }
             case Clock c -> c.instant();
             case Date d -> d.toInstant();
-            case String s -> Instant.parse(s);
+            case String s -> {
+                try {
+                    yield Instant.parse(s);
+                } catch (DateTimeException e) {
+                    throw new ELException(
+                            MessageFactory.get("error.convert", obj, obj.getClass().getName(), Instant.class), e);
+                }
+            }
             default -> {
                 throw new ELException(
                         MessageFactory.get("error.convert", obj, obj.getClass().getName(), Instant.class));

--- a/test/org/apache/el/lang/TestELSupport.java
+++ b/test/org/apache/el/lang/TestELSupport.java
@@ -19,6 +19,8 @@ package org.apache.el.lang;
 import java.beans.PropertyEditorManager;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.Instant;
+import java.time.LocalDate;
 import java.util.Map;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
@@ -236,6 +238,22 @@ public class TestELSupport {
         Object result = ELManager.getExpressionFactory().coerceToType(
                 "", TesterType.class);
         Assert.assertNull(result);
+    }
+
+    @Test
+    public void testCoerceToInstant01() {
+        Object result = ELSupport.coerceToType(null, "2024-01-01T00:00:00Z", Instant.class);
+        Assert.assertEquals(Instant.parse("2024-01-01T00:00:00Z"), result);
+    }
+
+    @Test(expected = ELException.class)
+    public void testCoerceToInstant02() {
+        ELSupport.coerceToType(null, "not-a-date", Instant.class);
+    }
+
+    @Test(expected = ELException.class)
+    public void testCoerceToInstant03() {
+        ELSupport.coerceToType(null, LocalDate.of(2024, 1, 1), Instant.class);
     }
 
     @Test


### PR DESCRIPTION
## Problem

Coercion to `java.time.Instant` (added for Tomcat 12) can leak unchecked exceptions instead of the `ELException` required by the EL specification.

In `ELSupport.coerceToInstant()`:

- `Instant.parse("not-a-date")` throws `java.time.format.DateTimeParseException`
- `Instant.from(LocalDate.of(...))` throws `java.time.DateTimeException` / `UnsupportedTemporalTypeException`

Both are `RuntimeException` subclasses that propagate directly to the caller, while the method contract (and the rest of `ELSupport`, e.g. `coerceToNumber`) requires a `jakarta.el.ELException`.

## Fix

Wrap the failures from `Instant.from()` and `Instant.parse()` in `ELException`, matching the pattern already used by `coerceToNumber` for `NumberFormatException`.

## Testing

Added three tests to `TestELSupport`:

- `testCoerceToInstant01` — valid string coerces to `Instant`
- `testCoerceToInstant02` — invalid string throws `ELException`
- `testCoerceToInstant03` — `LocalDate` (no timezone) throws `ELException`

`TestELSupport` passes (54 tests, 0 failures) on JDK 23.