### PR TITLE
Fix typos

### DIFF
--- a/java/org/apache/coyote/http2/Http2Parser.java
+++ b/java/org/apache/coyote/http2/Http2Parser.java
@@ -287,7 +287,7 @@ class Http2Parser {
             // The padding does not count towards the size of payload that is read below.
             payloadSize -= padLength;
 
-            // Any RFC 7450 priority data was read into the byte[] optional above. It is ignored.
+            // Any RFC 7540 priority data was read into the byte[] optional above. It is ignored.
         }
 
         readHeaderPayload(streamId, payloadSize, buffer);
@@ -306,7 +306,7 @@ class Http2Parser {
 
 
     protected void readPriorityFrame(int streamId, ByteBuffer buffer) throws IOException {
-        // RFC 7450 priority frames are ignored. Still need to treat as overhead.
+        // RFC 7540 priority frames are ignored. Still need to treat as overhead.
         try {
             swallowPayload(streamId, FrameType.PRIORITY.getId(), 5, false, buffer);
         } catch (ConnectionException ignore) {

--- a/java/org/apache/coyote/http2/Http2UpgradeHandler.java
+++ b/java/org/apache/coyote/http2/Http2UpgradeHandler.java
@@ -1852,7 +1852,7 @@ class Http2UpgradeHandler extends AbstractStream implements InternalHttpUpgradeH
         } else if (setting == Setting.NO_RFC7540_PRIORITIES) {
             // This should not be changed after the initial setting
             if (value != ConnectionSettingsBase.DEFAULT_NO_RFC7540_PRIORITIES) {
-                throw new ConnectionException(sm.getString("upgradeHandler.enableRfc7450Priorities", connectionId),
+                throw new ConnectionException(sm.getString("upgradeHandler.enableRfc7540Priorities", connectionId),
                         Http2Error.PROTOCOL_ERROR);
             }
         } else {

--- a/java/org/apache/coyote/http2/LocalStrings.properties
+++ b/java/org/apache/coyote/http2/LocalStrings.properties
@@ -143,7 +143,7 @@ upgradeHandler.allocate.debug=Connection [{0}], Stream [{1}], allocated [{2}] by
 upgradeHandler.allocate.left=Connection [{0}], Stream [{1}], [{2}] bytes unallocated - trying to allocate to children
 upgradeHandler.clientCancel=Client reset the stream before the response was complete
 upgradeHandler.connectionError=Connection error
-upgradeHandler.enableRfc7450Priorities=Connection [{0}], RFC 7450 priorities may not be enabled after being disabled in the initial connection settings frame (see RFC 9218)
+upgradeHandler.enableRfc7540Priorities=Connection [{0}], RFC 7540 priorities may not be enabled after being disabled in the initial connection settings frame (see RFC 9218)
 upgradeHandler.fallToDebug=\n\
 \ Note: further occurrences of HTTP/2 stream errors will be logged at DEBUG level.
 upgradeHandler.goaway.debug=Connection [{0}], Goaway, Last stream [{1}], Error code [{2}], Debug data [{3}]

--- a/java/org/apache/coyote/http2/LocalStrings_fr.properties
+++ b/java/org/apache/coyote/http2/LocalStrings_fr.properties
@@ -146,7 +146,7 @@ upgradeHandler.allocate.debug=Connection [{0}], Flux [{1}], [{2}] octets alloué
 upgradeHandler.allocate.left=Connection [{0}], Flux [{1}], [{2}] octets désalloués, essai d''allocation aux enfants
 upgradeHandler.clientCancel=Le client a réinitialisé la stream avant que la réponse ne soit complète
 upgradeHandler.connectionError=Erreur de la connection
-upgradeHandler.enableRfc7450Priorities=Connection [{0}], les priorités RFC 7450 ne doivent pas être activées après avoir été désactivées dans la trame initiale des paramètres de connection (voir la RFC 9218)
+upgradeHandler.enableRfc7540Priorities=Connection [{0}], les priorités RFC 7540 ne doivent pas être activées après avoir été désactivées dans la trame initiale des paramètres de connection (voir la RFC 9218)
 upgradeHandler.fallToDebug=\n\
 \ Note: les occurrences suivantes d'erreurs de stream HTTP/2 seront enregistrées au niveau DEBUG.
 upgradeHandler.goaway.debug=Connection [{0}], Goaway, Dernier flux [{1}], Code d''erreur [{2}], Données de débogage [{3}]

--- a/java/org/apache/coyote/http2/LocalStrings_ja.properties
+++ b/java/org/apache/coyote/http2/LocalStrings_ja.properties
@@ -146,7 +146,7 @@ upgradeHandler.allocate.debug=コネクション [{0}]、ストリーム [{1}]�
 upgradeHandler.allocate.left=コネクション [{0}]、ストリーム [{1}]、[{2}] バイトが未割り当て - 子への割り当てを試みています
 upgradeHandler.clientCancel=レスポンスが完了する前にクライアントがストリームをリセットしました
 upgradeHandler.connectionError=接続エラー
-upgradeHandler.enableRfc7450Priorities=接続 [{0}] は、RFC 7450 優先順位が初期接続設定フレームで無効にされた後に有効にならない場合があります (RFC 9218 を参照)
+upgradeHandler.enableRfc7540Priorities=接続 [{0}] は、RFC 7540 優先順位が初期接続設定フレームで無効にされた後に有効にならない場合があります (RFC 9218 を参照)
 upgradeHandler.fallToDebug=\n\
 \ 注: 以降のHTTP/2 ストリームエラーの発生はDEBUGレベルでログに出力されます。
 upgradeHandler.goaway.debug=コネクション [{0}]、Goaway、最終ストリーム [{1}]、エラーコード [{2}]、デバッグデータ [{3}]


### PR DESCRIPTION
There were several obvious typos regarding RFC number in the source code.

- RFC 7450 - Automatic Multicast Tunneling 🙅 
- RFC 7540 - Hypertext Transfer Protocol Version 2 (HTTP/2) 🙆 