### PR TITLE
Fix automatic pong close race

### DIFF
--- a/java/org/apache/tomcat/websocket/WsFrameBase.java
+++ b/java/org/apache/tomcat/websocket/WsFrameBase.java
@@ -377,7 +377,14 @@ public abstract class WsFrameBase {
             wsSession.onClose(new CloseReason(Util.getCloseCode(code), reason));
         } else if (opCode == Constants.OPCODE_PING) {
             if (wsSession.isOpen()) {
-                wsSession.getBasicRemote().sendPong(controlBufferBinary);
+                try {
+                    wsSession.getBasicRemote().sendPong(controlBufferBinary);
+                } catch (IllegalStateException ise) {
+                    // The close process may have started after isOpen() was checked.
+                    if (!wsSession.isClosing()) {
+                        throw ise;
+                    }
+                }
             }
         } else if (opCode == Constants.OPCODE_PONG) {
             MessageHandler.Whole<PongMessage> mhPong = wsSession.getPongMessageHandler();

--- a/java/org/apache/tomcat/websocket/WsSession.java
+++ b/java/org/apache/tomcat/websocket/WsSession.java
@@ -459,6 +459,16 @@ public class WsSession implements Session {
 
 
     /**
+     * Checks if the session close process has started.
+     *
+     * @return true if the session is closing or closed
+     */
+    boolean isClosing() {
+        return state.get() != State.OPEN;
+    }
+
+
+    /**
      * Checks if the session is closed.
      *
      * @return true if the session is closed

--- a/test/org/apache/tomcat/websocket/TestWsFrame.java
+++ b/test/org/apache/tomcat/websocket/TestWsFrame.java
@@ -17,9 +17,16 @@
 package org.apache.tomcat.websocket;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
+import jakarta.websocket.RemoteEndpoint;
+
+import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Test;
+
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
 
 public class TestWsFrame {
 
@@ -57,5 +64,77 @@ public class TestWsFrame {
         Assert.assertEquals(0x7FFFFFFFFFFFFFFFL,
                 WsFrameBase.byteArrayToLong(new byte[] { 20, 127, -1, -1, -1, -1, -1, -1, -1 }, 1, 8));
         Assert.assertEquals(-1, WsFrameBase.byteArrayToLong(new byte[] { 20, -1, -1, -1, -1, -1, -1, -1, -1 }, 1, 8));
+    }
+
+
+    @Test
+    public void testAutomaticPongAfterCloseStarted() throws Exception {
+        WsSession wsSession = EasyMock.createNiceMock(WsSession.class);
+        RemoteEndpoint.Basic basicRemote = EasyMock.createMock(RemoteEndpoint.Basic.class);
+        EasyMock.expect(wsSession.isOpen()).andReturn(Boolean.TRUE);
+        EasyMock.expect(wsSession.getBasicRemote()).andReturn(basicRemote);
+        basicRemote.sendPong(EasyMock.anyObject(ByteBuffer.class));
+        EasyMock.expectLastCall().andThrow(new IllegalStateException());
+        EasyMock.expect(wsSession.isClosing()).andReturn(Boolean.TRUE);
+        EasyMock.replay(wsSession, basicRemote);
+
+        TestFrame frame = new TestFrame(wsSession);
+        frame.processPing();
+
+        EasyMock.verify(wsSession, basicRemote);
+    }
+
+
+    @Test
+    public void testAutomaticPongFailureWhileOpen() throws Exception {
+        WsSession wsSession = EasyMock.createNiceMock(WsSession.class);
+        RemoteEndpoint.Basic basicRemote = EasyMock.createMock(RemoteEndpoint.Basic.class);
+        EasyMock.expect(wsSession.isOpen()).andReturn(Boolean.TRUE);
+        EasyMock.expect(wsSession.getBasicRemote()).andReturn(basicRemote);
+        basicRemote.sendPong(EasyMock.anyObject(ByteBuffer.class));
+        EasyMock.expectLastCall().andThrow(new IllegalStateException());
+        EasyMock.expect(wsSession.isClosing()).andReturn(Boolean.FALSE);
+        EasyMock.replay(wsSession, basicRemote);
+
+        TestFrame frame = new TestFrame(wsSession);
+        try {
+            frame.processPing();
+            Assert.fail();
+        } catch (IllegalStateException expected) {
+            // Expected.
+        }
+
+        EasyMock.verify(wsSession, basicRemote);
+    }
+
+
+    private static class TestFrame extends WsFrameBase {
+
+        TestFrame(WsSession wsSession) {
+            super(wsSession, null);
+        }
+
+        void processPing() throws IOException {
+            inputBuffer.clear();
+            inputBuffer.put((byte) 0x89);
+            inputBuffer.put((byte) 0x00);
+            inputBuffer.flip();
+            processInputBuffer();
+        }
+
+        @Override
+        protected boolean isMasked() {
+            return false;
+        }
+
+        @Override
+        protected Log getLog() {
+            return LogFactory.getLog(TestFrame.class);
+        }
+
+        @Override
+        protected void resumeProcessing() {
+            // NO-OP
+        }
     }
 }

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -324,6 +324,10 @@
   </subsection>
   <subsection name="WebSocket">
     <changelog>
+      <fix>
+        Fix an exception when an automatic Pong response races with the
+        closing of the WebSocket session. (moritzfl)
+      </fix>
       <update>
         Update Tomcat's WebSocket support to version 2.3 of the Jakarta
         WebSocket API. (markt)
@@ -397,4 +401,3 @@
 </section>
 </body>
 </document>
-


### PR DESCRIPTION
## Fix automatic Pong/session-close race

A WebSocket session may begin closing after `WsFrameBase` checks `WsSession.isOpen()` but before it calls `sendPong()`. In that interval, `sendPong()` throws `IllegalStateException` on the inbound frame-processing thread. 

=> we have a TOCTOU situation

Suppress this exception only when closing has begun; propagate it otherwise. Add regression coverage for both outcomes.

### Backport applicability

The same non-atomic `isOpen()` / `sendPong()` sequence exists in all supported release branches: `11.0.x`, `10.1.x`, and `9.0.x`. These should be considered for backport after merge to `main`. We would need a fix for `11.0.x` at the company I work for.

### Testing

`ant test` with JDK 21.0.9 ran for 57m57s on my Windows machine but failed due to broad NIO2 test discovery failures (`No tests found`) affecting unrelated tests. The added `TestWsFrame` coverage passed under NIO: 4 tests, 0 failures.