### PR TITLE
Validate duplicate TLD functions during parsing

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -369,14 +369,13 @@ These are bugs, correctness issues, or missing functionality that may affect pro
 
 ---
 
-### 32. Jasper TLD Validation (2 items)
+### 32. Jasper TLD Validation (1 item)
 
 | # | File:Line | Description | Fix Idea | Effort | Difficulty |
 |---|-----------|-------------|----------|--------|------------|
-| 32.1 | `TagLibraryInfoImpl.java:193` | Duplicate function name validation should move to parsing stage | Add duplicate name detection in the TLD parser (`TaglibXmlParser`) before the `TagLibraryInfoImpl` is constructed. | 1 day | Medium |
 | 32.2 | `TagLibraryInfoImpl.java:231` | URL resolution logic for TLD resource paths looks incorrect | Audit the URI resolution logic against JSP spec section 7.3.6.2. Fix any deviations. | 1-2 days | Medium |
 
-**Total estimated effort: 2-3 days, Medium difficulty**
+**Total estimated effort: 1-2 days, Medium difficulty**
 
 ---
 

--- a/java/org/apache/jasper/compiler/TagLibraryInfoImpl.java
+++ b/java/org/apache/jasper/compiler/TagLibraryInfoImpl.java
@@ -26,10 +26,8 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import jakarta.servlet.jsp.tagext.FunctionInfo;
 import jakarta.servlet.jsp.tagext.PageData;
@@ -188,15 +186,7 @@ class TagLibraryInfoImpl extends TagLibraryInfo implements TagConstants {
                 tagFileInfos.add(createTagFileInfo(tagFileXml, jar));
             }
 
-            Set<String> names = new HashSet<>();
             List<FunctionInfo> functionInfos = taglibXml.getFunctions();
-            // TODO Move this validation to the parsing stage
-            for (FunctionInfo functionInfo : functionInfos) {
-                String name = functionInfo.getName();
-                if (!names.add(name)) {
-                    err.jspError("jsp.error.tld.fn.duplicate.name", name, uri);
-                }
-            }
 
             if (tlibversion == null) {
                 err.jspError("jsp.error.tld.mandatory.element.missing", "tlib-version", uri);

--- a/java/org/apache/jasper/resources/LocalStrings.properties
+++ b/java/org/apache/jasper/resources/LocalStrings.properties
@@ -227,7 +227,6 @@ jsp.error.taglibDirective.uriInvalid=The URI provided for a tag library [{0}] is
 jsp.error.tei.invalid.attributes=Validation error messages from TagExtraInfo for [{0}]
 jsp.error.teiclass.instantiation=Failed to load or instantiate TagExtraInfo class: [{0}]
 jsp.error.text.has_subelement=&lt;jsp:text&gt; must not have any subelements
-jsp.error.tld.fn.duplicate.name=Duplicate function name [{0}] in tag library [{1}]
 jsp.error.tld.fn.invalid.signature=Invalid syntax for function signature in TLD.  Tag Library: [{0}], Function: [{1}]
 jsp.error.tld.invalid_tld_file=Invalid tld file: [{0}], see JSP specification section 7.3.1 for more details
 jsp.error.tld.mandatory.element.missing=Mandatory TLD element [{0}] missing or empty in TLD [{1}]

--- a/java/org/apache/tomcat/util/descriptor/tld/LocalStrings.properties
+++ b/java/org/apache/tomcat/util/descriptor/tld/LocalStrings.properties
@@ -14,3 +14,5 @@
 # limitations under the License.
 
 implicitTldRule.elementNotAllowed=The element [{0}] is not permitted in an implicit.tld file
+
+taglibXml.duplicateFunction=Duplicate function name [{0}] in tag library

--- a/java/org/apache/tomcat/util/descriptor/tld/TaglibXml.java
+++ b/java/org/apache/tomcat/util/descriptor/tld/TaglibXml.java
@@ -17,9 +17,13 @@
 package org.apache.tomcat.util.descriptor.tld;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import jakarta.servlet.jsp.tagext.FunctionInfo;
+
+import org.apache.tomcat.util.res.StringManager;
 
 /**
  * Common representation of a Tag Library Descriptor (TLD) XML file.
@@ -29,6 +33,9 @@ import jakarta.servlet.jsp.tagext.FunctionInfo;
  * contain the uri and prefix values used by a JSP to reference this tag library.
  */
 public class TaglibXml {
+
+    private static final StringManager sm = StringManager.getManager(TaglibXml.class);
+
     /**
      * Constructs a new TaglibXml.
      */
@@ -84,6 +91,11 @@ public class TaglibXml {
      * The list of function definitions.
      */
     private final List<FunctionInfo> functions = new ArrayList<>();
+
+    /**
+     * The function names used to detect duplicate definitions.
+     */
+    private final Set<String> functionNames = new HashSet<>();
 
     /**
      * Returns the tag library version.
@@ -234,8 +246,12 @@ public class TaglibXml {
      * @param name the function name
      * @param klass the function class
      * @param signature the function signature
+     * @throws IllegalArgumentException if a function with the same name has already been added
      */
     public void addFunction(String name, String klass, String signature) {
+        if (!functionNames.add(name)) {
+            throw new IllegalArgumentException(sm.getString("taglibXml.duplicateFunction", name));
+        }
         functions.add(new FunctionInfo(name, klass, signature));
     }
 

--- a/test/org/apache/tomcat/util/descriptor/tld/TestTldParser.java
+++ b/test/org/apache/tomcat/util/descriptor/tld/TestTldParser.java
@@ -164,6 +164,14 @@ public class TestTldParser {
         Assert.assertEquals("org.apache.catalina.core.TesterTldListener", listeners.get(0));
     }
 
+    @Test
+    public void testDuplicateFunctionName() {
+        parser = new TldParser(true, false, new TldRuleSet(), true);
+        SAXException exception =
+                Assert.assertThrows(SAXException.class, () -> parse("test/tld/duplicate-function.tld"));
+        Assert.assertTrue(exception.getMessage(), exception.getMessage().contains("Duplicate function name [trim]"));
+    }
+
     private TaglibXml parse(String pathname) throws IOException, SAXException {
         File file = new File(pathname);
         TldResourcePath path = new TldResourcePath(file.toURI().toURL(), null);

--- a/test/tld/duplicate-function.tld
+++ b/test/tld/duplicate-function.tld
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<taglib xmlns="https://jakarta.ee/xml/ns/jakartaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+      https://jakarta.ee/xml/ns/jakartaee/web-jsptaglibrary_4_0.xsd"
+      version="4.0">
+  <tlib-version>1.0</tlib-version>
+  <short-name>duplicate-function</short-name>
+
+  <function>
+    <name>trim</name>
+    <function-class>org.apache.el.TesterFunctions</function-class>
+    <function-signature>
+      java.lang.String trim(java.lang.String)
+    </function-signature>
+  </function>
+  <function>
+    <name>trim</name>
+    <function-class>org.apache.el.TesterFunctions</function-class>
+    <function-signature>
+      java.lang.String trim(java.lang.String)
+    </function-signature>
+  </function>
+</taglib>

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -372,6 +372,11 @@
         Add support for <code>java.util.Optional</code> to the empty operator.
         (markt)
       </add>
+      <fix>
+        Detect duplicate function names while parsing a tag library descriptor
+        rather than when constructing its <code>TagLibraryInfo</code>.
+        (sainadh777)
+      </fix>
       <!-- Entries for backport and removal before 12.0.0-M1 below this line -->
     </changelog>
   </subsection>


### PR DESCRIPTION
## Summary

- detect duplicate TLD function names while the descriptor is parsed
- remove the later duplicate-name pass from `TagLibraryInfoImpl`
- add parser-level regression coverage and complete checked-in TODO 32.1

## Rationale and impact

The TLD data model now rejects a duplicate as soon as the second function is added during parsing. This keeps descriptor validation with the parser, avoids constructing a partially invalid `TaglibXml`, and preserves the existing user-visible validation behavior with a message owned by the TLD descriptor package.

The change is limited to duplicate function-name validation. Valid tag libraries are unaffected.

## Validation

All commands ran with Eclipse Temurin JDK 25 and Ant 1.10.15 in Linux. The complete suite used a native case-sensitive Linux filesystem rather than the macOS-backed bind mount.

- `/opt/ant/bin/ant -Dbase.path=/tomcat-build-libs -Dtest.entry=org.apache.tomcat.util.descriptor.tld.TestTldParser test`
  - BUILD SUCCESSFUL; 7 tests, 0 failures, 0 errors, 0 skipped
- `/opt/ant/bin/ant -Dbase.path=/tomcat-build-libs -Dexecute.validate=true validate`
  - BUILD SUCCESSFUL; Checkstyle 13.9.0 completed
- `/opt/ant/bin/ant -Dbase.path=/tomcat-build-libs clean deploy`
  - BUILD SUCCESSFUL
- `/opt/ant/bin/ant -quiet -Dbase.path=/tomcat-build-libs test`
  - BUILD SUCCESSFUL in 30m45s; 651 suites, 41,276 tests, 0 failures, 0 errors, 316 environment/feature skips
- generated-distribution runtime smoke test
  - `startup.sh` started Tomcat; `GET /` returned HTTP 200; `shutdown.sh` stopped Tomcat and the recorded PID exited cleanly
