### PR TITLE
Upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Git Checkout
       uses: actions/checkout@v7
     - name: Set up Java
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         java-version: 25
         distribution: zulu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Git Checkout
       uses: actions/checkout@v7
     - name: Set up Java
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         java-version: ${{ matrix.java }}
         distribution: zulu

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
-    - uses: actions/setup-java@v5
+    - uses: actions/setup-java@v6
       with:
         java-version: 21
         distribution: temurin

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Git Checkout
       uses: actions/checkout@v7
     - name: Set up Java
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         java-version: ${{ matrix.java }}
         distribution: zulu


### PR DESCRIPTION
## Summary

Upgrade `actions/setup-java` from v5 to v6 in every active workflow that uses it.

## Testing

- Ran `git diff --check`.
- Verified no pre-v6 `actions/setup-java` references remain in active workflows.
