### PR TITLE
Reset noContextManagerReceived when requesting session state

### DIFF
--- a/java/org/apache/catalina/ha/session/DeltaManager.java
+++ b/java/org/apache/catalina/ha/session/DeltaManager.java
@@ -841,6 +841,7 @@ public class DeltaManager extends ClusterManagerBase {
                 counterSend_EVT_GET_ALL_SESSIONS.incrementAndGet();
             }
             stateTransferred = false;
+            noContextManagerReceived = false;
             // FIXME This send call block the deploy thread, when sender waitForAck is enabled
             try {
                 synchronized (receivedMessageQueue) {

--- a/test/org/apache/catalina/ha/session/TestDeltaManagerStateTransfer.java
+++ b/test/org/apache/catalina/ha/session/TestDeltaManagerStateTransfer.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.catalina.ha.session;
+
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.apache.catalina.ha.CatalinaCluster;
+import org.apache.catalina.tribes.Member;
+
+/**
+ * Tests that {@link DeltaManager#getAllClusterSessions()} resets the
+ * {@code noContextManagerReceived} flag before requesting session state. If
+ * the flag is not reset, a previously received
+ * {@code EVT_ALL_SESSION_NOCONTEXTMANAGER} causes the state transfer wait to
+ * exit immediately on every subsequent request, even when the cluster node
+ * now has a context manager and sends session state.
+ */
+public class TestDeltaManagerStateTransfer {
+
+    private static CatalinaCluster createClusterWithOneMember() {
+        // findSessionMasterMember() uses members[0] as the state transfer
+        // source so the array must contain a non-null member.
+        Member member = EasyMock.createNiceMock(Member.class);
+        CatalinaCluster cluster = EasyMock.createNiceMock(CatalinaCluster.class);
+        EasyMock.expect(cluster.getMembers()).andReturn(new Member[] { member }).anyTimes();
+        // send() is a void method: a nice mock performs no action.
+        EasyMock.replay(cluster);
+        return cluster;
+    }
+
+    @Test
+    public void testNoContextManagerFlagResetOnNewStateRequest() throws Exception {
+        DeltaManager manager = new DeltaManager();
+        manager.setCluster(createClusterWithOneMember());
+        // Keep the wait short: the test does not provide a real reply so the
+        // wait will end via the timeout path.
+        manager.setStateTransferTimeout(1);
+
+        // Simulate a previously received EVT_ALL_SESSION_NOCONTEXTMANAGER
+        manager.setNoContextManagerReceived(true);
+
+        manager.getAllClusterSessions();
+
+        // The new state request must reset the flag so the wait is not
+        // skipped immediately on this and subsequent transfers.
+        Assert.assertFalse("noContextManagerReceived should be reset when requesting session state",
+                manager.isNoContextManagerReceived());
+    }
+
+    @Test
+    public void testStateTransferredResetOnNewStateRequest() throws Exception {
+        DeltaManager manager = new DeltaManager();
+        manager.setCluster(createClusterWithOneMember());
+        manager.setStateTransferTimeout(1);
+
+        // Simulate a completed previous transfer
+        manager.setStateTransferred(true);
+
+        manager.getAllClusterSessions();
+
+        Assert.assertFalse("stateTransferred should be reset when requesting session state",
+                manager.getStateTransferred());
+    }
+}

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -344,6 +344,13 @@
         <code>NegativeArraySizeException</code> during session state transfer.
         Pull request <pr>1042</pr> provided by lihongyi87. (markt)
       </fix>
+      <fix>
+        Ensure <code>DeltaManager</code> resets the
+        <code>noContextManagerReceived</code> flag when requesting session
+        state. A previously received <code>ALL_SESSION_NOCONTEXTMANAGER</code>
+        event caused all subsequent state transfers to return immediately,
+        skipping sessions sent by the cluster. (lihongyi87)
+      </fix>
     </changelog>
   </subsection>
   <subsection name="WebSocket">


### PR DESCRIPTION
## Problem

`noContextManagerReceived` is set to `true` when `EVT_ALL_SESSION_NOCONTEXTMANAGER` is received and is never reset. `getAllClusterSessions()` resets `stateTransferred` before requesting session state but leaves `noContextManagerReceived` set.

Because `waitForSendAllSessions()` includes `!isNoContextManagerReceived()` in its loop condition, every subsequent state transfer on the same manager instance returns immediately — even when the cluster node now has a context manager and sends session state. The sessions are skipped.

The flag has existed since it was introduced in 2011 (r1195384) without a reset.

## Trigger

A manager instance receives `ALL_SESSION_NOCONTEXTMANAGER` (peer not yet deployed), then the same instance requests session state again — for example after a web application reload (`reloadable=true`) reuses the manager.

## Fix

Reset the flag alongside `stateTransferred` when requesting session state, so the wait is governed only by the response to the current request.

## Testing

Two tests in `TestDeltaManagerStateTransfer` verify both flags are reset when `getAllClusterSessions()` is called with a mocked cluster member. On unpatched code the noContextManagerReceived test fails; with the fix both pass.