### PR TITLE
Skip OCSP tests when responder port is unavailable instead of fail

### DIFF
--- a/test/org/apache/tomcat/util/net/ocsp/TestOcspEnabled.java
+++ b/test/org/apache/tomcat/util/net/ocsp/TestOcspEnabled.java
@@ -16,6 +16,7 @@
  */
 package org.apache.tomcat.util.net.ocsp;
 
+import java.net.BindException;
 import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -40,12 +41,35 @@ public class TestOcspEnabled extends OcspBaseTest {
 
     @BeforeClass
     public static void startOcspResponder() {
-        ocspResponder = new TesterOcspResponder();
+        TesterOcspResponder responder = new TesterOcspResponder();
         try {
-            ocspResponder.start();
+            responder.start();
+            ocspResponder = responder;
         } catch (Exception e) {
-            e.printStackTrace();
+            responder.stop();
+            if (isBindException(e)) {
+                // The fixed OCSP responder port (8888, baked into the test
+                // certificates) is in use by another process. This is an
+                // environmental issue, so leave ocspResponder null to skip the
+                // tests rather than reporting spurious failures.
+                ocspResponder = null;
+                e.printStackTrace();
+            } else {
+                // Any other startup failure is a genuine problem.
+                throw new IllegalStateException("Failed to start OCSP responder", e);
+            }
         }
+    }
+
+
+    private static boolean isBindException(Throwable t) {
+        while (t != null) {
+            if (t instanceof BindException) {
+                return true;
+            }
+            t = t.getCause();
+        }
+        return false;
     }
 
 

--- a/test/org/apache/tomcat/util/net/ocsp/TestOcspEnabled.java
+++ b/test/org/apache/tomcat/util/net/ocsp/TestOcspEnabled.java
@@ -130,7 +130,7 @@ public class TestOcspEnabled extends OcspBaseTest {
 
     @Test
     public void test() throws Exception {
-        Assume.assumeNotNull(ocspResponder);
+        Assume.assumeTrue("OCSP responder unavailable (port 8888 in use?)", ocspResponder != null);
         try {
             doTest(clientCertValid, serverCertValid, verifyClientCert, verifyServerCert);
             if (handshakeFailureExpected) {

--- a/test/org/apache/tomcat/util/net/ocsp/TestOcspSoftFailInternalError.java
+++ b/test/org/apache/tomcat/util/net/ocsp/TestOcspSoftFailInternalError.java
@@ -17,6 +17,7 @@
 package org.apache.tomcat.util.net.ocsp;
 
 import java.io.IOException;
+import java.net.BindException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -40,13 +41,36 @@ public class TestOcspSoftFailInternalError extends OcspBaseTest {
 
     @BeforeClass
     public static void startOcspResponder() {
-        ocspResponder = new TesterOcspResponder();
-        ocspResponder.setFixedResponse(OcspResponse.INTERNAL_ERROR);
+        TesterOcspResponder responder = new TesterOcspResponder();
+        responder.setFixedResponse(OcspResponse.INTERNAL_ERROR);
         try {
-            ocspResponder.start();
+            responder.start();
+            ocspResponder = responder;
         } catch (Exception e) {
-            e.printStackTrace();
+            responder.stop();
+            if (isBindException(e)) {
+                // The fixed OCSP responder port (8888, baked into the test
+                // certificates) is in use by another process. This is an
+                // environmental issue, so leave ocspResponder null to skip the
+                // tests rather than reporting spurious failures.
+                ocspResponder = null;
+                e.printStackTrace();
+            } else {
+                // Any other startup failure is a genuine problem.
+                throw new IllegalStateException("Failed to start OCSP responder", e);
+            }
         }
+    }
+
+
+    private static boolean isBindException(Throwable t) {
+        while (t != null) {
+            if (t instanceof BindException) {
+                return true;
+            }
+            t = t.getCause();
+        }
+        return false;
     }
 
 
@@ -94,7 +118,7 @@ public class TestOcspSoftFailInternalError extends OcspBaseTest {
 
     @Test
     public void test() throws Exception {
-        Assume.assumeNotNull(ocspResponder);
+        Assume.assumeTrue("OCSP responder unavailable (port 8888 in use?)", ocspResponder != null);
         try {
             doTest(clientCertValid, true, ClientCertificateVerification.ENABLED, false, softFail);
             if (handshakeFailureExpected) {

--- a/test/org/apache/tomcat/util/net/ocsp/TestOcspSoftFailTryLater.java
+++ b/test/org/apache/tomcat/util/net/ocsp/TestOcspSoftFailTryLater.java
@@ -16,6 +16,7 @@
  */
 package org.apache.tomcat.util.net.ocsp;
 
+import java.net.BindException;
 import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -42,13 +43,36 @@ public class TestOcspSoftFailTryLater extends OcspBaseTest {
 
     @BeforeClass
     public static void startOcspResponder() {
-        ocspResponder = new TesterOcspResponder();
-        ocspResponder.setFixedResponse(OcspResponse.TRY_LATER);
+        TesterOcspResponder responder = new TesterOcspResponder();
+        responder.setFixedResponse(OcspResponse.TRY_LATER);
         try {
-            ocspResponder.start();
+            responder.start();
+            ocspResponder = responder;
         } catch (Exception e) {
-            e.printStackTrace();
+            responder.stop();
+            if (isBindException(e)) {
+                // The fixed OCSP responder port (8888, baked into the test
+                // certificates) is in use by another process. This is an
+                // environmental issue, so leave ocspResponder null to skip the
+                // tests rather than reporting spurious failures.
+                ocspResponder = null;
+                e.printStackTrace();
+            } else {
+                // Any other startup failure is a genuine problem.
+                throw new IllegalStateException("Failed to start OCSP responder", e);
+            }
         }
+    }
+
+
+    private static boolean isBindException(Throwable t) {
+        while (t != null) {
+            if (t instanceof BindException) {
+                return true;
+            }
+            t = t.getCause();
+        }
+        return false;
     }
 
 
@@ -96,7 +120,7 @@ public class TestOcspSoftFailTryLater extends OcspBaseTest {
 
     @Test
     public void test() throws Exception {
-        Assume.assumeNotNull(ocspResponder);
+        Assume.assumeTrue("OCSP responder unavailable (port 8888 in use?)", ocspResponder != null);
         try {
             doTest(clientCertValid, true, ClientCertificateVerification.ENABLED, false, softFail);
             if (handshakeFailureExpected) {


### PR DESCRIPTION
`TesterOcspResponder` binds to a fixed port, 8888 (which is baked into the test certificates' AIA extension), so it cannot start when another process is already using that port. The existing `Assume.assumeNotNull(ocspResponder)` guard was not enough because the field was assigned before `start()` was  called and the bind failure was only printed, leaving the field non-null and causing all tests to fail during the TLS handshake. This change only assigns `ocspResponder` on a successful start. On a `BindException`, we leave the field `null` so the tests are skipped as an environmental issue rather than failing. Any other startup failure is rethrown so genuine responder bugs are not masked.

Submitting a PR to get consensus on whether or not this is the correct behavior, or if we feel a failure is appropriate.