### PR TITLE
Load OCSP test status from certificate database

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -912,16 +912,6 @@ These are bugs, correctness issues, or missing functionality that may affect pro
 
 ---
 
-### 82. OCSP Test Hardcoded Serials (1 item)
-
-| # | File:Line | Description | Fix Idea | Effort | Difficulty |
-|---|-----------|-------------|----------|--------|------------|
-| 82.1 | `TesterOcspResponderServlet.java:221` | Certificate serial numbers hardcoded instead of read from index.db | Parse the OpenSSL CA `index.txt` file to extract serial numbers dynamically. | 1 day | Medium |
-
-**Total estimated effort: 1 day, Medium difficulty**
-
----
-
 ### 83. EL in JSP Escape Test (1 item)
 
 | # | File:Line | Description | Fix Idea | Effort | Difficulty |

--- a/test/org/apache/tomcat/util/net/ocsp/TestTesterOcspResponderServlet.java
+++ b/test/org/apache/tomcat/util/net/ocsp/TestTesterOcspResponderServlet.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tomcat.util.net.ocsp;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.math.BigInteger;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.apache.tomcat.util.net.ocsp.TesterOcspResponderServlet.CertificateState;
+
+public class TestTesterOcspResponderServlet {
+
+    @Test
+    public void testLoadCertificateStatuses() throws IOException {
+        String input = "V\t280811131918Z\t\t1000\tunknown\t/CN=valid\n" +
+                "R\t280811131918Z\t260812131922Z\t1001\tunknown\t/CN=revoked\n" +
+                "E\t250811131918Z\t\t1002\tunknown\t/CN=expired\n";
+
+        Map<BigInteger,CertificateState> statuses =
+                TesterOcspResponderServlet.loadCertificateStatuses(new StringReader(input));
+
+        Assert.assertEquals(2, statuses.size());
+        Assert.assertSame(CertificateState.GOOD, statuses.get(new BigInteger("1000", 16)));
+        Assert.assertSame(CertificateState.REVOKED, statuses.get(new BigInteger("1001", 16)));
+        Assert.assertNull(statuses.get(new BigInteger("1002", 16)));
+    }
+}

--- a/test/org/apache/tomcat/util/net/ocsp/TesterOcspResponderServlet.java
+++ b/test/org/apache/tomcat/util/net/ocsp/TesterOcspResponderServlet.java
@@ -16,8 +16,11 @@
  */
 package org.apache.tomcat.util.net.ocsp;
 
+import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.Reader;
+import java.math.BigInteger;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
@@ -28,6 +31,8 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Base64;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;
@@ -82,6 +87,12 @@ public class TesterOcspResponderServlet extends HttpServlet {
     private X509CertificateHolder[] responderCertificateChain;
     private RespID responderID;
     private ContentSigner contentSigner;
+    private Map<BigInteger,CertificateState> certificateStatuses;
+
+    enum CertificateState {
+        GOOD,
+        REVOKED
+    }
 
 
     @Override
@@ -89,6 +100,12 @@ public class TesterOcspResponderServlet extends HttpServlet {
         String value = config.getInitParameter(INIT_FIXED_RESPONSE);
         if (value != null) {
             fixedResponse = TesterOcspResponder.OcspResponse.valueOf(value);
+        }
+
+        try (FileReader reader = new FileReader(TesterSupport.DB_INDEX)) {
+            certificateStatuses = loadCertificateStatuses(reader);
+        } catch (IOException e) {
+            throw new ServletException(e);
         }
 
         // Enable the Bouncy Castle Provider
@@ -159,6 +176,37 @@ public class TesterOcspResponderServlet extends HttpServlet {
     }
 
 
+    static Map<BigInteger,CertificateState> loadCertificateStatuses(Reader input) throws IOException {
+        Map<BigInteger,CertificateState> result = new HashMap<>();
+        BufferedReader reader = new BufferedReader(input);
+        String line;
+        int lineNumber = 0;
+        while ((line = reader.readLine()) != null) {
+            lineNumber++;
+            String[] fields = line.split("\\t", -1);
+            if (fields.length < 4) {
+                throw new IOException("Invalid certificate database entry at line " + lineNumber);
+            }
+
+            CertificateState state;
+            if ("V".equals(fields[0])) {
+                state = CertificateState.GOOD;
+            } else if ("R".equals(fields[0])) {
+                state = CertificateState.REVOKED;
+            } else {
+                continue;
+            }
+
+            try {
+                result.put(new BigInteger(fields[3], 16), state);
+            } catch (NumberFormatException e) {
+                throw new IOException("Invalid certificate serial at line " + lineNumber, e);
+            }
+        }
+        return Map.copyOf(result);
+    }
+
+
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
 
@@ -217,21 +265,18 @@ public class TesterOcspResponderServlet extends HttpServlet {
         for (Req request : requests) {
             CertificateID certificateID = request.getCertID();
             if (fixedResponse == null) {
-                switch (certificateID.getSerialNumber().intValue()) {
-                    // TODO read index.db rather than hard-code certificate serial numbers
-                    case 4096:
-                    case 4098:
-                    case 4100:
-                    case 4101:
-                        responseBuilder.addResponse(certificateID, CertificateStatus.GOOD);
-                        break;
-                    case 4097:
-                    case 4099:
-                    case 4102:
-                        responseBuilder.addResponse(certificateID, new RevokedStatus(new Date(0)));
-                        break;
-                    default:
-                        responseBuilder.addResponse(certificateID, new UnknownStatus());
+                CertificateState state = certificateStatuses.get(certificateID.getSerialNumber());
+                if (state == null) {
+                    responseBuilder.addResponse(certificateID, new UnknownStatus());
+                } else {
+                    switch (state) {
+                        case GOOD:
+                            responseBuilder.addResponse(certificateID, CertificateStatus.GOOD);
+                            break;
+                        case REVOKED:
+                            responseBuilder.addResponse(certificateID, new RevokedStatus(new Date(0)));
+                            break;
+                    }
                 }
             } else {
                 switch (fixedResponse) {


### PR DESCRIPTION
## Summary

- load valid and revoked certificate serials from the test CA's `index.db`
- use the parsed status when building OCSP responses instead of hard-coded serial numbers
- add focused parser coverage and remove completed TODO 82.1

## Rationale

The in-process OCSP responder duplicated serial numbers from the certificate
database. Regenerating the test certificates could therefore leave the
responder out of sync with the fixtures. Reading the database at responder
initialization keeps the OCSP status source of truth with the certificates.

This is test infrastructure only. It does not change Tomcat runtime behavior
or public APIs, so no changelog entry is needed.

## Validation

Environment: Linux arm64 (`eclipse-temurin:21-jdk-jammy`), Java 21, Ant
1.10.15.

- `ant -Dbase.path=/workspace-cache -Dexecute.validate=true validate`
  - Passed with Checkstyle 14.1.0 over 7,687 files.
- `ant -Dbase.path=/workspace-cache -Dtest.entry=org.apache.tomcat.util.net.ocsp.TestTesterOcspResponderServlet test`
  - Passed: 1 test, 0 failures, 0 errors, 0 skips.
- `ant -Dbase.path=/workspace-cache -Dtest.name='**/ocsp/Test*.java' test`
  - Passed: 182 tests, 0 failures, 0 errors, 148 skips. The skips are the expected unavailable OpenSSL/Tomcat Native variants; JSSE OCSP paths ran.
- `ant -Dbase.path=/workspace-cache clean` followed by `ant -Dbase.path=/workspace-cache`
  - Passed clean source build in 58 seconds.
- `ant -Dbase.path=/workspace-cache clean test`
  - The first native-volume transfer materialized macOS AppleDouble `._*` files, including a false JAR fixture, so that non-clean run was stopped after unrelated manifest-read errors.
  - Retried from a fresh metadata-free Docker-native volume after verifying zero `._*` files and SHA-256 matching all changed files.
  - Passed unfiltered suite in 31 minutes 3 seconds: 653 suites, 41,344 tests, 0 failures, 0 errors, 330 skips.
- Generated-distribution runtime smoke
  - Started `output/build/bin/catalina.sh run`, required HTTP 200 from `http://127.0.0.1:8080/` (11,229-byte response), ran `shutdown.sh`, and verified the server exited with status 0.

The committed versions of all changed files match the SHA-256 hashes of the
files used for the successful Linux validation.
