### PR TITLE
Fix drawboard rendering for axis-aligned shapes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -997,16 +997,6 @@ These are bugs, correctness issues, or missing functionality that may affect pro
 
 ---
 
-### 90. Example WebSocket Draw Message (1 item)
-
-| # | File:Line | Description | Fix Idea | Effort | Difficulty |
-|---|-----------|-------------|----------|--------|------------|
-| 90.1 | `DrawMessage.java:163` | Axis-aligned rectangles should be drawn as lines | Add a check: if `x1 == x2` or `y1 == y2`, draw a line instead of a rectangle. | 0.25 day | Low |
-
-**Total estimated effort: 0.25 day, Low difficulty**
-
----
-
 ### 91. Example WebSocket Client Blocking (2 items)
 
 | # | File:Line | Description | Fix Idea | Effort | Difficulty |

--- a/test/org/apache/tomcat/websocket/TestDrawMessage.java
+++ b/test/org/apache/tomcat/websocket/TestDrawMessage.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tomcat.websocket;
+
+import java.awt.Graphics2D;
+import java.awt.Shape;
+import java.awt.geom.Line2D;
+
+import org.easymock.Capture;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Test;
+
+import websocket.drawboard.DrawMessage;
+
+public class TestDrawMessage {
+
+    @Test
+    public void testAxisAlignedRectangleDrawnAsLine() {
+        assertDrawsLine(3, 5, 20, 5, 30);
+    }
+
+    @Test
+    public void testAxisAlignedEllipseDrawnAsLine() {
+        assertDrawsLine(4, 20, 5, 30, 5);
+    }
+
+    private static void assertDrawsLine(int type, double x1, double y1, double x2, double y2) {
+        Graphics2D graphics = EasyMock.createNiceMock(Graphics2D.class);
+        Capture<Shape> shape = EasyMock.newCapture();
+        graphics.draw(EasyMock.capture(shape));
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(graphics);
+
+        DrawMessage message = new DrawMessage(type, (byte) 0, (byte) 0, (byte) 0, (byte) 0, 1, x1, x2, y1, y2);
+        message.draw(graphics);
+
+        EasyMock.verify(graphics);
+        Assert.assertTrue(shape.getValue() instanceof Line2D);
+    }
+}

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -393,6 +393,10 @@
   </subsection>
   <subsection name="Web applications">
     <changelog>
+      <fix>
+        Examples: Draw axis-aligned rectangles and ellipses as lines in the
+        WebSocket drawboard. (sainadh777)
+      </fix>
       <update>
         Manager: Drop session handling dedicated to extracting the locale from
         Tapestry attributes, used for locale session sorting. (remm)

--- a/webapps/examples/WEB-INF/classes/websocket/drawboard/DrawMessage.java
+++ b/webapps/examples/WEB-INF/classes/websocket/drawboard/DrawMessage.java
@@ -160,9 +160,12 @@ public final class DrawMessage {
                 y2 = this.y1;
             }
 
-            // TODO: If (x1 == x2 || y1 == y2) draw as line.
+            if (x1 == x2 || y1 == y2) {
+                // Draw axis-aligned shapes as lines to match the behavior in the HTML5 Canvas.
+                Line2D line = new Line2D.Double(x1, y1, x2, y2);
+                g.draw(line);
 
-            if (type == 3) {
+            } else if (type == 3) {
                 // Draw a rectangle.
                 Rectangle2D rect = new Rectangle2D.Double(x1, y1,
                         x2 - x1, y2 - y1);


### PR DESCRIPTION
## Summary

- complete maintained TODO item 90.1 for the WebSocket drawboard example
- render axis-aligned rectangle and ellipse messages as lines, matching HTML5 Canvas behavior
- add regression coverage for both shape types
- remove the completed TODO and add a changelog entry

## Rationale and impact

A zero-width or zero-height rectangle/ellipse is not rendered by the Java2D implementation used by the drawboard example, while the browser canvas renders the corresponding user gesture as a line. The change is confined to the example application and preserves existing behavior for non-axis-aligned shapes.

## Validation

- `ant validate` — BUILD SUCCESSFUL
- `ant test -Dtest.entry=org.apache.tomcat.websocket.TestDrawMessage` — BUILD SUCCESSFUL; 2 tests, 0 failures, 0 errors, 0 skipped
- `ant clean` — BUILD SUCCESSFUL
- `ant` — BUILD SUCCESSFUL
- `ant test` on macOS — did not qualify: Tribes multicast tests failed with `NoRouteToHostException`; rerun in isolated Linux as required
- initial Linux source-transfer run — discarded because macOS extended attributes materialized as AppleDouble `._*.jar` files
- first clean Linux `ant test` run — completed but did not qualify after the Colima VM clock corrected forward by about 13 hours mid-run, producing unrelated timeout/rate-window failures and an impossible 788-minute Ant duration
- stable-clock Linux `ant clean && ant test` on `eclipse-temurin:25-jdk-noble` (ARM64) — BUILD SUCCESSFUL in 29m59s; 651 suite summaries, no failed suites; standard native/OpenSSL-dependent skips only
- generated-distribution smoke test on the same tested build in a Docker `--init` container — HTTP 200 from `http://127.0.0.1:8080/` (11,229 bytes); `shutdown.sh` stopped Tomcat and the JVM PID was reaped

Tested and pushed commit: `63bd5f30e892eb93d536a2ee27b3948c28d1b829`.
