### PR TITLE
Allow Request#getDateHeader to parse dates in RFC 9651 Structured Field Values format

### DIFF
--- a/java/org/apache/tomcat/util/http/ConcurrentDateFormat.java
+++ b/java/org/apache/tomcat/util/http/ConcurrentDateFormat.java
@@ -28,7 +28,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  * A thread safe wrapper around {@link SimpleDateFormat} that does not make use of ThreadLocal and - broadly - only
  * creates enough SimpleDateFormat objects to satisfy the concurrency requirements.
  */
-public class ConcurrentDateFormat {
+public class ConcurrentDateFormat implements FastHttpDateFormat.TryParseDateToTimestamp {
 
     private final String format;
     private final Locale locale;
@@ -86,6 +86,11 @@ public class ConcurrentDateFormat {
             sdf.setTimeZone(timezone);
             queue.add(sdf);
         }
+    }
+
+    @Override
+    public long tryParseDate(String dateString) throws ParseException {
+        return parse(dateString).getTime();
     }
 
     private SimpleDateFormat createInstance() {

--- a/java/org/apache/tomcat/util/http/ConcurrentDateFormat.java
+++ b/java/org/apache/tomcat/util/http/ConcurrentDateFormat.java
@@ -89,8 +89,12 @@ public class ConcurrentDateFormat implements FastHttpDateFormat.TryParseDateToTi
     }
 
     @Override
-    public long tryParseDate(String dateString) throws ParseException {
-        return parse(dateString).getTime();
+    public long tryParseDate(String dateString) {
+        try {
+            return parse(dateString).getTime();
+        } catch (ParseException e) {
+            return -1;
+        }
     }
 
     private SimpleDateFormat createInstance() {

--- a/java/org/apache/tomcat/util/http/FastHttpDateFormat.java
+++ b/java/org/apache/tomcat/util/http/FastHttpDateFormat.java
@@ -63,13 +63,13 @@ public final class FastHttpDateFormat {
         FORMAT_OBSOLETE_ASCTIME = new ConcurrentDateFormat(DATE_OBSOLETE_ASCTIME, Locale.US, tz);
         FORMAT_RFC9651 = dateString -> {
             if(dateString == null || !dateString.startsWith("@")) {
-                throw new ParseException("Date " + dateString + " not in RFC 9651 format", 0);
+                return -1;
             }
             try {
                 // An RFC 9651 timestamp is in seconds, not milliseconds.
                 return Long.parseLong(dateString.substring(1)) * 1_000;
             } catch (NumberFormatException e) {
-                throw new ParseException("Unable to parse number in date string " + dateString, 1);
+                return -1;
             }
         };
 
@@ -158,13 +158,9 @@ public final class FastHttpDateFormat {
 
         long date = -1;
         for (int i = 0; (date == -1) && (i < httpParseFormats.length); i++) {
-            try {
-                date = httpParseFormats[i].tryParseDate(value);
-                updateParseCache(value, Long.valueOf(date));
-            } catch (ParseException e) {
-                // Ignore
-            }
+            date = httpParseFormats[i].tryParseDate(value);
         }
+        updateParseCache(value, Long.valueOf(date));
 
         return date;
     }
@@ -203,9 +199,8 @@ public final class FastHttpDateFormat {
          * Tries to parse the given string as a date and returns it as a timestamp.
          *
          * @param dateString the string representation of the date trying to be parsed
-         * @return the number of *milli*seconds since January 1, 1970, 00:00:00 GMT
-         * @throws ParseException if dateString cannot be parsed
+         * @return the number of *milli*seconds since January 1, 1970, 00:00:00 GMT or -1 if parsing failed
          */
-        long tryParseDate(String dateString) throws ParseException;
+        long tryParseDate(String dateString);
     }
 }

--- a/java/org/apache/tomcat/util/http/FastHttpDateFormat.java
+++ b/java/org/apache/tomcat/util/http/FastHttpDateFormat.java
@@ -66,7 +66,8 @@ public final class FastHttpDateFormat {
                 throw new ParseException("Date " + dateString + " not in RFC 9651 format", 0);
             }
             try {
-                return Long.parseLong(dateString.substring(1));
+                // An RFC 9651 timestamp is in seconds, not milliseconds.
+                return Long.parseLong(dateString.substring(1)) * 1_000;
             } catch (NumberFormatException e) {
                 throw new ParseException("Unable to parse number in date string " + dateString, 1);
             }
@@ -198,6 +199,13 @@ public final class FastHttpDateFormat {
 
     @FunctionalInterface
     interface TryParseDateToTimestamp {
+        /**
+         * Tries to parse the given string as a date and returns it as a timestamp.
+         *
+         * @param dateString the string representation of the date trying to be parsed
+         * @return the number of *milli*seconds since January 1, 1970, 00:00:00 GMT
+         * @throws ParseException if dateString cannot be parsed
+         */
         long tryParseDate(String dateString) throws ParseException;
     }
 }

--- a/java/org/apache/tomcat/util/http/FastHttpDateFormat.java
+++ b/java/org/apache/tomcat/util/http/FastHttpDateFormat.java
@@ -50,8 +50,9 @@ public final class FastHttpDateFormat {
     private static final ConcurrentDateFormat FORMAT_RFC5322;
     private static final ConcurrentDateFormat FORMAT_OBSOLETE_RFC850;
     private static final ConcurrentDateFormat FORMAT_OBSOLETE_ASCTIME;
+    private static final TryParseDateToTimestamp FORMAT_RFC9651;
 
-    private static final ConcurrentDateFormat[] httpParseFormats;
+    private static final TryParseDateToTimestamp[] httpParseFormats;
 
     static {
         // All the formats that use a timezone use GMT
@@ -60,9 +61,19 @@ public final class FastHttpDateFormat {
         FORMAT_RFC5322 = new ConcurrentDateFormat(DATE_RFC5322, Locale.US, tz);
         FORMAT_OBSOLETE_RFC850 = new ConcurrentDateFormat(DATE_OBSOLETE_RFC850, Locale.US, tz);
         FORMAT_OBSOLETE_ASCTIME = new ConcurrentDateFormat(DATE_OBSOLETE_ASCTIME, Locale.US, tz);
+        FORMAT_RFC9651 = dateString -> {
+            if(dateString == null || !dateString.startsWith("@")) {
+                throw new ParseException("Date " + dateString + " not in RFC 9651 format", 0);
+            }
+            try {
+                return Long.parseLong(dateString.substring(1));
+            } catch (NumberFormatException e) {
+                throw new ParseException("Unable to parse number in date string " + dateString, 1);
+            }
+        };
 
         httpParseFormats =
-                new ConcurrentDateFormat[] { FORMAT_RFC5322, FORMAT_OBSOLETE_RFC850, FORMAT_OBSOLETE_ASCTIME };
+                new TryParseDateToTimestamp[] { FORMAT_RFC5322, FORMAT_OBSOLETE_RFC850, FORMAT_OBSOLETE_ASCTIME, FORMAT_RFC9651 };
     }
 
     /**
@@ -147,7 +158,7 @@ public final class FastHttpDateFormat {
         long date = -1;
         for (int i = 0; (date == -1) && (i < httpParseFormats.length); i++) {
             try {
-                date = httpParseFormats[i].parse(value).getTime();
+                date = httpParseFormats[i].tryParseDate(value);
                 updateParseCache(value, Long.valueOf(date));
             } catch (ParseException e) {
                 // Ignore
@@ -185,5 +196,8 @@ public final class FastHttpDateFormat {
         parseCache.put(key, value);
     }
 
-
+    @FunctionalInterface
+    interface TryParseDateToTimestamp {
+        long tryParseDate(String dateString) throws ParseException;
+    }
 }

--- a/test/org/apache/tomcat/util/http/TestFastHttpDateFormat.java
+++ b/test/org/apache/tomcat/util/http/TestFastHttpDateFormat.java
@@ -1,3 +1,4 @@
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -71,5 +72,24 @@ public class TestFastHttpDateFormat {
             }
             Assert.assertTrue("Saw [" + changes + "] changes in formatted date", changes > 1 && changes < 5);
         }
+    }
+
+    @Test
+    public void testRfc9651Date_valid() {
+        Assert.assertEquals(0L, FastHttpDateFormat.parseDate("@0"));
+        Assert.assertEquals(1659578233L, FastHttpDateFormat.parseDate("@1659578233")); // Example from RFC
+        Assert.assertEquals(-62135596800L, FastHttpDateFormat.parseDate("@-62135596800")); // Example from RFC
+        Assert.assertEquals(253402214400L, FastHttpDateFormat.parseDate("@253402214400")); // Example from RFC
+    }
+
+    @Test
+    public void testRfc9651Date_invalid() {
+        Assert.assertEquals(-1L, FastHttpDateFormat.parseDate("@"));
+        Assert.assertEquals(-1L, FastHttpDateFormat.parseDate("@-1")); //  Technically valid but we use -1 as a sentinel
+        Assert.assertEquals(-1L, FastHttpDateFormat.parseDate(" @1"));
+        Assert.assertEquals(-1L, FastHttpDateFormat.parseDate("@0000-"));
+        Assert.assertEquals(-1L, FastHttpDateFormat.parseDate("@15+"));
+        Assert.assertEquals(-1L, FastHttpDateFormat.parseDate("@12p"));
+        Assert.assertEquals(-1L, FastHttpDateFormat.parseDate("@0x15"));
     }
 }

--- a/test/org/apache/tomcat/util/http/TestFastHttpDateFormat.java
+++ b/test/org/apache/tomcat/util/http/TestFastHttpDateFormat.java
@@ -77,16 +77,18 @@ public class TestFastHttpDateFormat {
     @Test
     public void testRfc9651Date_valid() {
         Assert.assertEquals(0L, FastHttpDateFormat.parseDate("@0"));
-        Assert.assertEquals(1659578233L, FastHttpDateFormat.parseDate("@1659578233")); // Example from RFC
-        Assert.assertEquals(-62135596800L, FastHttpDateFormat.parseDate("@-62135596800")); // Example from RFC
-        Assert.assertEquals(253402214400L, FastHttpDateFormat.parseDate("@253402214400")); // Example from RFC
+        Assert.assertEquals(1000L, FastHttpDateFormat.parseDate("@1"));
+        Assert.assertEquals(-1000L, FastHttpDateFormat.parseDate("@-1"));
+        Assert.assertEquals(1659578233000L, FastHttpDateFormat.parseDate("@1659578233")); // Example from RFC
+        Assert.assertEquals(-62135596800000L, FastHttpDateFormat.parseDate("@-62135596800")); // Example from RFC
+        Assert.assertEquals(253402214400000L, FastHttpDateFormat.parseDate("@253402214400")); // Example from RFC
     }
 
     @Test
     public void testRfc9651Date_invalid() {
         Assert.assertEquals(-1L, FastHttpDateFormat.parseDate("@"));
-        Assert.assertEquals(-1L, FastHttpDateFormat.parseDate("@-1")); //  Technically valid but we use -1 as a sentinel
         Assert.assertEquals(-1L, FastHttpDateFormat.parseDate(" @1"));
+        Assert.assertEquals(-1L, FastHttpDateFormat.parseDate("@ 1"));
         Assert.assertEquals(-1L, FastHttpDateFormat.parseDate("@0000-"));
         Assert.assertEquals(-1L, FastHttpDateFormat.parseDate("@15+"));
         Assert.assertEquals(-1L, FastHttpDateFormat.parseDate("@12p"));


### PR DESCRIPTION
[RFC 9651 (Structured Field Values for HTTP)](https://datatracker.ietf.org/doc/rfc9651/) defines formats for header values of specific types. The format it uses for dates is `@«timestamp»`, which is different from other date headers.

This PR aims to support the date header format from RFC 9651 in `org.apache.catalina.connector.Request#getDateHeader(String)`.
