### PR TITLE
Add OpenSSL cipher operator tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -902,16 +902,6 @@ These are bugs, correctness issues, or missing functionality that may affect pro
 
 ---
 
-### 81. OpenSSL Cipher Test Coverage (1 item)
-
-| # | File:Line | Description | Fix Idea | Effort | Difficulty |
-|---|-----------|-------------|----------|--------|------------|
-| 81.1 | `TestOpenSSLCipherConfigurationParser.java:497` | Individual operator tests missing | Add unit tests for each cipher string operator: `+`, `-`, `!`, `@`, colon separator, etc. | 1-2 days | Medium |
-
-**Total estimated effort: 1-2 days, Medium difficulty**
-
----
-
 ### 82. OCSP Test Hardcoded Serials (1 item)
 
 | # | File:Line | Description | Fix Idea | Effort | Difficulty |

--- a/test/org/apache/tomcat/util/net/openssl/ciphers/TestOpenSSLCipherConfigurationParser.java
+++ b/test/org/apache/tomcat/util/net/openssl/ciphers/TestOpenSSLCipherConfigurationParser.java
@@ -440,7 +440,42 @@ public class TestOpenSSLCipherConfigurationParser {
     }
 
 
-    // TODO: Add tests for the individual operators
+    @Test
+    public void testOperatorExclude() throws Exception {
+        testSpecification("AES128:!SHA256:SHA256");
+    }
+
+
+    @Test
+    public void testOperatorDelete() throws Exception {
+        testSpecification("AES128:-SHA256:SHA256");
+    }
+
+
+    @Test
+    public void testOperatorMoveToEnd() throws Exception {
+        testSpecification("AES128:AES256:+AES128");
+    }
+
+
+    @Test
+    public void testOperatorIntersection() throws Exception {
+        testSpecification("AES128+SHA256");
+    }
+
+
+    @Test
+    public void testOperatorStrengthSort() throws Exception {
+        testSpecification("AES128:AES256:@STRENGTH");
+    }
+
+
+    @Test
+    public void testSeparators() throws Exception {
+        testSpecification("AES128:AES256");
+        testSpecification("AES128,AES256");
+        testSpecification("AES128 AES256");
+    }
 
     @Test
     public void testSpecification01() throws Exception {


### PR DESCRIPTION
## Summary

- add focused coverage for each OpenSSL cipher expression operator: `!`, `-`, `+`, intersection, and `@STRENGTH`
- verify colon, comma, and space separators independently
- remove completed TODO item 81.1

## Rationale

The parser integration test compared a number of compound expressions with the installed OpenSSL implementation, but it did not isolate each operator. These focused cases make regressions in exclusion, deletion/re-addition, ordering, intersection, strength sorting, and separator handling easier to identify.

## Impact

Test-only change. There is no runtime behavior or public API change, so no changelog entry is included.

## Validation

Environment: Ubuntu 22.04 container on Linux 6.8 (aarch64), Eclipse Temurin 21.0.12, Ant 1.10.12, OpenSSL 3.0.2.

- `ant -Dbase.path=/workspace-cache -Dexecute.validate=true validate`
  - `BUILD SUCCESSFUL`; Checkstyle 14.1.0 checked 7,685 files.
- `ant -Dbase.path=/workspace-cache -Dtest.entry=org.apache.tomcat.util.net.openssl.ciphers.TestOpenSSLCipherConfigurationParser test`
  - `BUILD SUCCESSFUL`; 79 tests, 0 failures, 0 errors, 0 skipped.
- `ant -Dbase.path=/workspace-cache clean`
  - `BUILD SUCCESSFUL`.
- `ant -Dbase.path=/workspace-cache`
  - `BUILD SUCCESSFUL` (clean source/distribution build).
- First `ant -Dbase.path=/workspace-cache test` on a macOS-backed container bind mount
  - failed after 371m34s in five unrelated suites because the mount retained macOS case behavior and severe I/O timing distortion.
- Each failed suite rerun on the container's native Linux filesystem:
  - `TestGroupChannelMemberArrival`: `BUILD SUCCESSFUL` (32s).
  - `TestDirResourceSetReadOnly`: `BUILD SUCCESSFUL` (3s).
  - `TestChunkedInputFilter`: `BUILD SUCCESSFUL` (29s).
  - `TestHttp2Section_6_8`: `BUILD SUCCESSFUL` (29s).
  - `TestWsWebSocketContainerTimeoutClient`: `BUILD SUCCESSFUL` (14s).
- Clean native-Linux `ant -Dbase.path=/workspace-cache test`
  - `BUILD SUCCESSFUL` in 99m38s; 652 suites, 41,327 tests, 0 failures, 0 errors, 330 skipped.
- Generated-distribution smoke test
  - started `/linux-workspace/output/build`, received HTTP 200 from `http://127.0.0.1:8080/`, accepted the shutdown command, exited with status 0, and was reaped cleanly.

The two tested source files were SHA-256 matched byte-for-byte to commit `d6d450fd9b938b95a397fa4a957b573c07e74af2` before pushing.
