### PR TITLE
Use LRU order for persistent session swaps

### DIFF
--- a/java/org/apache/catalina/session/PersistentManagerBase.java
+++ b/java/org/apache/catalina/session/PersistentManagerBase.java
@@ -18,6 +18,7 @@ package org.apache.catalina.session;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -797,7 +798,6 @@ public abstract class PersistentManagerBase extends ManagerBase implements Store
 
         Session[] sessions = findSessions();
 
-        // FIXME: Smarter algorithm (LRU)
         int limit = (int) (getMaxActiveSessions() * 0.9);
 
         if (limit >= sessions.length) {
@@ -809,6 +809,7 @@ public abstract class PersistentManagerBase extends ManagerBase implements Store
         }
 
         int toswap = sessions.length - limit;
+        Arrays.sort(sessions, Comparator.comparingLong(Session::getLastAccessedTimeInternal));
 
         for (int i = 0; i < sessions.length && toswap > 0; i++) {
             StandardSession session = (StandardSession) sessions[i];

--- a/test/org/apache/catalina/session/TestPersistentManager.java
+++ b/test/org/apache/catalina/session/TestPersistentManager.java
@@ -72,6 +72,38 @@ public class TestPersistentManager {
     }
 
     @Test
+    public void testMaxActiveSwapUsesLeastRecentlyUsed() throws Exception {
+        OrderedPersistentManager manager = new OrderedPersistentManager();
+        TesterStore store = new TesterStore();
+        manager.setStore(store);
+
+        Host host = new TesterHost();
+        Context context = new TesterContext();
+        context.setParent(host);
+
+        manager.setContext(context);
+        manager.setMaxActiveSessions(3);
+        manager.setMinIdleSwap(0);
+
+        manager.start();
+
+        StandardSession oldest = (StandardSession) manager.createSession("oldest");
+        StandardSession middle = (StandardSession) manager.createSession("middle");
+        StandardSession newest = (StandardSession) manager.createSession("newest");
+
+        long now = System.currentTimeMillis();
+        oldest.lastAccessedTime = now - 30000;
+        middle.lastAccessedTime = now - 20000;
+        newest.lastAccessedTime = now - 10000;
+
+        manager.setOrderedSessions(newest, middle, oldest);
+        manager.processMaxActiveSwaps();
+
+        Assert.assertEquals(1, store.getSavedIds().size());
+        Assert.assertEquals("oldest", store.getSavedIds().get(0));
+    }
+
+    @Test
     public void testBug62175() throws Exception {
         PersistentManager manager = new PersistentManager();
         AtomicInteger sessionExpireCounter = new AtomicInteger();
@@ -135,6 +167,28 @@ public class TestPersistentManager {
         @Override
         public void sessionDestroyed(HttpSessionEvent se) {
             request.getSession(false);
+        }
+    }
+
+    private static class OrderedPersistentManager extends PersistentManagerBase {
+
+        private Session[] orderedSessions;
+
+        void setOrderedSessions(Session... orderedSessions) {
+            this.orderedSessions = orderedSessions;
+        }
+
+        @Override
+        public Session[] findSessions() {
+            if (orderedSessions == null) {
+                return super.findSessions();
+            }
+            return orderedSessions;
+        }
+
+        @Override
+        public String getName() {
+            return "OrderedPersistentManager";
         }
     }
 

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -253,6 +253,11 @@
         Ensure that capture groups from a <code>RewriteCond</code> always
         reflect the result of the current request. (markt)
       </fix>
+      <fix>
+        When a <code>PersistentManager</code> needs to reduce the number of
+        active sessions, swap out the least recently used eligible sessions
+        first. (sainadh777)
+      </fix>
     </changelog>
   </subsection>
   <subsection name="Coyote">


### PR DESCRIPTION
## Summary

- sort active sessions by internal last-access time before enforcing `maxActiveSessions`
- swap the least recently used eligible sessions first
- add deterministic regression coverage and a changelog entry

## Rationale

`PersistentManagerBase.processMaxActiveSwaps()` previously consumed the manager's unordered session array, so the sessions selected for persistence were arbitrary. This completes the maintained TODO 5.1 item in `TODO.md` while preserving the existing threshold and eligibility checks.

## Impact

Only the victim selection order changes: when the active-session limit is exceeded, older eligible sessions are swapped before newer ones.

## Validation

All final gates passed against commit `d475a6bf38227a1b3f66a37c3591e79468627c7c`.

- `JAVA_HOME=/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home ant test -Dtest.entry=org.apache.catalina.session.TestPersistentManager -Dtest.silent=true` — passed
- `JAVA_HOME=/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home ant -Dexecute.validate=true validate` — passed (Checkstyle 13.9.0)
- `JAVA_HOME=/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home ant clean` — passed
- `JAVA_HOME=/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home ant` — passed
- `JAVA_HOME=/opt/java/openjdk ant test -Dtest.silent=true -Dtest.threads=1 -Dtest.openssl.path=/usr/bin/openssl` in an isolated Ubuntu/Temurin 21 container — passed in 27m07s: 649 suites, 41,258 tests, 0 failures, 0 errors, 314 skipped
- generated-distribution smoke test in a fresh init-managed Temurin 21 container — Tomcat started, returned HTTP 200 from `/`, and stopped cleanly with the server PID exiting

The initial macOS four-thread full-suite attempt hit five multicast tests with `NoRouteToHostException`, so the complete suite was moved to Linux. Two preliminary four-thread Linux runs each exposed an unrelated timing/parallelism failure (`TestTimeBucketCounter`; then `TestRateLimitFilterWithExactRateLimiter` plus a fixed-port standalone fork conflict); every affected test passed alone. The final unfiltered Linux run above used one test thread and passed completely.
