### PR TITLE
Fix 70208: Strengthen app context comparison logic

### DIFF
--- a/java/org/apache/catalina/util/RequestUtil.java
+++ b/java/org/apache/catalina/util/RequestUtil.java
@@ -111,6 +111,40 @@ public final class RequestUtil {
 
 
     /**
+     * Strip parameters for given path.
+     *
+     * @param input   the input path
+     * @param request the request to add the parameters to
+     *
+     * @return the cleaned path
+     */
+    public static String stripPathParams(String input) {
+        // Shortcut
+        if (input.indexOf(';') < 0) {
+            return input;
+        }
+
+        StringBuilder sb = new StringBuilder(input.length());
+        int pos = 0;
+        int limit = input.length();
+        while (pos < limit) {
+            int nextSemiColon = input.indexOf(';', pos);
+            if (nextSemiColon < 0) {
+                nextSemiColon = limit;
+            }
+            sb.append(input, pos, nextSemiColon);
+            int followingSlash = input.indexOf('/', nextSemiColon);
+            if (followingSlash < 0) {
+                pos = limit;
+            } else {
+                pos = followingSlash;
+            }
+        }
+
+        return sb.toString();
+    }
+
+    /**
      * Tests whether the provided URL is for a resource contained within the same web application as the request.
      *
      * @param request The request to test
@@ -148,14 +182,26 @@ public final class RequestUtil {
         }
 
         /*
-         * This isn't perfect but is the best that can be done without running the full mapping logic on the url to
-         * determine which web application that url will map to.
+         * May not perfect, but try best to determine whether the url belongs to current request or not.
          */
-        if (!url.getPath().startsWith(request.getServletContext().getContextPath())) {
+        String urlPath = url.getPath();
+        urlPath = stripPathParams(urlPath);
+        urlPath = org.apache.tomcat.util.http.RequestUtil.normalize(urlPath);
+        String requestContextPath = request.getServletContext().getContextPath();
+        
+        if(urlPath==null) {
             return false;
         }
-
-        return true;
+        
+        if(urlPath.equals(requestContextPath)) {
+            return true;
+        } else if(requestContextPath.endsWith("/") && urlPath.startsWith(requestContextPath)) {
+            return true;
+        } else if(urlPath.startsWith(requestContextPath+"/")) {
+            return true;
+        } else {
+            return false;
+        }
     }
 
 

--- a/test/org/apache/catalina/connector/TestResponse.java
+++ b/test/org/apache/catalina/connector/TestResponse.java
@@ -349,7 +349,11 @@ public class TestResponse extends TomcatBaseTest {
 
 
     private void doTestEncodeURL(String location, String expected) {
-        Request req = new TesterRequest(true);
+        doTestEncodeURL("", location, expected);
+    }
+
+    private void doTestEncodeURL(String currentContextPath, String location, String expected) {
+        Request req = new TesterRequest(true,"/level1/level2/foo.html", currentContextPath);
         req.setRequestedSessionId("1234");
         req.setRequestedSessionURL(true);
         Response resp = new Response(null);
@@ -358,7 +362,6 @@ public class TestResponse extends TomcatBaseTest {
         String result = resp.encodeURL(location);
         Assert.assertEquals(expected, result);
     }
-
 
     @Test
     public void testEncodeURL01() throws Exception {
@@ -454,7 +457,27 @@ public class TestResponse extends TomcatBaseTest {
         doTestEncodeURL("./..#/../..", "./..;jsessionid=1234#/../..");
     }
 
+    @Test
+    public void testEncodeURLBug70208a() throws Exception {
+        doTestEncodeURL("/admin", "/admin/index", "/admin/index;jsessionid=1234");
+    }
 
+    @Test
+    public void testEncodeURLBug70208b() throws Exception {
+        doTestEncodeURL("/admin", "/admin/../public/index", "/admin/../public/index");
+    }
+
+    @Test
+    public void testEncodeURLBug70208c() throws Exception {
+        doTestEncodeURL("/admin", "/public/..;/admin/index;jsessionid=zzz",
+                "/public/..;/admin/index;jsessionid=zzz;jsessionid=1234");
+    }
+
+    @Test
+    public void testEncodeURLBug70208d() throws Exception {
+        doTestEncodeURL("/admin", "/administrator/index",
+                "/administrator/index");
+    }
     private void doTestEncodeRedirectURL(String location, String expected) {
         Request req = new TesterRequest(true);
         req.setRequestedSessionId("1234");

--- a/test/org/apache/tomcat/unittest/TesterRequest.java
+++ b/test/org/apache/tomcat/unittest/TesterRequest.java
@@ -56,9 +56,13 @@ public class TesterRequest extends Request {
 
 
     public TesterRequest(boolean withSession, String requestUri) {
+        this(withSession, requestUri, "");
+    }
+
+    public TesterRequest(boolean withSession, String requestUri, String reqContextPath) {
         super(null, null);
         context = new TesterContext();
-        servletContext = new TesterServletContext();
+        servletContext = new TesterServletContext(reqContextPath);
         context.setServletContext(servletContext);
         if (withSession) {
             Set<SessionTrackingMode> modes = new HashSet<>();
@@ -71,8 +75,7 @@ public class TesterRequest extends Request {
         }
         this.requestUri = requestUri;
     }
-
-
+    
     @Override
     public String getScheme() {
         return "http";

--- a/test/org/apache/tomcat/unittest/TesterServletContext.java
+++ b/test/org/apache/tomcat/unittest/TesterServletContext.java
@@ -43,6 +43,15 @@ import org.apache.tomcat.util.descriptor.web.FilterDef;
 
 public class TesterServletContext implements ServletContext {
 
+    private String contextPath = "";
+    
+    public TesterServletContext() {
+        this("");
+    }
+    
+    public TesterServletContext(String contextPath) {
+        this.contextPath=contextPath;
+    }
     /**
      * {@inheritDoc}
      * <p>
@@ -50,7 +59,7 @@ public class TesterServletContext implements ServletContext {
      */
     @Override
     public String getContextPath() {
-        return "";
+        return contextPath;
     }
 
     /**


### PR DESCRIPTION
Strip Path Param and normalize it before context-path matching, may not perfect but do more.