### PR TITLE
Wrap RewriteRule syntax reference

### DIFF
--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -372,6 +372,10 @@
   </subsection>
   <subsection name="Web applications">
     <changelog>
+      <docs>
+        Wrap the <code>RewriteRule</code> regular expression syntax reference
+        on narrow displays. (sainadh777)
+      </docs>
       <update>
         Manager: Drop session handling dedicated to extracting the locale from
         Tapestry attributes, used for locale session sorting. (remm)

--- a/webapps/docs/rewrite.xml
+++ b/webapps/docs/rewrite.xml
@@ -527,33 +527,30 @@ RewriteRule ^/(.*)$ ${uc:$1}
       <p>Some hints on the syntax of regular
       expressions:</p>
 
-<!-- TODO: Why is the following pre-formatted non-wrappable text? -->
-<pre>
-<strong>Text:</strong>
-  <strong><code>.</code></strong>           Any single character
-  <strong><code>[</code></strong>chars<strong><code>]</code></strong>     Character class: Any character of the class 'chars'
-  <strong><code>[^</code></strong>chars<strong><code>]</code></strong>    Character class: Not a character of the class 'chars'
-  text1<strong><code>|</code></strong>text2 Alternative: text1 or text2
+<source wrapped="true"><strong>Text:</strong>
+  <strong>.</strong>           Any single character
+  <strong>[</strong>chars<strong>]</strong>     Character class: Any character of the class 'chars'
+  <strong>[^</strong>chars<strong>]</strong>    Character class: Not a character of the class 'chars'
+  text1<strong>|</strong>text2 Alternative: text1 or text2
 
 <strong>Quantifiers:</strong>
-  <strong><code>?</code></strong>           0 or 1 occurrences of the preceding text
-  <strong><code>*</code></strong>           0 or N occurrences of the preceding text (N &gt; 0)
-  <strong><code>+</code></strong>           1 or N occurrences of the preceding text (N &gt; 1)
+  <strong>?</strong>           0 or 1 occurrences of the preceding text
+  <strong>*</strong>           0 or N occurrences of the preceding text (N &gt; 0)
+  <strong>+</strong>           1 or N occurrences of the preceding text (N &gt; 1)
 
 <strong>Grouping:</strong>
-  <strong><code>(</code></strong>text<strong><code>)</code></strong>      Grouping of text
+  <strong>(</strong>text<strong>)</strong>      Grouping of text
               (used either to set the borders of an alternative as above, or
               to make backreferences, where the <strong>N</strong>th group can
-              be referred to on the RHS of a RewriteRule as <code>$</code><strong>N</strong>)
+              be referred to on the RHS of a RewriteRule as $<strong>N</strong>)
 
 <strong>Anchors:</strong>
-  <strong><code>^</code></strong>           Start-of-line anchor
-  <strong><code>$</code></strong>           End-of-line anchor
+  <strong>^</strong>           Start-of-line anchor
+  <strong>$</strong>           End-of-line anchor
 
 <strong>Escaping:</strong>
-  <strong><code>\</code></strong>char       escape the given char
-              (for instance, to specify the chars "<code>.[]()</code>" <em>etc.</em>)
-</pre>
+  <strong>\</strong>char       escape the given char
+              (for instance, to specify the chars ".[]()" <em>etc.</em>)</source>
 
       <p>For more information about regular expressions, have a look at the
       perl regular expression manpage ("<a

--- a/webapps/docs/rewrite.xml
+++ b/webapps/docs/rewrite.xml
@@ -527,30 +527,38 @@ RewriteRule ^/(.*)$ ${uc:$1}
       <p>Some hints on the syntax of regular
       expressions:</p>
 
-<source wrapped="true"><strong>Text:</strong>
-  <strong>.</strong>           Any single character
-  <strong>[</strong>chars<strong>]</strong>     Character class: Any character of the class 'chars'
-  <strong>[^</strong>chars<strong>]</strong>    Character class: Not a character of the class 'chars'
-  text1<strong>|</strong>text2 Alternative: text1 or text2
-
-<strong>Quantifiers:</strong>
-  <strong>?</strong>           0 or 1 occurrences of the preceding text
-  <strong>*</strong>           0 or N occurrences of the preceding text (N &gt; 0)
-  <strong>+</strong>           1 or N occurrences of the preceding text (N &gt; 1)
-
-<strong>Grouping:</strong>
-  <strong>(</strong>text<strong>)</strong>      Grouping of text
-              (used either to set the borders of an alternative as above, or
-              to make backreferences, where the <strong>N</strong>th group can
-              be referred to on the RHS of a RewriteRule as $<strong>N</strong>)
-
-<strong>Anchors:</strong>
-  <strong>^</strong>           Start-of-line anchor
-  <strong>$</strong>           End-of-line anchor
-
-<strong>Escaping:</strong>
-  <strong>\</strong>char       escape the given char
-              (for instance, to specify the chars ".[]()" <em>etc.</em>)</source>
+      <table class="defaultTable">
+        <tr><th colspan="2">Text</th></tr>
+        <tr><td><code>.</code></td>
+          <td>Any single character</td></tr>
+        <tr><td><code>[chars]</code></td>
+          <td>Character class: Any character of the class 'chars'</td></tr>
+        <tr><td><code>[^chars]</code></td>
+          <td>Character class: Not a character of the class 'chars'</td></tr>
+        <tr><td><code>text1|text2</code></td>
+          <td>Alternative: text1 or text2</td></tr>
+        <tr><th colspan="2">Quantifiers</th></tr>
+        <tr><td><code>?</code></td>
+          <td>0 or 1 occurrences of the preceding text</td></tr>
+        <tr><td><code>*</code></td>
+          <td>0 or N occurrences of the preceding text (N &gt; 0)</td></tr>
+        <tr><td><code>+</code></td>
+          <td>1 or N occurrences of the preceding text (N &gt; 1)</td></tr>
+        <tr><th colspan="2">Grouping</th></tr>
+        <tr><td><code>(text)</code></td>
+          <td>Grouping of text (used either to set the borders of an
+            alternative as above, or to make backreferences, where the Nth
+            group can be referred to on the RHS of a RewriteRule as $N)</td></tr>
+        <tr><th colspan="2">Anchors</th></tr>
+        <tr><td><code>^</code></td>
+          <td>Start-of-line anchor</td></tr>
+        <tr><td><code>$</code></td>
+          <td>End-of-line anchor</td></tr>
+        <tr><th colspan="2">Escaping</th></tr>
+        <tr><td><code>\char</code></td>
+          <td>Escape the given char (for instance, to specify the chars
+            ".[]()" <em>etc.</em>)</td></tr>
+      </table>
 
       <p>For more information about regular expressions, have a look at the
       perl regular expression manpage ("<a


### PR DESCRIPTION
## Summary

- replace the RewriteRule regular-expression syntax reference with a semantic two-column table
- use `<code>...</code>` only for syntax in the first column and standard prose in the second
- remove the checked-in TODO about the non-wrapping block
- add the corresponding changelog entry

## Rationale

The original reference was a raw `pre` element and did not adapt to narrow displays. The initial PR revision used Tomcat's wrapped source template, but that treated the entire block as source code. Following review feedback, the table now models the content correctly: syntax is code, descriptions are prose, and the browser can wrap the descriptive column naturally.

## Impact

This is documentation-only. The five existing sections and their reference content are preserved while the generated markup becomes semantic and responsive.

## Validation

- `ant -q build-docs` — passed; generated `rewrite.html` contains the two-column table
- generated-page responsive inspection at 1280 px and 375 px viewports — passed; all five section headings were present, the description column contained no `code` elements, and all 22 data cells had zero internal overflow at 375 px
- `ant -Dexecute.validate=true validate` — passed (Checkstyle 13.9.0 across 7,677 checked files, 54 seconds)
- `ant clean` — passed (1 second)
- `ant` — passed clean source build (27 seconds; existing deprecation, BND, and Java 8 source/target warnings only)
- `git diff --check` — passed
- `ant test -Dtest.silent=true -Dtest.threads=4 -Dtest.openssl.path=/opt/homebrew/opt/openssl@3/bin/openssl` — passed complete unfiltered suite in 16 minutes 37 seconds: 649 suites, 41,257 tests, 0 failures, 0 errors, 263 project-declared skips
- generated-distribution smoke with `JAVA_HOME=/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home` — passed: `http://127.0.0.1:8080/docs/rewrite.html` returned HTTP 200, contained the new table, and the server PID exited cleanly after shutdown
